### PR TITLE
feat: enforce canonical preset and plugin names (#89)

### DIFF
--- a/packages/liferay-npm-scripts/__tests__/utils/deep-merge.js
+++ b/packages/liferay-npm-scripts/__tests__/utils/deep-merge.js
@@ -287,5 +287,64 @@ describe('deepMerge()', () => {
 				);
 			}).toThrow(/malformed item/);
 		});
+
+		it('complains about non-shorthand "@babel/plugin-foo"', () => {
+			expect(() => {
+				deepMerge(
+					[{plugins: []}, {plugins: ['@babel/plugin-foo']}],
+					deepMerge.MODE.BABEL
+				);
+			}).toThrow('expected "@babel/foo"');
+		});
+
+		it('complains about non-shorthand "@org/babel-plugin-foo"', () => {
+			expect(() => {
+				deepMerge(
+					[{plugins: []}, {plugins: ['@org/babel-plugin-foo']}],
+					deepMerge.MODE.BABEL
+				);
+			}).toThrow('expected "@org/foo"');
+		});
+
+		it('complains about non-shorthand "babel-plugin-foo"', () => {
+			expect(() => {
+				deepMerge(
+					[{plugins: []}, {plugins: ['babel-plugin-foo']}],
+					deepMerge.MODE.BABEL
+				);
+			}).toThrow('expected "foo"');
+		});
+
+		it('complains about non-canonical "@babel/foo"', () => {
+			// Note that this one is the odd one out in the sense that
+			// Babel does understand both "@babel/preset-foo" and
+			// "@babel/foo", but in the docs it recommends the long-hand
+			// form. This is unlike plugins, where it again understands
+			// both, but recommends the short-hand form.
+			expect(() => {
+				deepMerge(
+					[{presets: []}, {presets: ['@babel/foo']}],
+					deepMerge.MODE.BABEL
+				);
+			}).toThrow('expected "@babel/preset-foo"');
+		});
+
+		it('complains about non-shorthand "@org/babel-preset-foo"', () => {
+			expect(() => {
+				deepMerge(
+					[{presets: []}, {presets: ['@org/babel-preset-foo']}],
+					deepMerge.MODE.BABEL
+				);
+			}).toThrow('expected "@org/foo"');
+		});
+
+		it('complains about non-shorthand "babel-preset-foo"', () => {
+			expect(() => {
+				deepMerge(
+					[{presets: []}, {presets: ['babel-preset-foo']}],
+					deepMerge.MODE.BABEL
+				);
+			}).toThrow('expected "foo"');
+		});
 	});
 });


### PR DESCRIPTION
As described in the related issue, Babel has various optional shorthand conventions for identifying plugins and presets, which means that it is possible to refer to the same module under different names. Babel will then complain about duplicates with an error message which isn't very helpful:

    Error: Duplicate plugin/preset detected.
    If you'd like to use two separate instances of a plugin,
    they need separate names, e.g.

      plugins: [
        ['some-plugin', {}],
        ['some-plugin', {}, 'some unique name'],
      ]

It doesn't mention the actual names that are duplicated, or even if it's a preset or a plugin that it's complaining about. This, combined with the fact that we dynamically generate a ".babelrc" at runtime, means that this is very confusing for people not familiar with the tooling; they may look at their on-disk ".babelrc" and "package.json" wonder what duplicates it is talking about.

We could silently normalize the names and merge them, but I think it's better to do what we do in this commit: normalize to detect duplicates and issue an error if one is found; that way, we avoid redundant config from finding its way into the repo.

Closes: https://github.com/liferay/liferay-npm-tools/issues/89