### PR TITLE
Fixes #55 - Add ability to override default config

### DIFF
--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -77,6 +77,38 @@ Eject will remove `liferay-npm-scripts` as a dependency and write all of the nec
 
 If you need to add additional configuration you can do so by creating a `.liferaynpmscriptsrc` file at the root of your project. The default configuration of this file can be seen [here](./src/config/liferay-npm-scripts.json).
 
+#### Overriding default arrays
+
+In the rare case you want to override default config such as the default dependency list or lint/format globs, we provide an escape hatch via `.liferaynpmscriptsrc-override`. By using this file, you are able to override a configuration rather than merging with the default values. See examples below for more info.
+
+The example below would result in _only_ `foo-bar` being passed as a soy dependency.
+
+```json
+{
+	"build": {
+		"dependencies": ["foo-bar"]
+	}
+}
+```
+
+The example below would result in _only_ jsx files being linted, instead of adding `**/*.jsx` to the pre-existing [defaults](./src/config/liferay-npm-scripts.json#L14-L20).
+
+```json
+{
+	"lint": ["**/*.jsx"]
+}
+```
+
+The example below would result in passing no globs to the lint task and override the [default globs](./src/config/liferay-npm-scripts.json#L14-L20).
+
+```json
+{
+	"lint": []
+}
+```
+
+_Using `.liferaynpmscriptsrc-override` is not recommended and will likely be removed in the next major version change._
+
 ### Other Config
 
 If you need more flexibility over babel or the bundler. You can still add a `.babelrc` or `.npmbundlerrc` which will be merged with the default settings this tool provides. [Default Babel Config](./src/config/babel.json), [Default Bundler Config](./src/config/npm-bundler.json)

--- a/packages/liferay-npm-scripts/src/utils/deep-merge.js
+++ b/packages/liferay-npm-scripts/src/utils/deep-merge.js
@@ -31,11 +31,24 @@ function combineMerge(target, source, options) {
 }
 
 /**
+ * Code copied from https://github.com/TehShrike/deepmerge#combine-array
+ */
+const overwriteMerge = (destinationArray, sourceArray) => sourceArray;
+
+/**
  * Helper to get merge two json objects
  * @param {Object} defaultConfig Config file
  * @param {Object} customConfig Config file
  * @returns {Object}
  */
-module.exports = function() {
-	return merge.all([...arguments], {arrayMerge: combineMerge});
+exports.deepMerge = function() {
+	return merge.all([...arguments], {
+		arrayMerge: combineMerge
+	});
+};
+
+exports.deepMergeOverWrite = function() {
+	return merge.all([...arguments], {
+		arrayMerge: overwriteMerge
+	});
 };

--- a/packages/liferay-npm-scripts/src/utils/get-merged-config.js
+++ b/packages/liferay-npm-scripts/src/utils/get-merged-config.js
@@ -6,7 +6,7 @@
 
 const sortKeys = require('sort-keys');
 const getUserConfig = require('./get-user-config');
-const deepMerge = require('./deep-merge');
+const {deepMerge, deepMergeOverWrite} = require('./deep-merge');
 
 /**
  * Helper to get JSON configs
@@ -40,12 +40,15 @@ module.exports = function(type) {
 
 		case 'npmscripts':
 			return sortKeys(
-				deepMerge(
-					require('../config/liferay-npm-scripts'),
-					require('../config/liferay-npm-scripts-build-deps-clay.json'),
-					require('../config/liferay-npm-scripts-build-deps-liferay.json'),
-					require('../config/liferay-npm-scripts-build-deps-metal.json'),
-					getUserConfig('.liferaynpmscriptsrc')
+				deepMergeOverWrite(
+					deepMerge(
+						require('../config/liferay-npm-scripts'),
+						require('../config/liferay-npm-scripts-build-deps-clay.json'),
+						require('../config/liferay-npm-scripts-build-deps-liferay.json'),
+						require('../config/liferay-npm-scripts-build-deps-metal.json'),
+						getUserConfig('.liferaynpmscriptsrc')
+					),
+					getUserConfig('.liferaynpmscriptsrc-override')
 				)
 			);
 


### PR DESCRIPTION
Hey @jbalsas this is a general idea I had for what we were talking about in regards to overriding/merging configs.

Rather than add another field to the existing config and rather than changing the behavior for the way we merge other types of config(babel, jest, etc). I went with the idea of the user creating another rc file that allows configuration to override rather than merge. We won't have to make a breaking change with this and it will also allow us developers to use something in the mean time while we try and iron out the higher level ideas behind the tooling. I also made sure to note in the README that this solution is not encouraged and also likely will go away in the future, but I think it provides us some flexibility in the mean time.

Let me know what you think.