### PR TITLE
refactor(scripts)!: rename "lint"/"format" to "check"/"fix" (#110)

### DIFF
--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -30,21 +30,21 @@ Do you have soy dependencies? `build` should automatically detect them.
 
 Do you need to use `liferay-npm-bridge-generator`? Just add a `.npmbridgerc` file and follow the configuration options [here](https://github.com/liferay/liferay-npm-build-tools/wiki/How-to-use-liferay-npm-bridge-generator).
 
-### lint
+### check
 
 ```sh
-liferay-npm-scripts lint
+liferay-npm-scripts check
 ```
 
-Lint calls `prettier` for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L25-L32)..
+Check calls `prettier` for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L25-L32).
 
-### format
+### fix
 
 ```sh
-liferay-npm-scripts format
+liferay-npm-scripts fix
 ```
 
-Format calls `prettier` with the `--write` flag for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L17-L24).
+Fix calls `prettier` with the `--write` flag for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L17-L24).
 
 ### test
 
@@ -119,7 +119,7 @@ If you just set dependencies to be `['my-new-dependency']`, it will override the
 
 If you need more flexibility over babel or the bundler. You can still add a `.babelrc` or `.npmbundlerrc` which will be merged with the default settings this tool provides. [Default Babel Config](./src/config/babel.json), [Default Bundler Config](./src/config/npm-bundler.json)
 
-For more control over `lint` and `format`, follow the configuration options [here](https://github.com/liferay/liferay-frontend-source-formatter#custom-configuration)
+For more control over `check` and `fix`, follow the configuration options [here](https://github.com/liferay/liferay-frontend-source-formatter#custom-configuration)
 
 Want to use a different `NODE_ENV`? Try doing something like
 

--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -36,7 +36,7 @@ Do you need to use `liferay-npm-bridge-generator`? Just add a `.npmbridgerc` fil
 liferay-npm-scripts check
 ```
 
-Check calls `prettier` for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L25-L32).
+Check calls `prettier` with the `--check` flag for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L25-L32).
 
 ### fix
 

--- a/packages/liferay-npm-scripts/__tests__/scripts/check.js
+++ b/packages/liferay-npm-scripts/__tests__/scripts/check.js
@@ -8,19 +8,19 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-describe('scripts/lint.js', () => {
+describe('scripts/check.js', () => {
 	let cwd;
-	let lint;
+	let check;
 	let spawnSync;
 	let temp;
 
 	beforeEach(() => {
 		cwd = process.cwd();
-		temp = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-'));
+		temp = fs.mkdtempSync(path.join(os.tmpdir(), 'check-'));
 		process.chdir(temp);
 
 		jest.mock('../../src/utils/spawn-sync');
-		lint = require('../../src/scripts/lint');
+		check = require('../../src/scripts/check');
 		spawnSync = require('../../src/utils/spawn-sync');
 	});
 
@@ -30,16 +30,16 @@ describe('scripts/lint.js', () => {
 	});
 
 	it('invokes prettier', () => {
-		lint();
+		check();
 		expect(spawnSync).toHaveBeenCalledWith('prettier', expect.anything());
 	});
 
-	describe('when no "lint" globs are configured', () => {
+	describe('when no "check" globs are configured', () => {
 		let log;
 
 		beforeEach(() => {
 			const config = `module.exports = ${JSON.stringify(
-				{lint: []},
+				{check: []},
 				null,
 				2
 			)};`;
@@ -48,13 +48,13 @@ describe('scripts/lint.js', () => {
 
 			jest.resetModules();
 			jest.mock('../../src/utils/log');
-			lint = require('../../src/scripts/lint');
+			check = require('../../src/scripts/check');
 			log = require('../../src/utils/log');
 			spawnSync = require('../../src/utils/spawn-sync');
 		});
 
 		it('logs a message indicating how to configure globs', () => {
-			lint();
+			check();
 			expect(log).toHaveBeenCalledWith(
 				expect.stringContaining(
 					'paths can be configured via npmscripts.config.js'
@@ -63,7 +63,7 @@ describe('scripts/lint.js', () => {
 		});
 
 		it('does not run prettier', () => {
-			lint();
+			check();
 			expect(spawnSync).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -18,12 +18,12 @@ module.exports = function() {
 			require('./scripts/build')();
 		},
 
-		format() {
-			require('./scripts/format')();
+		fix() {
+			require('./scripts/fix')();
 		},
 
-		lint() {
-			require('./scripts/lint')();
+		check() {
+			require('./scripts/check')();
 		},
 
 		test() {

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -18,12 +18,12 @@ module.exports = function() {
 			require('./scripts/build')();
 		},
 
-		fix() {
-			require('./scripts/fix')();
-		},
-
 		check() {
 			require('./scripts/check')();
+		},
+
+		fix() {
+			require('./scripts/fix')();
 		},
 
 		test() {

--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -14,10 +14,10 @@ module.exports = {
 		input: 'src/main/resources/META-INF/resources',
 		output: 'classes/META-INF/resources'
 	},
-	format: [
+	check: [
 		'{src,test}/**/*.css',
 		'{src,test}/**/*.js',
 		'{src,test}/**/*.scss'
 	],
-	lint: ['{src,test}/**/*.css', '{src,test}/**/*.js', '{src,test}/**/*.scss']
+	fix: ['{src,test}/**/*.css', '{src,test}/**/*.js', '{src,test}/**/*.scss']
 };

--- a/packages/liferay-npm-scripts/src/scripts/check.js
+++ b/packages/liferay-npm-scripts/src/scripts/check.js
@@ -12,12 +12,12 @@ const spawnSync = require('../utils/spawn-sync');
 
 /**
  * Main function for linting and formatting files
- * @param {boolean} fix Specify if the linter should auto-fix the files
+ * @param {boolean} fix Specify whether to auto-fix the files
  */
 module.exports = function(fix) {
 	const CONFIG = getMergedConfig('npmscripts');
 
-	const globs = fix ? CONFIG.format : CONFIG.lint;
+	const globs = fix ? CONFIG.fix : CONFIG.check;
 
 	if (!globs.length) {
 		log(

--- a/packages/liferay-npm-scripts/src/scripts/fix.js
+++ b/packages/liferay-npm-scripts/src/scripts/fix.js
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const lintScript = require('./lint');
+const check = require('./check');
 
 /**
- * Main function for formatting files
+ * Main function for fixing (formatting and applying lint fixes to) files.
  */
 module.exports = function() {
-	lintScript(true);
+	check(true);
 };


### PR DESCRIPTION
BREAKING CHANGE: For consistency, "liferay-npm-scripts lint" and "liferay-npm-scripts format" are now "liferay-npm-scripts check" and "liferay-npm-scripts fix", respectively. The corresponding glob properties in "npmscripts.config.js" have also been renamed from "lint" to "check", and from "format" to "fix".

See the related issue for a lengthy explanation.

Related: https://github.com/liferay/liferay-npm-tools/issues/110