### PR TITLE
chore: Update dependencies on liferay-npm-build-tools packages (#42)

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -4,12 +4,12 @@
   "description": "Default configuration for liferay-npm-bundler inside liferay-portal.",
   "main": "config.json",
   "dependencies": {
-    "babel-preset-liferay-standard": "2.6.2",
-    "liferay-npm-bundler-plugin-exclude-imports": "2.6.2",
-    "liferay-npm-bundler-plugin-inject-imports-dependencies": "2.6.2",
-    "liferay-npm-bundler-plugin-inject-peer-dependencies": "2.6.2",
-    "liferay-npm-bundler-plugin-namespace-packages": "2.6.2",
-    "liferay-npm-bundler-plugin-replace-browser-modules": "2.6.2",
-    "liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.6.2"
+    "babel-preset-liferay-standard": "2.7.0",
+    "liferay-npm-bundler-plugin-exclude-imports": "2.7.0",
+    "liferay-npm-bundler-plugin-inject-imports-dependencies": "2.7.0",
+    "liferay-npm-bundler-plugin-inject-peer-dependencies": "2.7.0",
+    "liferay-npm-bundler-plugin-namespace-packages": "2.7.0",
+    "liferay-npm-bundler-plugin-replace-browser-modules": "2.7.0",
+    "liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,14 +1481,6 @@ babel-plugin-name-amd-modules@2.2.1:
     liferay-npm-build-tools-common "2.2.1"
     read-json-sync "^1.1.1"
 
-babel-plugin-name-amd-modules@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.6.2.tgz#e04517b25fedd28ea3709ea534a71c6a33354f51"
-  integrity sha512-O7eIf0wjS/onyKDQZb6+8U9ShmoqnO7Y4BPXeyKlMa8c5gczjusYpBEGyDC4R/GhK0MJe3Wj3Zm5i6pH2KqlAA==
-  dependencies:
-    liferay-npm-build-tools-common "2.6.2"
-    read-json-sync "^1.1.1"
-
 babel-plugin-name-amd-modules@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.7.0.tgz#8800984881fdeee5ee9a239bed4b6787c4920039"
@@ -1503,13 +1495,6 @@ babel-plugin-namespace-amd-define@2.2.1:
   integrity sha512-0MwvmbPDHXHG0YBoqP8V36mqPZe5+Ay0f2kWm3JUt3mLFOMVjrvUm87ZF2oyYI75zVHD7QwmGmTdpzfAYZzZYQ==
   dependencies:
     liferay-npm-build-tools-common "2.2.1"
-
-babel-plugin-namespace-amd-define@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.6.2.tgz#e80edc7cde45739f92544159332b06cdd36bd4aa"
-  integrity sha512-KnJrqYiq5bcZl7yuf80CcCqOHp6RfCqhILsrqkxWr7V8u4A6RL3mSiJ7dyhV52AmxqW5larWFL8ynX0XRDOeOQ==
-  dependencies:
-    liferay-npm-build-tools-common "2.6.2"
 
 babel-plugin-namespace-amd-define@2.7.0:
   version "2.7.0"
@@ -1526,14 +1511,6 @@ babel-plugin-namespace-modules@2.2.1:
     liferay-npm-build-tools-common "2.2.1"
     read-json-sync "^1.1.1"
 
-babel-plugin-namespace-modules@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.6.2.tgz#40679fb7fd601f07bd56b8c10adacbb42d17c5b9"
-  integrity sha512-N1h9copSN5eZ5gMTJ4QsHajmwfzy5TAV1n3PMAUi7HSi8Wg7oEYpPWWKzKZtDl3sosUTcVa/RX1XvRnhkPGfHw==
-  dependencies:
-    liferay-npm-build-tools-common "2.6.2"
-    read-json-sync "^1.1.1"
-
 babel-plugin-namespace-modules@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.7.0.tgz#a9f93d97a1d2542deb74e5bdea8917f883447132"
@@ -1548,13 +1525,6 @@ babel-plugin-normalize-requires@2.2.1:
   integrity sha512-EBmo/rAFa32bHy7ZjqCFuTWJX5AeqF4/MQS1BZlu1f8Qfhhz5U+8wkEm/MNZv4LvNaSP0fTle+WmWscQ6X/H2w==
   dependencies:
     liferay-npm-build-tools-common "2.2.1"
-
-babel-plugin-normalize-requires@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.6.2.tgz#ff792de97980059cdfd367673a5c85abd53a9dda"
-  integrity sha512-igvOZ7j1pargM5lXDne4rLC88yYN8y9Qwjpr4gVsmIkI9qo6zOF/sE/dkRpxMOYyULC7V5ULASU/CjN1wRs7DA==
-  dependencies:
-    liferay-npm-build-tools-common "2.6.2"
 
 babel-plugin-normalize-requires@2.7.0:
   version "2.7.0"
@@ -1815,15 +1785,6 @@ babel-plugin-wrap-modules-amd@2.2.1:
     liferay-npm-build-tools-common "2.2.1"
     read-json-sync "^1.1.1"
 
-babel-plugin-wrap-modules-amd@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.6.2.tgz#9b75f8770d6daccff2c9ccc1e05c410215d08eef"
-  integrity sha512-4pVqGfvvINO9sXk2Iv/35D+CDRwdCm7/EJlu2vmSeQQ+wE5rDotdNBw3sVswyHOD3cfCmLZJ8fQWQM7GBUVkjg==
-  dependencies:
-    babel-template "^6.25.0"
-    liferay-npm-build-tools-common "2.6.2"
-    read-json-sync "^1.1.1"
-
 babel-plugin-wrap-modules-amd@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.7.0.tgz#133f344dfd9cc66eea9f3cb6095f2d249af35684"
@@ -1888,18 +1849,6 @@ babel-preset-liferay-standard@2.2.1:
     babel-plugin-normalize-requires "2.2.1"
     babel-plugin-transform-node-env-inline "0.2.0"
     babel-plugin-wrap-modules-amd "2.2.1"
-
-babel-preset-liferay-standard@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.6.2.tgz#ff723cd9fcff5de1f71c3373935621831320a1df"
-  integrity sha512-p2Dy77fzNmLNLbROk06Z01vtEvx9k8Mcs0zIjuBN331F/jFsWWP7sbINI/kHWjQDxgMBWj6PJiLQ/oa6j3mSoQ==
-  dependencies:
-    babel-plugin-name-amd-modules "2.6.2"
-    babel-plugin-namespace-amd-define "2.6.2"
-    babel-plugin-namespace-modules "2.6.2"
-    babel-plugin-normalize-requires "2.6.2"
-    babel-plugin-transform-node-env-inline "0.2.0"
-    babel-plugin-wrap-modules-amd "2.6.2"
 
 babel-preset-liferay-standard@2.7.0:
   version "2.7.0"
@@ -5384,13 +5333,6 @@ liferay-npm-build-tools-common@2.2.1:
   dependencies:
     read-json-sync "^2.0.0"
 
-liferay-npm-build-tools-common@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.6.2.tgz#7f982be49c2a4e16870bb04b737a9fe48a9e6a4a"
-  integrity sha512-qQan8nw4jw0Sa8P05hKwwUUN452BVUyb2cLjejg4Mi0/VepdSvRRlKEP2KFpUggY2TixFjRH71i/YPcyddiEYg==
-  dependencies:
-    read-json-sync "^2.0.0"
-
 liferay-npm-build-tools-common@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.7.0.tgz#9e7215cbac38bd974d47ffb134b2cea8678a9d31"
@@ -5404,13 +5346,6 @@ liferay-npm-bundler-plugin-exclude-imports@2.2.1:
   integrity sha512-BLVB1V/Hk4RLmabgzMbWA1AYX81XrRCIsUa682wwV3pNBnPuz7srIFtC5OmdemaAQVoQmfghA+Kb/XV3mgJXGA==
   dependencies:
     liferay-npm-build-tools-common "2.2.1"
-
-liferay-npm-bundler-plugin-exclude-imports@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.6.2.tgz#1a619daeca0cb493a547145fec6f5721431ad802"
-  integrity sha512-lI1TfCK7LnHudk7AO5unvgY9qdmKN3ArF8FXaoFfU2KtA79hlnanRh/NYNG5zqZ6JMwfLP+HUa9bKlgPEhgfpQ==
-  dependencies:
-    liferay-npm-build-tools-common "2.6.2"
 
 liferay-npm-bundler-plugin-exclude-imports@2.7.0:
   version "2.7.0"
@@ -5426,13 +5361,6 @@ liferay-npm-bundler-plugin-inject-imports-dependencies@2.2.1:
   dependencies:
     liferay-npm-build-tools-common "2.2.1"
 
-liferay-npm-bundler-plugin-inject-imports-dependencies@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.6.2.tgz#feb871ea22bd5aea91feed7a4928a61fe18ef794"
-  integrity sha512-9hK5nK/mPy+kXB3mAf2knBLqqh6QZ2xUgLnW1kolUaJCV0iAV52z3+q+1+SrfJpzIpYAHJK70ICff6fpeC6Z7g==
-  dependencies:
-    liferay-npm-build-tools-common "2.6.2"
-
 liferay-npm-bundler-plugin-inject-imports-dependencies@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.7.0.tgz#f66e2807a34d9e16733b234b495960e3bf2bd8b4"
@@ -5447,16 +5375,6 @@ liferay-npm-bundler-plugin-inject-peer-dependencies@2.2.1:
   dependencies:
     globby "^8.0.1"
     liferay-npm-build-tools-common "2.2.1"
-    read-json-sync "^2.0.0-0"
-    resolve "^1.6.0"
-
-liferay-npm-bundler-plugin-inject-peer-dependencies@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.6.2.tgz#255fdadf96161074f0d6c185e1227e77ed2c710f"
-  integrity sha512-zCyMRd9VQAsE84D0QqQ4z85zFjY1f0qyHmOYIN7AUgDZcYdTKqBV/rYE6z1g7Doz0svmc1AvSyu34ZK9s4w0Yw==
-  dependencies:
-    globby "^8.0.1"
-    liferay-npm-build-tools-common "2.6.2"
     read-json-sync "^2.0.0-0"
     resolve "^1.6.0"
 
@@ -5477,13 +5395,6 @@ liferay-npm-bundler-plugin-namespace-packages@2.2.1:
   dependencies:
     liferay-npm-build-tools-common "2.2.1"
 
-liferay-npm-bundler-plugin-namespace-packages@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.6.2.tgz#fe52f805d6019e337e35281977bc71f056b811b0"
-  integrity sha512-aNzcGifoosYbnEXOPYUpgZZaBeAz5BuTRRPk178rsvJcShs8MjmmdOkIBO3HUeFwqAV3STLV5Lk9jUXVep4nlA==
-  dependencies:
-    liferay-npm-build-tools-common "2.6.2"
-
 liferay-npm-bundler-plugin-namespace-packages@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.7.0.tgz#974628f778897272fc8b8d1a485b6d20c7490117"
@@ -5497,14 +5408,6 @@ liferay-npm-bundler-plugin-replace-browser-modules@2.2.1:
   integrity sha512-d4envMxvHt4banK45KbMENv84+QXQeQoz+BoowKw/G3Hch10NjYFvA50CZ9sFjyfuUF3Nm6qwN0fkx/bKAV7Ng==
   dependencies:
     liferay-npm-build-tools-common "2.2.1"
-
-liferay-npm-bundler-plugin-replace-browser-modules@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.6.2.tgz#f87d1f00a0cd2339d3ddfed0c0f92417e7617b4c"
-  integrity sha512-uQWgp2Ge4oXk9N1PgdgVcEe4kCCU61Uxa3TSjrJxXF2aG/+xvKW36yH26wqDOi/40hz68V08c+rWjBZ/4JT2kQ==
-  dependencies:
-    fs-extra "^7.0.1"
-    liferay-npm-build-tools-common "2.6.2"
 
 liferay-npm-bundler-plugin-replace-browser-modules@2.7.0:
   version "2.7.0"
@@ -5520,15 +5423,6 @@ liferay-npm-bundler-plugin-resolve-linked-dependencies@2.2.1:
   integrity sha512-JkUS3HbfgE/qhjMHKQXGqt4GBhRPYfaL8/t2STvwx1/22pd036sVBxh/eZRjjIIst/e4NMUR4XbIivv4QeggBg==
   dependencies:
     liferay-npm-build-tools-common "2.2.1"
-    read-json-sync "^2.0.0"
-    semver "^5.5.0"
-
-liferay-npm-bundler-plugin-resolve-linked-dependencies@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.6.2.tgz#368aa43da108eb4e82de18c77f05dcb49ee2c76b"
-  integrity sha512-DR7ZksQZgVYxtgxwK7y2jUqsONdR0rkEoGqLnWhbHj+Cn+FBXbkvegdTBHPi4G3JrDLcYlTsB5PR7ElFB/MEOQ==
-  dependencies:
-    liferay-npm-build-tools-common "2.6.2"
     read-json-sync "^2.0.0"
     semver "^5.5.0"
 


### PR DESCRIPTION
Ideally this would have been done in #43 as part of the solution to #42, but I didn't realize we needed to update these packages as well.

You know the change is good when it only leads to red lines in the lockfile diff.