### PR TITLE
Add META-INF path to Soy dependencies

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/generate-soy-dependencies.js
+++ b/packages/liferay-npm-scripts/src/utils/generate-soy-dependencies.js
@@ -29,5 +29,5 @@ module.exports = function(dependencies) {
 		.filter(dependencyPath => dependencyPath !== cwd)
 		.join(',');
 
-	return `{${stringDependencies}}/src/**/*.soy`;
+	return `{${stringDependencies}}/{src,META-INF}/**/*.soy`;
 };


### PR DESCRIPTION
Liferay modules injected with `jsCompile` gradle command do not have a `src` directory, but a `META-INF/...`

/cc @jbalsas 
/cc @boton