### PR TITLE
fix: recover original .npmbundlerrc after failures (#71)

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -39,17 +39,19 @@ function compileBabel() {
  * `liferay-npm-bundler` executable.
  */
 function runBundler() {
-	moveToTemp(CWD, '.npmbundlerrc');
+	try {
+		moveToTemp(CWD, '.npmbundlerrc');
 
-	const RC_PATH = path.join(CWD, '.npmbundlerrc');
+		const RC_PATH = path.join(CWD, '.npmbundlerrc');
 
-	fs.writeFileSync(RC_PATH, JSON.stringify(BUNDLER_CONFIG));
+		fs.writeFileSync(RC_PATH, JSON.stringify(BUNDLER_CONFIG));
 
-	spawnSync('liferay-npm-bundler');
+		spawnSync('liferay-npm-bundler');
 
-	fs.unlinkSync(RC_PATH);
-
-	removeFromTemp(CWD, '.npmbundlerrc');
+		fs.unlinkSync(RC_PATH);
+	} finally {
+		removeFromTemp(CWD, '.npmbundlerrc');
+	}
 }
 
 /**


### PR DESCRIPTION
Unlike what I did with Babel in #82, just add a `try`/`finally` wrapper. I wanted something more generic and reusable for Babel because we use it in 3 places, but we only use liferay-npm-bundler in one place, so something simpler and more direct is called for.

Test plan: install in liferay-portal, add a `throw` after bundling, and run the `yarn build` in a module with an .npmbundlerrc file (eg. frontend-js-web). See the original config file is restored despite the error.

Closes: https://github.com/liferay/liferay-npm-tools/issues/71