### PR TITLE
feat: simplify release process (#50)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,21 +8,15 @@ At the time of writing we have a pretty informal release process for the package
 git checkout master
 git pull --ff-only upstream master
 
-# Make sure formatting is up-to-date:
-yarn format:check
-
-# Run tests (currently, we don't have many of them):
-yarn test
-
 # Update individual package versions:
 # - Note that this time we updated all the packages,
 #   but on many occasions we'll update only one, or two.
 cd packages/liferay-jest-junit-reporter
-yarn version --no-git-tag-version --new-version 1.0.1
+yarn version --new-version 1.0.1 # or: yarn version --patch etc
 cd ../liferay-npm-bundler-preset-liferay-dev
-yarn version --no-git-tag-version --new-version 1.1.4
+yarn version --new-version 1.1.4
 cd ../liferay-npm-scripts
-yarn version --no-git-tag-version --new-version 1.4.8
+yarn version --new-version 1.4.8
 cd ../..
 
 # Note that if you update the preset, or the reporter,
@@ -36,19 +30,13 @@ cd ../..
 # Ensure lockfile is up-to-date.
 yarn
 
-# Produce and push final commit.
-git commit -p
+# Push final commit(s).
 git push upstream master.
 
-# Update stable branch and create tags.
+# Update and publish the stable branch and tags.
 git checkout stable
 git pull upstream --ff-only stable
 git merge --ff-only master
-git tag liferay-jest-junit-reporter/v1.0.1 -m 'liferay-jest-junit-reporter v1.0.1'
-git tag liferay-npm-bundler-preset-liferay-dev/v1.1.4 -m 'liferay-npm-bundler-preset-liferay-dev v1.1.4'
-git tag liferay-npm-scripts/v1.4.8 -m 'liferay-npm-scripts v1.4.8'
-
-# Publish the tags.
 git push upstream stable --follow-tags
 
 # Publish packages in order; liferay-npm-scripts must

--- a/packages/liferay-jest-junit-reporter/.yarnrc
+++ b/packages/liferay-jest-junit-reporter/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "liferay-jest-junit-reporter/v"
+version-git-message "liferay-jest-junit-reporter/v%s"

--- a/packages/liferay-jest-junit-reporter/package.json
+++ b/packages/liferay-jest-junit-reporter/package.json
@@ -4,6 +4,7 @@
 	"description": "A JUnit reporter for Jest and Liferay CI",
 	"main": "index.js",
 	"scripts": {
+		"preversion": "cd ../.. && yarn ci",
 		"test": "jest"
 	},
 	"repository": {

--- a/packages/liferay-npm-bundler-preset-liferay-dev/.yarnrc
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "liferay-npm-bundler-preset-liferay-dev/v"
+version-git-message "liferay-npm-bundler-preset-liferay-dev/v%s"

--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -13,6 +13,7 @@
 		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.7.1"
 	},
 	"scripts": {
+		"preversion": "cd ../.. && yarn ci",
 		"test": "echo 'No tests currently defined for liferay-npm-bundler-preset-liferay-dev'"
 	}
 }

--- a/packages/liferay-npm-scripts/.yarnrc
+++ b/packages/liferay-npm-scripts/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "liferay-npm-scripts/v"
+version-git-message "liferay-npm-scripts/v%s"

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -34,6 +34,7 @@
 		"sort-keys": "^2.0.0"
 	},
 	"scripts": {
+		"preversion": "cd ../.. && yarn ci",
 		"test": "jest"
 	},
 	"jest": {


### PR DESCRIPTION
As you can see in the changes to CONTRIBUTING.md, the release process can be made simpler by doing two things:

- Adding `.yarnrc` config files that set up the templates for the correct tag and release commit message formats.
- Using `"preversion"` scripts to automatically run the CI checks (formatting, linting, and testing) before cutting a release.

Note that we run the checks for *all* packages in the repo, which is overkill, but it is the simplest thing to do. If a problem in package A ever blocks you from publishing package B you can pass `--ignore-scripts`, but you should probably just fix package A because we want the CI to be green on every commit anyway. As a follow-up, we should make it possible to run the tests independently within a given repo.

There are still further steps we can take to make releasing even simpler (see the related issue), but this is a good first step.

Test plan:

Prepare some pretend releases using different invocations of `yarn version`, see the CI runs succeed, and then inspect output of `git log -p` to see that created commits include the right messages and tags.

    cd packages
    cd liferay-jest-junit-reporter
    yarn version --minor
    cd ../liferay-npm-scripts
    yarn version --patch
    cd ../liferay-npm-bundler-preset-liferay-dev
    yarn version
    git log -p
    git tag -l

Related: https://github.com/liferay/liferay-npm-tools/issues/50