### PR TITLE
feat: provide a way to skip linting/formatting entirely

### DIFF
--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -36,7 +36,7 @@ Do you need to use `liferay-npm-bridge-generator`? Just add a `.npmbridgerc` fil
 liferay-npm-scripts lint
 ```
 
-Lint calls `check-source-formatting` for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L25-L32)..
+Lint calls `prettier` for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L25-L32)..
 
 ### format
 
@@ -44,7 +44,7 @@ Lint calls `check-source-formatting` for the globs specified in your `npmscripts
 liferay-npm-scripts format
 ```
 
-Format calls `check-source-formatting` with the `--inline-edit` flag for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L17-L24).
+Format calls `prettier` with the `--write` flag for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L17-L24).
 
 ### test
 

--- a/packages/liferay-npm-scripts/__tests__/scripts/lint.js
+++ b/packages/liferay-npm-scripts/__tests__/scripts/lint.js
@@ -1,0 +1,70 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('scripts/lint.js', () => {
+	let cwd;
+	let lint;
+	let spawnSync;
+	let temp;
+
+	beforeEach(() => {
+		cwd = process.cwd();
+		temp = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-'));
+		process.chdir(temp);
+
+		jest.mock('../../src/utils/spawn-sync');
+		lint = require('../../src/scripts/lint');
+		spawnSync = require('../../src/utils/spawn-sync');
+	});
+
+	afterEach(() => {
+		jest.resetModules();
+		process.chdir(cwd);
+	});
+
+	it('invokes prettier', () => {
+		lint();
+		expect(spawnSync).toHaveBeenCalledWith('prettier', expect.anything());
+	});
+
+	describe('when no "lint" globs are configured', () => {
+		let log;
+
+		beforeEach(() => {
+			const config = `module.exports = ${JSON.stringify(
+				{lint: []},
+				null,
+				2
+			)};`;
+
+			fs.writeFileSync('npmscripts.config.js', config);
+
+			jest.resetModules();
+			jest.mock('../../src/utils/log');
+			lint = require('../../src/scripts/lint');
+			log = require('../../src/utils/log');
+			spawnSync = require('../../src/utils/spawn-sync');
+		});
+
+		it('logs a message indicating how to configure globs', () => {
+			lint();
+			expect(log).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'paths can be configured via npmscripts.config.js'
+				)
+			);
+		});
+
+		it('does not run prettier', () => {
+			lint();
+			expect(spawnSync).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -7,16 +7,25 @@
 const fs = require('fs');
 const path = require('path');
 const getMergedConfig = require('../utils/get-merged-config');
+const log = require('../utils/log');
 const spawnSync = require('../utils/spawn-sync');
-
-const CONFIG = getMergedConfig('npmscripts');
 
 /**
  * Main function for linting and formatting files
  * @param {boolean} fix Specify if the linter should auto-fix the files
  */
 module.exports = function(fix) {
+	const CONFIG = getMergedConfig('npmscripts');
+
 	const globs = fix ? CONFIG.format : CONFIG.lint;
+
+	if (!globs.length) {
+		log(
+			'No paths specified: paths can be configured via npmscripts.config.js'
+		);
+
+		return;
+	}
 
 	const CONFIG_PATH = path.join(process.cwd(), 'TEMP-prettier-config.json');
 

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -9,13 +9,15 @@ const path = require('path');
 const getMergedConfig = require('../utils/get-merged-config');
 const spawnSync = require('../utils/spawn-sync');
 
-const LINT_PATHS = getMergedConfig('npmscripts').lint;
+const CONFIG = getMergedConfig('npmscripts');
 
 /**
  * Main function for linting and formatting files
  * @param {boolean} fix Specify if the linter should auto-fix the files
  */
 module.exports = function(fix) {
+	const globs = fix ? CONFIG.format : CONFIG.lint;
+
 	const CONFIG_PATH = path.join(process.cwd(), 'TEMP-prettier-config.json');
 
 	fs.writeFileSync(CONFIG_PATH, JSON.stringify(getMergedConfig('prettier')));
@@ -25,7 +27,7 @@ module.exports = function(fix) {
 			'--config',
 			CONFIG_PATH,
 			fix ? '--write' : '--check',
-			...LINT_PATHS
+			...globs
 		];
 
 		spawnSync('prettier', args);


### PR DESCRIPTION
In integrating `prettier` with liferay-portal I have found modules that have "checkFormat" scripts defined even though they don't have any source code (for example, wrapper modules like frontend-js-metal-web, which is basically just declares dependencies but doesn't contain any committed code of its own under "src/"):

    "scripts": {
            "build": "liferay-npm-scripts build",
            "checkFormat": "liferay-npm-scripts lint",
            "format": "liferay-npm-scripts format"
    },

For these, `prettier` will complain about not finding any files that match the default globs. You would think that you could define an `npmscripts.config.js` file, then, that removes the globs, but that won't work either (because `prettier` will complain that you didn't pass any globs).

I am going to explore if there is any downside to removing those "checkFormat" and "format" scripts, but I can also understand why we might want to be able to run `yarn format` in any module and not have it blow up, so that's what this commit is about: it makes it possible to configure an empty set of globs, in which case we won't invoke `prettier` at all.

Along the way, made a tweak to ensure that our behavior matches what we claim in the documentation (details in e954c27).