### PR TITLE
feat: expand lint/format globs to cover "test" (#95)

### DIFF
--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -14,6 +14,10 @@ module.exports = {
 		input: 'src/main/resources/META-INF/resources',
 		output: 'classes/META-INF/resources'
 	},
-	format: ['src/**/*.css', 'src/**/*.js', 'src/**/*.scss'],
-	lint: ['src/**/*.css', 'src/**/*.js', 'src/**/*.scss']
+	format: [
+		'{src,test}/**/*.css',
+		'{src,test}/**/*.js',
+		'{src,test}/**/*.scss'
+	],
+	lint: ['{src,test}/**/*.css', '{src,test}/**/*.js', '{src,test}/**/*.scss']
 };


### PR DESCRIPTION
As described in the related issue, we determined that:

- We want test code in liferay-portal to reside in a top-level "test" directory inside each module.
- Currently there are only two modules which don't follow that pattern:
  - One is dead code which I am proposing to remove here: https://github.com/brunobasto/liferay-portal/pull/1036
  - The other can be moved; currently testing a PR that does that here: https://github.com/wincent/liferay-portal/pull/28

Closes: https://github.com/liferay/liferay-npm-tools/issues/95