### PR TITLE
Change merge order so that local overrides have precedence

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/get-merged-config.js
+++ b/packages/liferay-npm-scripts/src/utils/get-merged-config.js
@@ -16,35 +16,35 @@ module.exports = function(type) {
 		case 'babel':
 			return sortKeys(
 				deepMerge(
-					getUserConfig('.babelrc', 'babel'),
-					require('../config/babel')
+					require('../config/babel'),
+					getUserConfig('.babelrc', 'babel')
 				)
 			);
 			break;
 		case 'bundler':
 			return sortKeys(
 				deepMerge(
-					getUserConfig('.npmbundlerrc'),
-					require('../config/npm-bundler')
+					require('../config/npm-bundler'),
+					getUserConfig('.npmbundlerrc')
 				)
 			);
 			break;
 		case 'jest':
 			return sortKeys(
 				deepMerge(
-					getUserConfig('jest.config.js', 'jest'),
-					require('../config/jest')
+					require('../config/jest'),
+					getUserConfig('jest.config.js', 'jest')
 				)
 			);
 			break;
 		case 'npmscripts':
 			return sortKeys(
 				deepMerge(
-					getUserConfig('.liferaynpmscriptsrc'),
 					require('../config/liferay-npm-scripts'),
 					require('../config/liferay-npm-scripts-build-deps-clay.json'),
 					require('../config/liferay-npm-scripts-build-deps-liferay.json'),
-					require('../config/liferay-npm-scripts-build-deps-metal.json')
+					require('../config/liferay-npm-scripts-build-deps-metal.json'),
+					getUserConfig('.liferaynpmscriptsrc')
 				)
 			);
 			break;


### PR DESCRIPTION
Noticed while preparing #37 that if I made a local override in my "package.json" it had no effect. That's because liferay-npm-scripts is taking whatever user settings are provided (either in "package.json" or in a "jest.config.js" file) and then overwriting them with the top-level defaults defined in its own "config/jest.json" file.

This seems to be the wrong behavior for defaults, which should only take effect in the absence of a more explicit setting.

Before merging this, we should check the portal repo to make sure we're not relying on the old behavior anywhere; at the very least we can clean out some settings from the repo that can't possibly be having any effect.