### PR TITLE
feat: add Babel merge strategy to get-merged-config.js

### DIFF
--- a/packages/liferay-npm-scripts/__tests__/utils/deep-merge.js
+++ b/packages/liferay-npm-scripts/__tests__/utils/deep-merge.js
@@ -1,0 +1,291 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const deepMerge = require('../../src/utils/deep-merge');
+
+describe('deepMerge()', () => {
+	it('uses the "DEFAULT" mode by default', () => {
+		// DEFAULT mode concatenates arrays.
+		expect(deepMerge([[1], [2]])).toEqual([1, 2]);
+	});
+
+	it('complains if passed an invalid mode', () => {
+		expect(() => deepMerge([], NaN)).toThrow(/unsupported mode/);
+	});
+
+	describe('MODE.DEFAULT', () => {
+		it('concatenates arrays', () => {
+			expect(
+				deepMerge([[1, 2], ['a', 'b']], deepMerge.MODE.DEFAULT)
+			).toEqual([1, 2, 'a', 'b']);
+		});
+	});
+
+	describe('MODE.OVERWRITE_ARRAYS', () => {
+		it('overwrites arrays', () => {
+			expect(
+				deepMerge(
+					[[1, 2, 3], ['a', 'b', 'c']],
+					deepMerge.MODE.OVERWRITE_ARRAYS
+				)
+			).toEqual(['a', 'b', 'c']);
+		});
+	});
+
+	describe('MODE.BABEL', () => {
+		it('concatenates named plugins', () => {
+			expect(
+				deepMerge(
+					[
+						{
+							plugins: ['a', 'b']
+						},
+						{
+							plugins: ['c', 'd']
+						}
+					],
+					deepMerge.MODE.BABEL
+				)
+			).toEqual({
+				plugins: ['a', 'b', 'c', 'd']
+			});
+		});
+
+		it('deduplicates named plugins', () => {
+			expect(
+				deepMerge(
+					[
+						{
+							plugins: ['a', 'b']
+						},
+						{
+							plugins: ['a', 'b', 'c']
+						}
+					],
+					deepMerge.MODE.BABEL
+				)
+			).toEqual({
+				plugins: ['a', 'b', 'c']
+			});
+		});
+
+		it('deduplicates irrespective of plugin order', () => {
+			expect(
+				deepMerge(
+					[
+						{
+							plugins: ['b', 'a']
+						},
+						{
+							plugins: ['c', 'b', 'a']
+						}
+					],
+					deepMerge.MODE.BABEL
+				)
+			).toEqual({
+				plugins: ['b', 'a', 'c']
+			});
+		});
+
+		it('merges a named plugin into a plugin with options', () => {
+			expect(
+				deepMerge(
+					[
+						{
+							plugins: [['a', {option: 1}], 'b']
+						},
+						{
+							plugins: ['a', 'c']
+						}
+					],
+					deepMerge.MODE.BABEL
+				)
+			).toEqual({
+				plugins: [['a', {option: 1}], 'b', 'c']
+			});
+		});
+
+		it('merges a plugin with options into a named plugin ', () => {
+			expect(
+				deepMerge(
+					[
+						{
+							plugins: ['a', 'b']
+						},
+						{
+							plugins: ['c', ['b', {option: 2}]]
+						}
+					],
+					deepMerge.MODE.BABEL
+				)
+			).toEqual({
+				plugins: ['a', ['b', {option: 2}], 'c']
+			});
+		});
+
+		it('merges two plugins with options', () => {
+			expect(
+				deepMerge(
+					[
+						{
+							plugins: ['a', ['b', {foo: true, bar: false}]]
+						},
+						{
+							plugins: [['b', {foo: false, baz: null}], 'c']
+						}
+					],
+					deepMerge.MODE.BABEL
+				)
+			).toEqual({
+				plugins: ['a', ['b', {foo: false, bar: false, baz: null}], 'c']
+			});
+		});
+
+		it('omits empty options objects', () => {
+			expect(
+				deepMerge(
+					[
+						{
+							plugins: [['a'], 'b', ['z', {}]]
+						},
+						{
+							plugins: [['a', {}], 'c', ['d', {}], ['e']]
+						}
+					],
+					deepMerge.MODE.BABEL
+				)
+			).toEqual({
+				plugins: ['a', 'b', 'z', 'c', 'd', 'e']
+			});
+		});
+
+		it('merges other fields using the default strategy', () => {
+			expect(
+				deepMerge(
+					[
+						{
+							plugins: ['a', ['b', {option: 1}]],
+							ignore: ['./mocks/*.js']
+						},
+						{
+							plugins: ['c'],
+							ignore: ['./tests/*.disabled.js']
+						}
+					],
+					deepMerge.MODE.BABEL
+				)
+			).toEqual({
+				plugins: ['a', ['b', {option: 1}], 'c'],
+				ignore: ['./mocks/*.js', './tests/*.disabled.js']
+			});
+		});
+
+		it('merges presets correctly as well', () => {
+			// Just a smoke test here, because it is powered by the exact same
+			// code that's exercised in all the "plugins" tests above.
+			expect(
+				deepMerge(
+					[
+						{
+							plugins: [
+								'a',
+								['b', {option: 1}],
+								['c', {option: 2}],
+								'd'
+							],
+							presets: [
+								['a', {targets: [1, 2]}],
+								'b',
+								'c',
+								['d', {foo: 1}]
+							],
+							ignore: ['*.mjs']
+						},
+						{
+							plugins: ['d'],
+							presets: [
+								'a',
+								['d', {foo: 2, bar: 3}],
+								['e', {true: false}],
+								'c'
+							],
+							extends: 'other'
+						}
+					],
+					deepMerge.MODE.BABEL
+				)
+			).toEqual({
+				plugins: ['a', ['b', {option: 1}], ['c', {option: 2}], 'd'],
+				presets: [
+					['a', {targets: [1, 2]}],
+					'b',
+					'c',
+					['d', {foo: 2, bar: 3}],
+					['e', {true: false}]
+				],
+				ignore: ['*.mjs'],
+				extends: 'other'
+			});
+		});
+
+		it("doesn't break the segments-web build (regression test)", () => {
+			const localConfig = {
+				presets: ['@babel/preset-react'],
+				plugins: [
+					[
+						'module-resolver',
+						{
+							root: [
+								'./src/main/resources/META-INF/resources/js/'
+							],
+							alias: {
+								test: './test/js/'
+							}
+						}
+					]
+				]
+			};
+
+			const defaultConfig = {
+				presets: ['@babel/preset-env'],
+				plugins: [
+					'@babel/proposal-class-properties',
+					'@babel/proposal-object-rest-spread'
+				]
+			};
+
+			expect(
+				deepMerge([defaultConfig, localConfig], deepMerge.MODE.BABEL)
+			).toEqual({
+				presets: ['@babel/preset-env', '@babel/preset-react'],
+				plugins: [
+					'@babel/proposal-class-properties',
+					'@babel/proposal-object-rest-spread',
+					[
+						'module-resolver',
+						{
+							root: [
+								'./src/main/resources/META-INF/resources/js/'
+							],
+							alias: {
+								test: './test/js/'
+							}
+						}
+					]
+				]
+			});
+		});
+
+		it('complains about malformed plugin names', () => {
+			expect(() => {
+				deepMerge(
+					[{plugins: [1]}, {plugins: []}],
+					deepMerge.MODE.BABEL
+				);
+			}).toThrow(/malformed item/);
+		});
+	});
+});

