### PR TITLE
fix: broken "eject" in liferay-npm-scripts (#44)

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/eject.js
+++ b/packages/liferay-npm-scripts/src/scripts/eject.js
@@ -92,7 +92,7 @@ module.exports = function() {
 
 	// Set initial npm scripts
 	projectPackage.scripts = {
-		build: generateBuildScript(),
+		build: generateBuildScript(config),
 		format: `csf ${NPM_SCRIPTS_CONFIG.format.join(' ')} --inline-edit`,
 		lint: `csf ${NPM_SCRIPTS_CONFIG.lint.join(' ')}`,
 		test: 'jest'


### PR DESCRIPTION
"eject" explodes as follows:

```
? Are you sure you want to eject? This action is permanent. Yes
(node:95558) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'soy' of undefined
    at generateBuildScript (/Users/greghurrell/code/liferay-npm-tools/packages/liferay-npm-scripts/example/eject/before/node_modules/liferay-npm-scripts/src/scripts/eject.js:35:13)
    at module.exports (/Users/greghurrell/code/liferay-npm-tools/packages/liferay-npm-scripts/example/eject/before/node_modules/liferay-npm-scripts/src/scripts/eject.js:95:10)
    at inquirer.prompt.then (/Users/greghurrell/code/liferay-npm-tools/packages/liferay-npm-scripts/example/eject/before/node_modules/liferay-npm-scripts/src/index.js:47:33)
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
(node:95558) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:95558) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
✨  Done in 2.22s.
```

This has been broken since 3d8ec75358ce2d0e97a83769.

Test plan: In "packages/liferay-npm-scripts/example/eject/before", run `yarn install` and then sneak into the "node_modules" folder to pick up the local fix with `ln -sf ../../../../../liferay-npm-scripts`, then run `yarn eject` and see it complete without blowing up.

Closes: https://github.com/liferay/liferay-npm-tools/issues/44