### PR TITLE
fix: improve executable selection on Windows (#62)

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/src/utils/spawnSync.js
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+const fs = require('fs');
 const path = require('path');
-
-const CWD = process.cwd();
-const PATH = path.resolve(`${__dirname}/../../node_modules/.bin`);
 
 const {spawn} = require('cross-spawn');
 
@@ -22,12 +20,14 @@ function getDescription(command, args) {
  * @param {Object=} options={} Options to pass to spawn.sync
  */
 module.exports = function(command, args = [], options = {}) {
-	const {error, status} = spawn.sync(command, args, {
-		cwd: CWD,
-		env: {
-			...process.env,
-			PATH: `${PATH}:${process.env.PATH}`
-		},
+	const localCommand = path.join(
+		__dirname,
+		'../../node_modules/.bin',
+		command
+	);
+	const executable = fs.existsSync(localCommand) ? localCommand : command;
+
+	const {error, status} = spawn.sync(executable, args, {
 		stdio: 'inherit',
 		...options
 	});
@@ -35,14 +35,14 @@ module.exports = function(command, args = [], options = {}) {
 	if (status) {
 		throw new Error(
 			`Command ${getDescription(
-				command,
+				executable,
 				args
 			)} exited with code ${status}`
 		);
 	} else if (error) {
 		throw new Error(
 			`Command ${getDescription(
-				command,
+				executable,
 				args
 			)} failed with error ${error}`
 		);


### PR DESCRIPTION
In liferay-portal on Windows, but apparently only on some Windows machines, we have this mysterious error during builds:

    [exec] > Task :apps:frontend-taglib:frontend-taglib-clay:npmRunBuild
        [exec] Error: Requires Babel "^7.0.0-0", but was loaded with "6.26.3".

In short, `spawnSync` is trying to set the `PATH` to ensure that we use its local Babel 7, but that doesn't seem to be working, at least on the version of Windows that I tested, and the versions used by the people who have reported build difficulties over the last few days. Stack trace shows the top-level Babel v6 binary being used instead. So when liferay-npm-scripts writes out its `.babelrc` file, it references `@babel/preset-env`, which is a version 7 package, and everything blows up.

The fix is to grab the local executable, if available, and use the absolute path directly instead of relying on the `PATH` environment variable.

Test plan: I was going to write automated tests for this, but they would need me to do so much mocking that I don't think I'd be testing anything at all, so instead I did manual tests:

On my local development machine in this repo:

See it run `jest` successfully:

    $ node
    > require('./src/utils/spawnSync')('jest')
    ...
    Ran all test suites.

See it report the absolute path to the local `jest` executable when I issue a bad command:

    > require('./src/utils/spawnSync')('jest', ['--explode'])
    ...
    Error: Command /Users/greghurrell/code/liferay-npm-tools/packages/liferay-npm-scripts/node_modules/.bin/jest --explode exited with code 1

That proves it is using the local executable, when present.

Now get rid of the local executable (`mv node_modules/.bin/jest{,.off}`) and see it use a relative path when I issue a bad command:

    > require('./src/utils/spawnSync')('jest', ['--explode'])
    ...
    Error: Command jest --explode failed with error Error: spawnSync jest ENOENT

That shows that is uses a bare command name when the local executable isn't to be found.

On windows, apply patch manually and perform `gradlew.bat deploy` in the liferay-portal repo and see it work without errors.

Closes: https://github.com/liferay/liferay-npm-tools/issues/62
