### PR TITLE
chore: remove sort-keys dependency

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -35,7 +35,6 @@
 		"minimist": "^1.2.0",
 		"prettier": "^1.17.1",
 		"rimraf": "^2.6.2",
-		"sort-keys": "^3.0.0",
 		"webpack": "^4.30.0",
 		"webpack-cli": "^3.3.1",
 		"webpack-dev-server": "^3.3.1"

--- a/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const sortKeys = require('sort-keys');
 const deepMerge = require('./deepMerge');
 const getUserConfig = require('./getUserConfig');
 
@@ -15,33 +14,28 @@ const getUserConfig = require('./getUserConfig');
 function getMergedConfig(type) {
 	switch (type) {
 		case 'babel':
-			return sortKeys(
-				deepMerge(
-					[require('../config/babel'), getUserConfig('babel')],
-					deepMerge.MODE.BABEL
-				)
+			return deepMerge(
+				[require('../config/babel'), getUserConfig('babel')],
+				deepMerge.MODE.BABEL
 			);
 
 		case 'bundler':
-			return sortKeys(
-				deepMerge([
-					require('../config/npm-bundler'),
-					getUserConfig('npmbundler')
-				])
-			);
+			return deepMerge([
+				require('../config/npm-bundler'),
+				getUserConfig('npmbundler')
+			]);
 
 		case 'jest':
-			return sortKeys(
-				deepMerge([require('../config/jest'), getUserConfig('jest')])
-			);
+			return deepMerge([
+				require('../config/jest'),
+				getUserConfig('jest')
+			]);
 
 		case 'prettier':
-			return sortKeys(
-				deepMerge([
-					require('../config/prettier'),
-					getUserConfig('prettier')
-				])
-			);
+			return deepMerge([
+				require('../config/prettier'),
+				getUserConfig('prettier')
+			]);
 
 		case 'npmscripts': {
 			let presetConfig = {};
@@ -58,11 +52,9 @@ function getMergedConfig(type) {
 				presetConfig = require(userConfig.preset);
 			}
 
-			return sortKeys(
-				deepMerge(
-					[presetConfig, userConfig],
-					deepMerge.MODE.OVERWRITE_ARRAYS
-				)
+			return deepMerge(
+				[presetConfig, userConfig],
+				deepMerge.MODE.OVERWRITE_ARRAYS
 			);
 		}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5738,11 +5738,6 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-obj@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.0.0.tgz#7fd1a7f1b69e160cde9181d2313f445c68aa2679"
-  integrity sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==
-
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -9621,13 +9616,6 @@ sort-keys@^2.0.0:
   integrity sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=
   dependencies:
     is-plain-obj "^1.0.0"
-
-sort-keys@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-3.0.0.tgz#fa751737e3da363ef80632d4fd78e324d661fe9a"
-  integrity sha512-77XUKMiZN5LvQXZ9sgWfJza19AvYIDwaDGwGiULM+B5XYru8Z90Oh06JvqDlJczvjjYvssrV0aK1GI6+YXvn5A==
-  dependencies:
-    is-plain-obj "^2.0.0"
 
 source-list-map@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Just to reduce our dependency footprint a little and remove some "clutter" from the source. We added this in 08fa78d03ebd197 but as far as I can tell there is no need for the keys to be sorted (the merged configs are never committed to the repo or inspected by a human, and we don't do anything order-sensitive with them either).

Note that we still have another copy of sort-keys in the yarn.lock, but that one is a transitive dependency so I'm going to ignore it for now.