### PR TITLE
fix: don't silently swallow failures in spawnSync (#38)

### DIFF
--- a/packages/liferay-npm-scripts/__tests__/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/__tests__/utils/spawnSync.js
@@ -1,0 +1,21 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const spawnSync = require('../../src/utils/spawnSync');
+
+describe('spawnSync()', () => {
+	it('throws for non-existent commands', () => {
+		expect(() => spawnSync('non-existent-command')).toThrow(/ENOENT/);
+	});
+
+	it('throws for commands that return a non-zero exit code', () => {
+		expect(() => spawnSync('false')).toThrow(/code 1/);
+	});
+
+	it('succeeds for valid commands', () => {
+		expect(() => spawnSync('true')).not.toThrow();
+	});
+});

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -32,5 +32,13 @@
 		"minimist": "^1.2.0",
 		"rimraf": "^2.6.2",
 		"sort-keys": "^2.0.0"
+	},
+	"scripts": {
+		"test": "jest"
+	},
+	"jest": {
+		"testRegex": [
+			"/__tests__/.*"
+		]
 	}
 }

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -23,7 +23,7 @@ const JEST_CONFIG = getMergedConfig('jest');
 /**
  * Main script that runs `jest` with a merged config
  */
-module.exports = function(arrArgs) {
+module.exports = function(arrArgs = []) {
 	const useSoy = soyExists();
 
 	const CONFIG_PATH = path.join(CWD, 'TEMP_jest.config.json');

--- a/packages/liferay-npm-scripts/src/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/src/utils/spawnSync.js
@@ -11,6 +11,10 @@ const PATH = path.resolve(`${__dirname}/../../node_modules/.bin`);
 
 const {spawn} = require('cross-spawn');
 
+function getDescription(command, args) {
+	return [command].concat(args).join(' ');
+}
+
 /**
  * Wrapper function for spawning a synchronous process.
  * @param {string} command Path to bin file
@@ -18,7 +22,7 @@ const {spawn} = require('cross-spawn');
  * @param {Object=} options={} Options to pass to spawn.sync
  */
 module.exports = function(command, args = [], options = {}) {
-	spawn.sync(command, args, {
+	const {error, status} = spawn.sync(command, args, {
 		cwd: CWD,
 		env: {
 			...process.env,
@@ -27,4 +31,20 @@ module.exports = function(command, args = [], options = {}) {
 		stdio: 'inherit',
 		...options
 	});
+
+	if (status) {
+		throw new Error(
+			`Command ${getDescription(
+				command,
+				args
+			)} exited with code ${status}`
+		);
+	} else if (error) {
+		throw new Error(
+			`Command ${getDescription(
+				command,
+				args
+			)} failed with error ${error}`
+		);
+	}
 };


### PR DESCRIPTION
Test plan: `yarn test` in "liferay-npm-scripts". By way of an integration test, also do this (which will error out due to a config clash):

```
../../node_modules/.bin/liferay-npm-scripts test
● Validation Error:

  Configuration options testMatch and testRegex cannot be used together.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html

/Users/greghurrell/code/liferay-npm-tools/packages/liferay-npm-scripts/src/utils/spawnSync.js:36
                throw new Error(
                ^

Error: Command jest --config /Users/greghurrell/code/liferay-npm-tools/packages/liferay-npm-scripts/TEMP_jest.config.json exited with code 1
zsh: exit 1     ../../node_modules/.bin/liferay-npm-scripts test
```

Closes: https://github.com/liferay/liferay-npm-tools/issues/38