### PR TITLE
fix: jest-haste-map warnings about module naming collisions (#53)

### DIFF
--- a/packages/liferay-npm-scripts/src/config/jest.json
+++ b/packages/liferay-npm-scripts/src/config/jest.json
@@ -3,7 +3,7 @@
 		"Liferay": {}
 	},
 	"coverageDirectory": "build/coverage",
-	"modulePathIgnorePatterns": ["/__fixtures__/", "/classes/"],
+	"modulePathIgnorePatterns": ["/__fixtures__/", "/build/", "/classes/"],
 	"testMatch": ["**/test/**/*.js"],
 	"testResultsProcessor": "liferay-jest-junit-reporter",
 	"testURL": "http://localhost"


### PR DESCRIPTION
Before this commit, when you ran `yarn test` in a directory like "modules/apps/layout/layout-content-page-editor-web", you'd see:

    jest-haste-map: Haste module naming collision: layout-content-page-editor-web
      The following files share their name; please adjust your hasteImpl:
        * <rootDir>/package.json
        * <rootDir>/build/unzipped-jar/package.json

Test plan: Apply this change in the modules/node_modules copy of liferay-npm-scripts and run `yarn test` in the directory mentioned above. See the tests pass and no warnings from jest-haste-map any more.

Closes: https://github.com/liferay/liferay-npm-tools/issues/53