### PR TITLE
feat: add "theme" subcommand (#64)

### DIFF
--- a/packages/liferay-npm-scripts/__fixtures__/scripts/theme/modules/apps/frontend-theme-fjord/frontend-theme-fjord/.gitignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/theme/modules/apps/frontend-theme-fjord/frontend-theme-fjord/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/theme/modules/apps/frontend-theme/frontend-theme-classic/.gitignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/theme/modules/apps/frontend-theme/frontend-theme-classic/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/theme/not/the/apps/you/are/looking/for/.gitignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/theme/not/the/apps/you/are/looking/for/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/packages/liferay-npm-scripts/__tests__/scripts/theme.js
+++ b/packages/liferay-npm-scripts/__tests__/scripts/theme.js
@@ -22,7 +22,7 @@ const UNSTYLED = path.join(
 	'frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled'
 );
 
-describe('', () => {
+describe('scripts/theme.js', () => {
 	let cwd;
 	let spawnSync;
 

--- a/packages/liferay-npm-scripts/__tests__/scripts/theme.js
+++ b/packages/liferay-npm-scripts/__tests__/scripts/theme.js
@@ -1,0 +1,208 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const os = require('os');
+const path = require('path');
+
+const FIXTURES = path.resolve(__dirname, '../../__fixtures__/scripts/theme');
+const APPS = path.join(FIXTURES, 'modules/apps');
+const FJORD = path.join(APPS, 'frontend-theme-fjord/frontend-theme-fjord');
+const CLASSIC = path.join(APPS, 'frontend-theme/frontend-theme-classic');
+const BAD = path.join(FIXTURES, 'not/the/apps/you/are/looking/for');
+const FRONTEND = path.join(APPS, 'frontend-theme');
+const STYLED = path.join(
+	FRONTEND,
+	'frontend-theme-styled/src/main/resources/META-INF/resources/_styled'
+);
+const UNSTYLED = path.join(
+	FRONTEND,
+	'frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled'
+);
+
+describe('', () => {
+	let cwd;
+	let spawnSync;
+
+	beforeEach(() => {
+		cwd = process.cwd();
+		jest.mock('../../src/utils/spawnSync');
+		spawnSync = require('../../src/utils/spawnSync');
+	});
+
+	afterEach(() => {
+		jest.resetModules();
+		process.chdir(cwd);
+	});
+
+	describe('checkExistingBuildArgs()', () => {
+		let checkExistingBuildArgs;
+
+		beforeEach(() => {
+			({checkExistingBuildArgs} = require('../../src/scripts/theme'));
+		});
+
+		it('complains about --css-common-path', () => {
+			expect(() => {
+				checkExistingBuildArgs(['--css-common-path', '.']);
+			}).toThrow(/Must not supply --css-common-path/);
+		});
+
+		it('complains about --styled-path', () => {
+			expect(() => {
+				checkExistingBuildArgs(['--styled-path', '.']);
+			}).toThrow(/Must not supply --styled-path/);
+		});
+
+		it('complains about --unstyled-path', () => {
+			expect(() => {
+				checkExistingBuildArgs(['--unstyled-path', '.']);
+			}).toThrow(/Must not supply --unstyled-path/);
+		});
+
+		it('accepts other arguments', () => {
+			expect(() => {
+				checkExistingBuildArgs(['--verbose']);
+			}).not.toThrow();
+		});
+
+		it('does not require existing arguments', () => {
+			expect(() => {
+				checkExistingBuildArgs([]);
+			}).not.toThrow();
+		});
+	});
+
+	describe('findAppsDirectory()', () => {
+		let findAppsDirectory;
+
+		beforeEach(() => {
+			({findAppsDirectory} = require('../../src/scripts/theme'));
+		});
+
+		it('returns null when there is no "apps" ancestor', () => {
+			expect(findAppsDirectory(os.tmpdir())).toBe(null);
+		});
+
+		it('returns the path when there is an "apps" ancestor', () => {
+			expect(findAppsDirectory(CLASSIC)).toBe(APPS);
+			expect(findAppsDirectory(FJORD)).toBe(APPS);
+		});
+	});
+
+	describe('prepareAdditionalBuildArgs()', () => {
+		let prepareAdditionalBuildArgs;
+
+		beforeEach(() => {
+			({prepareAdditionalBuildArgs} = require('../../src/scripts/theme'));
+		});
+
+		it('complains if there is no "apps" ancestor', () => {
+			process.chdir(os.tmpdir());
+			expect(() => prepareAdditionalBuildArgs()).toThrow(
+				/Unable to find "apps"/
+			);
+		});
+
+		it('complains if there is no "frontend-theme" directory', () => {
+			process.chdir(BAD);
+			expect(() => prepareAdditionalBuildArgs()).toThrow(
+				/Unable to find "frontend-theme"/
+			);
+		});
+
+		it('returns a set of build arguments (classic)', () => {
+			process.chdir(CLASSIC);
+			expect(prepareAdditionalBuildArgs()).toEqual([
+				'--css-common-path',
+				'./build_gradle/frontend-css-common',
+				'--styled-path',
+				STYLED,
+				'--unstyled-path',
+				UNSTYLED
+			]);
+		});
+
+		it('returns a set of build arguments (fjord)', () => {
+			process.chdir(FJORD);
+			expect(prepareAdditionalBuildArgs()).toEqual([
+				'--css-common-path',
+				'./build_gradle/frontend-css-common',
+				'--styled-path',
+				STYLED,
+				'--unstyled-path',
+				UNSTYLED
+			]);
+		});
+	});
+
+	describe('run()', () => {
+		let run;
+
+		beforeEach(() => {
+			({run} = require('../../src/scripts/theme'));
+		});
+
+		describe('build', () => {
+			it('invokes gulp with custom arguments (classic)', () => {
+				process.chdir(CLASSIC);
+				run('build');
+				expect(spawnSync).toHaveBeenCalledWith('gulp', [
+					'build',
+					'--css-common-path',
+					'./build_gradle/frontend-css-common',
+					'--styled-path',
+					STYLED,
+					'--unstyled-path',
+					UNSTYLED
+				]);
+			});
+
+			it('invokes gulp with custom arguments (fjord)', () => {
+				process.chdir(FJORD);
+				run('build');
+				expect(spawnSync).toHaveBeenCalledWith('gulp', [
+					'build',
+					'--css-common-path',
+					'./build_gradle/frontend-css-common',
+					'--styled-path',
+					STYLED,
+					'--unstyled-path',
+					UNSTYLED
+				]);
+			});
+
+			it('complains if passed forbidden arguments', () => {
+				process.chdir(CLASSIC);
+				expect(() => run('build', '--css-common-path', '.')).toThrow(
+					/Must not supply --css-common-path/
+				);
+			});
+
+			it('accepts additional permitted arguments', () => {
+				process.chdir(CLASSIC);
+				expect(() => run('build', '--verbose', '.')).not.toThrow();
+			});
+
+			it('complains if there is no "apps" ancestor', () => {
+				process.chdir(os.tmpdir());
+				expect(() => run('build')).toThrow(/Unable to find "apps"/);
+			});
+
+			it('complains if called when there is no "frontend-theme"', () => {
+				process.chdir(BAD);
+				expect(() => run('build')).toThrow(
+					/Unable to find "frontend-theme"/
+				);
+			});
+		});
+
+		describe('other tasks', () => {
+			it('passes the arguments through unchanged', () => {
+				run('help');
+			});
+		});
+	});
+});

--- a/packages/liferay-npm-scripts/__tests__/scripts/theme.js
+++ b/packages/liferay-npm-scripts/__tests__/scripts/theme.js
@@ -202,6 +202,7 @@ describe('scripts/theme.js', () => {
 		describe('other tasks', () => {
 			it('passes the arguments through unchanged', () => {
 				run('help');
+				expect(spawnSync).toHaveBeenCalledWith('gulp', ['help']);
 			});
 		});
 	});

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -55,6 +55,9 @@ module.exports = function() {
 		case 'format':
 			require('./scripts/format')();
 			break;
+		case 'theme':
+			require('./scripts/theme').run(ARGS_ARRAY);
+			break;
 		case 'test':
 			require('./scripts/test')(ARGS_ARRAY);
 			break;

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -56,7 +56,7 @@ module.exports = function() {
 			require('./scripts/format')();
 			break;
 		case 'theme':
-			require('./scripts/theme').run(ARGS_ARRAY);
+			require('./scripts/theme').run(...ARGS_ARRAY.slice(1));
 			break;
 		case 'test':
 			require('./scripts/test')(ARGS_ARRAY);

--- a/packages/liferay-npm-scripts/src/scripts/theme.js
+++ b/packages/liferay-npm-scripts/src/scripts/theme.js
@@ -1,0 +1,100 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+const spawnSync = require('../utils/spawnSync');
+
+const APPS_ROOT_DIR = '<AppsRootDir>';
+
+const BUILD_ARGS = {
+	'--css-common-path': './build_gradle/frontend-css-common',
+	'--styled-path': `${APPS_ROOT_DIR}/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled`,
+	'--unstyled-path': `${APPS_ROOT_DIR}/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled`
+};
+
+/**
+ * Walk up the directory hierarchy looking for an "apps" directory.
+ * Returns `null` if none can be found.
+ */
+function findAppsDirectory(from = process.cwd()) {
+	let current = from;
+	let previous = null;
+
+	while (current !== previous) {
+		const apps = path.join(current, 'apps');
+		if (fs.existsSync(apps)) {
+			return apps;
+		}
+		previous = current;
+		current = path.dirname(current);
+	}
+
+	return null;
+}
+
+/**
+ * Checks to make sure that the caller isn't supplying any build arguments that
+ * conflict with the ones that we want to set.
+ */
+function checkExistingBuildArgs(args) {
+	const reservedArgs = new Set(Object.keys(BUILD_ARGS));
+	args.forEach(arg => {
+		if (reservedArgs.has(arg)) {
+			throw new Error(
+				`Must not supply ${arg} when invoking \`theme build\``
+			);
+		}
+	});
+}
+
+/**
+ * Returns an array of additional build arguments required to build a theme.
+ */
+function prepareAdditionalBuildArgs() {
+	const apps = findAppsDirectory();
+	if (!apps) {
+		throw new Error('Unable to find "apps" directory');
+	}
+
+	const themes = path.join(apps, 'frontend-theme');
+	if (!fs.existsSync(themes)) {
+		throw new Error('Unable to find "frontend-theme" directory');
+	}
+
+	const args = [];
+	Object.keys(BUILD_ARGS).forEach(key => {
+		const value = BUILD_ARGS[key];
+		args.push(key, value.replace(APPS_ROOT_DIR, apps));
+	});
+	return args;
+}
+
+/**
+ * Wrapper to run `gulp` tasks for a theme in the liferay-portal repo.
+ */
+function run(...subcommandAndArgs) {
+	const [subcommand, ...args] = subcommandAndArgs;
+	switch (subcommand) {
+		case 'build':
+			checkExistingBuildArgs(args);
+			args.unshift(...prepareAdditionalBuildArgs());
+			break;
+
+		default:
+			// Pass-through.
+			break;
+	}
+
+	spawnSync('gulp', [subcommand, ...args]);
+}
+
+module.exports = {
+	checkExistingBuildArgs,
+	findAppsDirectory,
+	prepareAdditionalBuildArgs,
+	run
+};


### PR DESCRIPTION
With this, we can replace scripts like theses ones in liferay-portal:

    "build": "gulp build --css-common-path ./build_gradle/frontend-css-common --styled-path ../../frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled --unstyled-path ../../frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled"

with:

    "build": "liferay-npm-scripts theme build"

I added a bunch of tests because this involves traversing the filesystem and I didn't want to screw it up. Using runtime traversal rather than hardcoding relative paths in order to make us _somewhat_ resilient to possible future changes in the structure of the filesystem layout. As it is right now, we have two variants in liferay-portal, which I have reflected in the structure of the fixtures:

- Marketplace themes like fjord that live in modules like "frontend-theme-fjord/frontend-theme-fjord".
- Core themes which like "classic" that live under "frontend-theme",  right next to the "unstyled" and "styled" dependencies.

Test plan: `yarn test`

Closes: https://github.com/liferay/liferay-npm-tools/issues/64