### PR TITLE
doc: recommend using a recent version of NodeJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 ## Setup
 
-1. Install NodeJS >= [v6.11.0](http://nodejs.org/dist/v6.11.0/), if you don't have it yet.
+1. Install NodeJS >= [v10.15.1](http://nodejs.org/dist/v10.15.1/), if you don't have it yet.
+
+    (At the time of writing, v10.15.1 is the version used by [liferay-portal](liferay-portal), and code in this project is written using "modern JS" syntax and features — without transpilation and executed directly.)
 
 2. Run yarn to install local dependencies and link packages together:
 
-```sh
-yarn
-```
+    ```sh
+    yarn
+    ```


### PR DESCRIPTION
Because we don't use Babel to make these packages and they get run in the context of liferay-portal without transpilation, we should advise people to use a recent version so as not to choke on the various "modern JS" features that we use pretty freely in this codebase.