### PR TITLE
chore: separate formatting and linting scripts

### DIFF
--- a/copyright.js
+++ b/copyright.js
@@ -3,3 +3,4 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
 	},
 	"private": true,
 	"scripts": {
-		"format": "prettier --write \"./**/*.js\"",
-		"format:check": "prettier --list-different \"./**/*.js\""
+		"format": "prettier --write '**/*.js'",
+		"format:check": "prettier --list-different '**/*.js'",
+		"lint": "eslint '**/*.js'",
+		"lint:fix": "eslint --fix '**/*.js'"
 	},
 	"workspaces": [
 		"packages/*"

--- a/packages/liferay-jest-junit-reporter/__tests__/index.js
+++ b/packages/liferay-jest-junit-reporter/__tests__/index.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 jest.mock('fs');
 
 const reporter = require('../index');

--- a/packages/liferay-jest-junit-reporter/index.js
+++ b/packages/liferay-jest-junit-reporter/index.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 'use strict';
 
 const xml = require('xml');

--- a/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
+++ b/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
+
 /**
  * © 2019 Liferay, Inc. <https://liferay.com>
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 require('../src/index')();

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 // Do this as the first thing so that any code reading it knows the right env.
 if (!process.env.NODE_ENV) {
 	process.env.NODE_ENV = 'production';

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -58,6 +58,7 @@ module.exports = function() {
 			require('./scripts/test')(ARGS_ARRAY);
 			break;
 		default:
+			// eslint-disable-next-line no-console
 			console.log(
 				`'${type}' is not a valid command for liferay-npm-scripts.`
 			);

--- a/packages/liferay-npm-scripts/src/scripts/babel.js
+++ b/packages/liferay-npm-scripts/src/scripts/babel.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const fs = require('fs');
 const path = require('path');
 const CWD = process.cwd();

--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const CWD = process.cwd();
 
 const spawnSync = require('../utils/spawnSync');

--- a/packages/liferay-npm-scripts/src/scripts/eject.js
+++ b/packages/liferay-npm-scripts/src/scripts/eject.js
@@ -33,9 +33,9 @@ function generateBuildScript(config) {
 	let retStr = '';
 
 	if (config.soy) {
-		retStr += `metalsoy --soyDeps \"${generateSoyDependencies(
+		retStr += `metalsoy --soyDeps "${generateSoyDependencies(
 			NPM_SCRIPTS_CONFIG.build.dependencies
-		)}\" && `;
+		)}" && `;
 	}
 
 	retStr += `cross-env NODE_ENV=production babel --source-maps -d ${

--- a/packages/liferay-npm-scripts/src/scripts/eject.js
+++ b/packages/liferay-npm-scripts/src/scripts/eject.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const CWD = process.cwd();
 
 const fs = require('fs');

--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const lintScript = require('./lint');
 
 /**

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const getMergedConfig = require('../utils/get-merged-config');
 const spawnSync = require('../utils/spawnSync');
 

--- a/packages/liferay-npm-scripts/src/scripts/soy.js
+++ b/packages/liferay-npm-scripts/src/scripts/soy.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const glob = require('glob');
 const path = require('path');
 

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';

--- a/packages/liferay-npm-scripts/src/utils/deep-merge.js
+++ b/packages/liferay-npm-scripts/src/utils/deep-merge.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const merge = require('deepmerge');
 
 const emptyTarget = value => (Array.isArray(value) ? [] : {});

--- a/packages/liferay-npm-scripts/src/utils/generate-soy-dependencies.js
+++ b/packages/liferay-npm-scripts/src/utils/generate-soy-dependencies.js
@@ -25,7 +25,9 @@ module.exports = function(dependencies) {
 				resolvedDependency = path.dirname(
 					require.resolve(`${dependency}/package.json`)
 				);
-			} catch (err) {}
+			} catch (err) {
+				// Swallow.
+			}
 
 			return resolvedDependency;
 		})

--- a/packages/liferay-npm-scripts/src/utils/generate-soy-dependencies.js
+++ b/packages/liferay-npm-scripts/src/utils/generate-soy-dependencies.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const path = require('path');
 const process = require('process');
 

--- a/packages/liferay-npm-scripts/src/utils/get-merged-config.js
+++ b/packages/liferay-npm-scripts/src/utils/get-merged-config.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const sortKeys = require('sort-keys');
 const getUserConfig = require('./get-user-config');
 const deepMerge = require('./deep-merge');

--- a/packages/liferay-npm-scripts/src/utils/get-merged-config.js
+++ b/packages/liferay-npm-scripts/src/utils/get-merged-config.js
@@ -20,7 +20,7 @@ module.exports = function(type) {
 					getUserConfig('.babelrc', 'babel')
 				)
 			);
-			break;
+
 		case 'bundler':
 			return sortKeys(
 				deepMerge(
@@ -28,7 +28,7 @@ module.exports = function(type) {
 					getUserConfig('.npmbundlerrc')
 				)
 			);
-			break;
+
 		case 'jest':
 			return sortKeys(
 				deepMerge(
@@ -36,7 +36,7 @@ module.exports = function(type) {
 					getUserConfig('jest.config.js', 'jest')
 				)
 			);
-			break;
+
 		case 'npmscripts':
 			return sortKeys(
 				deepMerge(
@@ -47,8 +47,9 @@ module.exports = function(type) {
 					getUserConfig('.liferaynpmscriptsrc')
 				)
 			);
-			break;
+
 		default:
+			// eslint-disable-next-line no-console
 			console.log(`'${type}' is not a valid config`);
 	}
 };

--- a/packages/liferay-npm-scripts/src/utils/get-user-config.js
+++ b/packages/liferay-npm-scripts/src/utils/get-user-config.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const fs = require('fs');
 const path = require('path');
 

--- a/packages/liferay-npm-scripts/src/utils/move-to-temp.js
+++ b/packages/liferay-npm-scripts/src/utils/move-to-temp.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const fs = require('fs');
 const path = require('path');
 

--- a/packages/liferay-npm-scripts/src/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/src/utils/spawnSync.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const path = require('path');
 
 const CWD = process.cwd();


### PR DESCRIPTION
Adds these scripts to package.json, in addition to "format" and "format:check" which we already had:

- "lint": reports lints but doesn't fix them.
- "lint:fix": reports lints and fixes autofixable lints.

An earlier version of this commit in the PR had a "fix" script that was equivalent to "format" followed by "lint:fix" but we're temporarily backing that out until we come up with a better name.

Test plan: Run all the new scripts; see "format" fix formatting issues in one file, and "lint" report these issues which I then fixed:

    packages/liferay-npm-scripts/src/index.js
      61:4  error  Unexpected console statement  no-console

    packages/liferay-npm-scripts/src/scripts/eject.js
      36:33  error  Unnecessary escape character: \"  no-useless-escape
      38:5   error  Unnecessary escape character: \"  no-useless-escape

    packages/liferay-npm-scripts/src/utils/generate-soy-dependencies.js
      28:18  error  Empty block statement  no-empty

    packages/liferay-npm-scripts/src/utils/get-merged-config.js
      23:4  error  Unreachable code              no-unreachable
      31:4  error  Unreachable code              no-unreachable
      39:4  error  Unreachable code              no-unreachable
      50:4  error  Unreachable code              no-unreachable
      52:4  error  Unexpected console statement  no-console

    ✖ 9 problems (9 errors, 0 warnings)

Closes: https://github.com/liferay/liferay-npm-tools/issues/32