### PR TITLE
Don't use relative path for jest testResultsProcessor

### DIFF
--- a/packages/liferay-npm-scripts/src/config/jest.json
+++ b/packages/liferay-npm-scripts/src/config/jest.json
@@ -5,6 +5,6 @@
 	"coverageDirectory": "build/coverage",
 	"modulePathIgnorePatterns": ["/__fixtures__/", "/classes/"],
 	"testMatch": ["**/test/**/*.js"],
-	"testResultsProcessor": "./node_modules/liferay-jest-junit-reporter",
+	"testResultsProcessor": "liferay-jest-junit-reporter",
 	"testURL": "http://localhost"
 }


### PR DESCRIPTION
With the move to Yarn workspaces in the portal, this configuration was causing all tests that use liferay-npm-scripts to run their tests to fail, because the reporter module is now hoisted up to the top of the workspace.

It is defined as a dependency of the liferay-npm-scripts, so we can count on it being installed, and just reference it by its name; the node module resolution algorithm will find it.

Associated LPS: https://issues.liferay.com/browse/LPS-92609