### PR TITLE
feat: add top-level shortcut to run all tests (#67)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,7 @@ git pull --ff-only upstream master
 yarn format:check
 
 # Run tests (currently, we don't have many of them):
-(cd packages/liferay-jest-junit-reporter && yarn test)
-(cd packages/liferay-npm-scripts && yarn test)
+yarn test
 
 # Update individual package versions:
 # - Note that this time we updated all the packages,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"format": "prettier --write '**/*.js'",
 		"format:check": "prettier --list-different '**/*.js'",
 		"lint": "eslint '**/*.js'",
-		"lint:fix": "eslint --fix '**/*.js'"
+		"lint:fix": "eslint --fix '**/*.js'",
+		"test": "yarn workspaces run test"
 	},
 	"workspaces": [
 		"packages/*"

--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -11,5 +11,8 @@
 		"liferay-npm-bundler-plugin-namespace-packages": "2.7.1",
 		"liferay-npm-bundler-plugin-replace-browser-modules": "2.7.1",
 		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.7.1"
+	},
+	"scripts": {
+		"test": "echo 'No tests currently defined for liferay-npm-bundler-preset-liferay-dev'"
 	}
 }


### PR DESCRIPTION
This it the simplest thing I could think of to get tests running from the top-level. Ideally though, we could just run jest once at the top. That would be pretty easy to set-up, but would require a bit of extra work to make it happen while still preserving the ability to run the tests at the level of the individual packages, so I am keeping it simple for now.

Test plan: `yarn test` at top level and see all run. Then `yarn test` at individual package level to prove that that still works too.

Closes: https://github.com/liferay/liferay-npm-tools/issues/67