--- a/packages/liferay-npm-scripts/src/config/babel.json
+++ b/packages/liferay-npm-scripts/src/config/babel.json
@@ -1,7 +1,7 @@
 {
 	"presets": ["@babel/preset-env"],
 	"plugins": [
-		"@babel/plugin-proposal-class-properties",
-		"@babel/plugin-proposal-object-rest-spread"
+		"@babel/proposal-class-properties",
+		"@babel/proposal-object-rest-spread"
 	]
 }

--- a/packages/liferay-npm-scripts/src/utils/deep-merge.js
+++ b/packages/liferay-npm-scripts/src/utils/deep-merge.js
@@ -35,14 +35,125 @@ function combineMerge(target, source, options) {
  */
 const overwriteMerge = (destinationArray, sourceArray) => sourceArray;
 
+function getItemDescription(item) {
+	try {
+		return JSON.stringify(item);
+	} catch (error) {
+		// Could be a circular reference, but we're unlikely to ever get here
+		// because the deepmerge package itself will die first.
+		return `[unstringifiable item: ${error}]`;
+	}
+}
+
+function getBabelName(item) {
+	if (typeof item === 'string') {
+		return item;
+	} else if (Array.isArray(item) && typeof item[0] === 'string') {
+		return item[0];
+	} else {
+		throw new Error(
+			`getBabelName(): malformed item ${getItemDescription(item)}`
+		);
+	}
+}
+
+function getBabelOptions(item) {
+	if (typeof item === 'string') {
+		return null;
+	} else if (Array.isArray(item)) {
+		const options = item[1];
+		return options &&
+			typeof options === 'object' &&
+			Object.keys(options).length
+			? options
+			: null;
+	} else {
+		// We never expect to get here, but just in case...
+		throw new Error('getBabelOptions(): incompatible item type');
+	}
+}
+
+/**
+ * Custom merge that knows how to merge "plugins" and "presets".
+ */
+function babelMerge(key) {
+	if (key === 'plugins' || key === 'presets') {
+		return function(target, source, options) {
+			// Create a mutable copy of `source`.
+			const pending = source.slice();
+
+			const result = target.map(targetItem => {
+				const targetName = getBabelName(targetItem);
+				const sourceIndex = pending.findIndex(sourceItem => {
+					const sourceName = getBabelName(sourceItem);
+					return sourceName === targetName;
+				});
+				if (sourceIndex !== -1) {
+					const [sourceItem] = pending.splice(sourceIndex, 1);
+					const mergedOptions = merge.all(
+						[
+							getBabelOptions(targetItem),
+							getBabelOptions(sourceItem)
+						].filter(Boolean),
+						options
+					);
+
+					return Object.keys(mergedOptions).length
+						? [targetName, mergedOptions]
+						: targetName;
+				} else {
+					const targetOptions = getBabelOptions(targetItem);
+					return targetOptions ? targetItem : targetName;
+				}
+			});
+
+			return result.concat(
+				pending.map(item => {
+					const itemName = getBabelName(item);
+					const itemOptions = getBabelOptions(item);
+					return itemOptions ? [itemName, itemOptions] : itemName;
+				})
+			);
+		};
+	} else {
+		return combineMerge;
+	}
+}
+
+const MODE = Object.freeze({
+	DEFAULT: 0,
+	OVERWRITE_ARRAYS: 1,
+	BABEL: 2
+});
+
 /**
  * Helper to get merge two json objects
- * @param {Object} defaultConfig Config file
- * @param {Object} customConfig Config file
+ * @param {Array} items An array of config objects
+ * @param {Number} mode Merge strategy for combining values.
  * @returns {Object}
  */
-module.exports = function(items, overwrite) {
-	return merge.all(items, {
-		arrayMerge: overwrite ? overwriteMerge : combineMerge
-	});
-};
+function deepMerge(items, mode = MODE.DEFAULT) {
+	switch (mode) {
+		case MODE.DEFAULT:
+			return merge.all(items, {
+				arrayMerge: combineMerge
+			});
+
+		case MODE.OVERWRITE_ARRAYS:
+			return merge.all(items, {
+				arrayMerge: overwriteMerge
+			});
+
+		case MODE.BABEL:
+			return merge.all(items, {
+				customMerge: babelMerge
+			});
+
+		default:
+			throw new Error(`deepMerge(): unsupported mode: ${mode}`);
+	}
+}
+
+deepMerge.MODE = MODE;
+
+module.exports = deepMerge;

--- a/packages/liferay-npm-scripts/src/utils/get-merged-config.js
+++ b/packages/liferay-npm-scripts/src/utils/get-merged-config.js
@@ -17,10 +17,13 @@ module.exports = function(type) {
 	switch (type) {
 		case 'babel':
 			return sortKeys(
-				deepMerge([
-					require('../config/babel'),
-					getUserConfig('.babelrc', 'babel')
-				])
+				deepMerge(
+					[
+						require('../config/babel'),
+						getUserConfig('.babelrc', 'babel')
+					],
+					deepMerge.MODE.BABEL
+				)
 			);
 
 		case 'bundler':
@@ -54,7 +57,12 @@ module.exports = function(type) {
 				presetConfig = require(userConfig.preset);
 			}
 
-			return sortKeys(deepMerge([presetConfig, userConfig], true));
+			return sortKeys(
+				deepMerge(
+					[presetConfig, userConfig],
+					deepMerge.MODE.OVERWRITE_ARRAYS
+				)
+			);
 		}
 		default:
 			// eslint-disable-next-line no-console


### PR DESCRIPTION
As described in the related issue, our merge implementation is using the pre-2.0 version of the array merge algorithm in the "deepmerge" package. They removed it because it was a "complicated thing".

In the case of merging Babel configs it verily breaks them, because you can specify plugins and presets as either `'name'` or `['name', options]`. Here's a reduced example of some surprising behavior:

- merging `['a', 'b', ['c']]`
- into `['d', 'e']`
- yields: `['d', 'e', ['c'], 'b']`

ie. `'a'` disappears into the void.

See the test cases included in this commit for a real-life example taken from segments-web. The old algorithm would cause the `@babel/plugin-proposal-class-properties` plugin to vanish.

The implementation here doesn't intend to handle all possible edge cases (for example, it doesn't try to match plugins that have been written in different forms such as "@babel/plugin-x" and "x"), but it covers the ones we are most likely to see in liferay-portal and it is well tested.

I chose to write a narrow implementation like this rather than pull in a third-party dependency like "babel-merge", because I like to keep our dependency footprint small and we actually kind of want to discourage complicated Babel overrides in liferay-portal in any case, so it's in our interests to have something that isn't too flexible.

Closes: https://github.com/liferay/liferay-npm-tools/issues/83