### PR TITLE
feat: set NODE_ENV only for builds (#88)

### DIFF
--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-// Do this as the first thing so that any code reading it knows the right env.
-if (!process.env.NODE_ENV) {
-	process.env.NODE_ENV = 'production';
-}
-
 const fs = require('fs');
 const minimist = require('minimist');
 const path = require('path');

--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -11,6 +11,7 @@ const path = require('path');
 
 const getMergedConfig = require('../utils/get-merged-config');
 const {moveToTemp, removeFromTemp} = require('../utils/move-to-temp');
+const setEnv = require('../utils/set-env');
 const {buildSoy, cleanSoy, soyExists} = require('../utils/soy');
 const spawnSync = require('../utils/spawnSync');
 const validateConfig = require('../utils/validateConfig');
@@ -71,6 +72,8 @@ function runBridge() {
  * present, and soy is run when soy files are detected.
  */
 module.exports = function() {
+	setEnv('production');
+
 	validateConfig(
 		BUILD_CONFIG,
 		['input', 'output', 'dependencies'],

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-// Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
-
 const CWD = process.cwd();
 
 const fs = require('fs');

--- a/packages/liferay-npm-scripts/src/utils/set-env.js
+++ b/packages/liferay-npm-scripts/src/utils/set-env.js
@@ -1,0 +1,38 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+function log(message) {
+	// eslint-disable-next-line no-console
+	console.log(message);
+}
+
+/**
+ * Sets NODE_ENV to the supplied `env`, unless the user has already explicitly
+ * provided a value.
+ *
+ * To override, run:
+ *
+ * ```
+ * env NODE_ENV=development liferay-npm-scripts subcommand
+ * ```
+ *
+ * Babel will consult NODE_ENV if BABEL_ENV is not defined, but you can
+ * override Babel specifically with:
+ *
+ * ```
+ * env BABEL_ENV=development liferay-npm-scripts subcommand
+ * ```
+ */
+function setEnv(env) {
+	if (process.env.NODE_ENV) {
+		log(`Using pre-existing NODE_ENV: ${process.env.NODE_ENV}`);
+	} else {
+		log(`Using NODE_ENV: ${env}`);
+		process.env.NODE_ENV = env;
+	}
+}
+
+module.exports = setEnv;


### PR DESCRIPTION
This will allow Jest, for example, to use its normal default ("test").

Test plan: Use `yarn add -W path/to/liferay-npm-scripts` to install this version in the liferay-portal repo's "modules/" workspace root. Then change to a module that uses "liferay-npm-scripts" (eg. "segments/segments-web") and run `yarn build`; see:

```
$ liferay-npm-scripts build
Using NODE_ENV: production
Successfully compiled 39 files with Babel.
...
```

Then run `env NODE_ENV=development yarn build` and see:

```
$ liferay-npm-scripts build
Using pre-existing NODE_ENV: development
Successfully compiled 39 files with Babel.
...
```

Closes: https://github.com/liferay/liferay-npm-tools/issues/88