### PR TITLE
refactor: teach getMergedConfig() and index to reject invalid types

### DIFF
--- a/packages/liferay-npm-scripts/__tests__/index.js
+++ b/packages/liferay-npm-scripts/__tests__/index.js
@@ -1,0 +1,33 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const index = require('../src/index');
+
+describe('index.js', () => {
+	let argv;
+
+	function setArgv(...args) {
+		process.argv = ['/path/to/node', '/path/to/scripts', ...args];
+	}
+
+	beforeEach(() => {
+		argv = process.argv;
+	});
+
+	afterEach(() => {
+		process.argv = argv;
+	});
+
+	it('complains if given an invalid command', () => {
+		setArgv('foo');
+		expect(() => index()).toThrow('requires a valid command');
+	});
+
+	it('complains if not given an command', () => {
+		setArgv();
+		expect(() => index()).toThrow('requires a valid command');
+	});
+});

--- a/packages/liferay-npm-scripts/__tests__/utils/get-merged-config.js
+++ b/packages/liferay-npm-scripts/__tests__/utils/get-merged-config.js
@@ -1,0 +1,13 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const getMergedConfig = require('../../src/utils/get-merged-config');
+
+describe('getMergedConfig()', () => {
+	it('rejects invalid types', () => {
+		expect(() => getMergedConfig('foo')).toThrow('not a valid config');
+	});
+});

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -4,14 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const fs = require('fs');
 const minimist = require('minimist');
-const path = require('path');
-const rimraf = require('rimraf');
-
-const CWD = process.cwd();
-
-const TEMP_PATH = path.join(CWD, 'TEMP_LIFERAY_NPM_SCRIPTS');
 
 module.exports = function() {
 	const ARGS_ARRAY = process.argv.slice(2);
@@ -20,41 +13,38 @@ module.exports = function() {
 		_: [type]
 	} = minimist(ARGS_ARRAY);
 
-	if (!fs.existsSync(TEMP_PATH)) {
-		fs.mkdirSync(TEMP_PATH);
-	}
-
-	switch (type) {
-		case 'build':
+	const COMMANDS = {
+		build() {
 			require('./scripts/build')();
-			break;
+		},
 
-		case 'format':
+		format() {
 			require('./scripts/format')();
-			break;
+		},
 
-		case 'lint':
+		lint() {
 			require('./scripts/lint')();
-			break;
+		},
 
-		case 'test':
+		test() {
 			require('./scripts/test')(ARGS_ARRAY);
-			break;
+		},
 
-		case 'theme':
+		theme() {
 			require('./scripts/theme').run(...ARGS_ARRAY.slice(1));
-			break;
+		},
 
-		case 'webpack':
+		webpack() {
 			require('./scripts/webpack')(...ARGS_ARRAY.slice(1));
-			break;
+		}
+	};
 
-		default:
-			// eslint-disable-next-line no-console
-			console.log(
-				`'${type}' is not a valid command for liferay-npm-scripts.`
-			);
+	if (COMMANDS[type]) {
+		COMMANDS[type]();
+	} else {
+		const commands = Object.keys(COMMANDS).join(', ');
+		throw new Error(
+			`liferay-npm-scripts requires a valid command (${commands})`
+		);
 	}
-
-	rimraf.sync(TEMP_PATH);
 };

--- a/packages/liferay-npm-scripts/src/utils/get-merged-config.js
+++ b/packages/liferay-npm-scripts/src/utils/get-merged-config.js
@@ -13,7 +13,7 @@ const getUserConfig = require('./get-user-config');
  * Helper to get JSON configs
  * @param {string} type Name of configuration
  */
-module.exports = function(type) {
+function getMergedConfig(type) {
 	switch (type) {
 		case 'babel':
 			return sortKeys(
@@ -64,8 +64,10 @@ module.exports = function(type) {
 				)
 			);
 		}
+
 		default:
-			// eslint-disable-next-line no-console
-			console.log(`'${type}' is not a valid config`);
+			throw new Error(`'${type}' is not a valid config`);
 	}
-};
+}
+
+module.exports = getMergedConfig;


### PR DESCRIPTION
Based on discussion about use of `console.log` in:

https://github.com/liferay/liferay-npm-tools/pull/91

I did a quick audit and found that there are only two other places in this package where we use `console.log` and both should probably throw errors instead of just logging a message and proceeding.

For example, current behavior:

    $ liferay-npm-scripts formatz
    'formatz' is not a valid command for liferay-npm-scripts.
    $ liferay-npm-scripts
    'undefined' is not a valid command for liferay-npm-scripts.

(Both exit with status code 0.)

Behavior after this commit:

    $ liferay-npm-scripts formatz
    /path/to/index.js:46
                    throw new Error(
                    ^

    Error: liferay-npm-scripts requires a valid command (build, format, lint, test, theme, webpack)
    $ liferay-npm-scripts
    /path/to/index.js:46
                    throw new Error(
                    ^

    Error: liferay-npm-scripts requires a valid command (build, format, lint, test, theme, webpack)

(Both exit with status code 1.)

I changed a `switch` to an object so that I could auto-generate the list of commands, and also deleted some dead code on the way; we were creating a temporary dir but never using it.

In any case, now we have exactly one place in the code base that uses `console.log`.