### PR TITLE
feat(scripts): make it possible to target "*.es.js" alone

### DIFF
--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/.eslintignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/.eslintignore
@@ -1,0 +1,15 @@
+# This is the top-level .eslintignore.
+
+# Ignore all JS, except "modern" JS.
+**/*.js
+!**/*.es.js
+
+# Handle some top-level config files.
+!.prettierrc.js
+!npmscripts.config.js
+
+# Stuff we never want to touch anywhere.
+**/sdk/**/*.js
+**/build/**/*
+**/classes/**/*
+**/node_modules/**/*

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/frontend-js/frontend-js-aui-web/.eslintignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/frontend-js/frontend-js-aui-web/.eslintignore
@@ -1,0 +1,3 @@
+# A project-level .eslintignore.
+
+**/secret/*.es.js

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/frontend-js/frontend-js-web/.gitignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/frontend-js/frontend-js-web/.gitignore
@@ -1,0 +1,1 @@
+# This folder is an example of a project without a local .eslintignore.

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/rogue/project/yarn.lock
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/rogue/project/yarn.lock
@@ -1,0 +1,3 @@
+# Not really a lockfile, and projects aren't supposed to have their own
+# lockfiles, but we want to make sure the code doesn't misidentify a directory
+# like this one as being the top-level.

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/segments/segments-web/.eslintignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/segments/segments-web/.eslintignore
@@ -1,0 +1,4 @@
+# Another project-level .eslintignore.
+
+**/legacy/*
+!src/stuff/*.js

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/yarn.lock
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/yarn.lock
@@ -1,0 +1,2 @@
+# Not a real yarn.lock, but needed in order for code to identify
+# the top-level "modules/" root.

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/somewhere/subtree/with/a/lock/file/.gitignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/somewhere/subtree/with/a/lock/file/.gitignore
@@ -1,0 +1,1 @@
+# This is the directory where we will start the upwards traversal.

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/somewhere/subtree/yarn.lock
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/somewhere/subtree/yarn.lock
@@ -1,0 +1,1 @@
+# Not really a yarn.lock file, just a placeholder.

--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -8,12 +8,32 @@ const clay = require('./dependencies/clay');
 const liferay = require('./dependencies/liferay');
 const metal = require('./dependencies/metal');
 
+/**
+ * We need to (redundantly) include both "*.es.js" and "*.js" in the JS
+ * globs in order to pacify ESLint. If we use "*.js" alone, then it will
+ * complain if we try to use an `.eslintignore` file with contents like
+ * this:
+ *
+ *      *.js
+ *      !*.es.js
+ *
+ * ie. if the intent is to lint only "modern" ("*.es.js") files, and we
+ * pass just "*.js" as a glob, ESLint will error:
+ *
+ *      You are linting "*.js", but all of the files matching the glob
+ *      pattern "*.js" are ignored.
+ *
+ * With this hack, we can still run Prettier over all "*.js", but focus ESLint
+ * on "*.es.js" alone.
+ */
+const JS_GLOBS = ['{src,test}/**/*.es.js', '{src,test}/**/*.js'];
+
 module.exports = {
 	build: {
 		dependencies: [...clay, ...liferay, ...metal],
 		input: 'src/main/resources/META-INF/resources',
 		output: 'classes/META-INF/resources'
 	},
-	check: ['{src,test}/**/*.js', '{src,test}/**/*.scss'],
-	fix: ['{src,test}/**/*.js', '{src,test}/**/*.scss']
+	check: [...JS_GLOBS, '{src,test}/**/*.scss'],
+	fix: [...JS_GLOBS, '{src,test}/**/*.scss']
 };

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -5,6 +5,7 @@
  */
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const filterGlobs = require('../utils/filterGlobs');
@@ -21,6 +22,159 @@ const DEFAULT_OPTIONS = {
  * File extensions that ESLint can process.
  */
 const EXTENSIONS = ['.js', '.ts', '.tsx'];
+
+/**
+ * Attempt to locate the "modules/" root directory in the liferay-portal repo by
+ * walking up the tree looking for a yarn.lock.
+ */
+function findRoot() {
+	let directory = process.cwd();
+
+	while (directory) {
+		if (fs.existsSync(path.join(directory, 'yarn.lock'))) {
+			if (path.basename(directory) === 'modules') {
+				return directory;
+			} else {
+				log(
+					`Found a yarn.lock in ${directory}, but it is not the "modules/" root`
+				);
+			}
+		}
+
+		if (path.dirname(directory) === directory) {
+			// Can't go any higher.
+			directory = null;
+		} else {
+			directory = path.dirname(directory);
+		}
+	}
+}
+
+/**
+ * Scan for ignore files at locations of the form:
+ *
+ *      apps/[group]/[project]/.eslintignore
+ *
+ * inside the modules root (ie. "modules/").
+ */
+function findProjectIgnoreFiles(root) {
+	const cwd = `current working directory (${process.cwd()})`;
+
+	if (!root) {
+		log(`Unable to find "modules/" root from ${cwd}`);
+		return [];
+	}
+
+	const apps = path.join(root, 'apps');
+
+	try {
+		if (!fs.statSync(apps).isDirectory()) {
+			log(`"modules/apps/" in ${cwd} is not a directory`);
+			return [];
+		}
+	} catch (_error) {
+		log(`Unable to find "modules/apps/" from ${cwd}`);
+		return [];
+	}
+
+	const entries = fs.readdirSync(apps);
+
+	return entries.reduce((acc, entry) => {
+		const directory = path.join(apps, entry);
+
+		if (fs.statSync(directory).isDirectory()) {
+			const projects = fs.readdirSync(directory);
+
+			projects.forEach(project => {
+				const ignore = path.join(directory, project, '.eslintignore');
+
+				if (fs.existsSync(ignore)) {
+					acc.push(ignore);
+				}
+			});
+		}
+
+		return acc;
+	}, []);
+}
+
+/**
+ * ESLint only allows for a single .eslintignore file, and only in the current
+ * directory. In liferay-portal, however, we want the flexibility to have a
+ * top-level .eslintignore under "modules/apps/" and then project-specific ones
+ * that apply when running from a project subdirectory.
+ *
+ * When running from the modules root, we start with the top-level .eslintignore
+ * file and concatenate all sub-project .eslintignore files after relativizing
+ * the paths appropriately.
+ *
+ * When running from a specific project we just prepend the top-level
+ * .eslintignore, without peforming any relativization.
+ *
+ * @see https://eslint.org/docs/user-guide/configuring
+ */
+function getIgnoreFilePath() {
+	const ignores = fs.existsSync('.eslintignore')
+		? [fs.readFileSync('.eslintignore').toString()]
+		: [];
+
+	const root = findRoot();
+
+	if (process.cwd() === root) {
+		findProjectIgnoreFiles(root).forEach(file => {
+			const directory = path.dirname(file);
+			const lines = fs
+				.readFileSync(file)
+				.toString()
+				.split(/[\r\n]+/);
+
+			// Make patterns relative to the "modules/" root.
+			const patterns = lines.map(line => {
+				const match = line.match(/^\s*(\S.+)$/);
+
+				if (match) {
+					if (match[1].startsWith('#')) {
+						// Comment.
+						return line;
+					} else if (match[1].startsWith('!')) {
+						// Negated pattern.
+						return (
+							'!' + path.join('/', directory, match[1].slice(1))
+						);
+					} else {
+						// Normal pattern.
+						return path.join('/', directory, match[1]);
+					}
+				} else {
+					return line;
+				}
+			});
+
+			ignores.push(patterns.join('\n'));
+		});
+	} else if (root) {
+		// Prepend "modules/.eslintignore"
+		const rootIgnore = path.join(root, '.eslintignore');
+
+		if (fs.existsSync(rootIgnore)) {
+			ignores.unshift(fs.readFileSync(rootIgnore).toString());
+		} else {
+			log(`Did not find expected .eslintignore at ${root}`);
+		}
+	}
+
+	const contents = ignores.join('\n');
+
+	const directory = fs.mkdtempSync(
+		path.join(os.tmpdir(), 'liferay-npm-scripts-')
+	);
+
+	const file = path.join(directory, '.eslintignore');
+
+	fs.writeFileSync(file, contents);
+
+	return file;
+}
 
 /**
  * ESLint wrapper.
@@ -47,15 +201,19 @@ function lint(options = {}) {
 		return;
 	}
 
-	const CONFIG_PATH = path.join(process.cwd(), 'TEMP-eslint-config.json');
+	const configPath = path.join(process.cwd(), 'TEMP-eslint-config.json');
 
-	fs.writeFileSync(CONFIG_PATH, JSON.stringify(getMergedConfig('eslint')));
+	fs.writeFileSync(configPath, JSON.stringify(getMergedConfig('eslint')));
 
 	try {
+		const ignorePath = getIgnoreFilePath();
+
 		const args = [
 			'--no-eslintrc',
 			'--config',
-			CONFIG_PATH,
+			configPath,
+			'--ignore-path',
+			ignorePath,
 			fix ? '--fix' : null,
 			quiet ? '--quiet' : null,
 			...globs
@@ -63,7 +221,7 @@ function lint(options = {}) {
 
 		spawnSync('eslint', args);
 	} finally {
-		fs.unlinkSync(CONFIG_PATH);
+		fs.unlinkSync(configPath);
 	}
 }
 

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -77,13 +77,13 @@ function findProjectIgnoreFiles(root) {
 		return [];
 	}
 
-	const entries = fs.readdirSync(apps);
+	const entries = fs.readdirSync(apps).sort();
 
 	return entries.reduce((acc, entry) => {
 		const directory = path.join(apps, entry);
 
 		if (fs.statSync(directory).isDirectory()) {
-			const projects = fs.readdirSync(directory);
+			const projects = fs.readdirSync(directory).sort();
 
 			projects.forEach(project => {
 				const ignore = path.join(directory, project, '.eslintignore');
@@ -122,7 +122,7 @@ function getIgnoreFilePath() {
 
 	if (process.cwd() === root) {
 		findProjectIgnoreFiles(root).forEach(file => {
-			const directory = path.dirname(file);
+			const directory = path.relative('', path.dirname(file));
 			const lines = fs
 				.readFileSync(file)
 				.toString()
@@ -161,6 +161,8 @@ function getIgnoreFilePath() {
 		} else {
 			log(`Did not find expected .eslintignore at ${root}`);
 		}
+	} else {
+		log(`Unable to find "modules/" root`);
 	}
 
 	const contents = ignores.join('\n');

--- a/packages/liferay-npm-scripts/test/scripts/lint.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint.js
@@ -4,27 +4,279 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Allow "." in regular expressions to match newlines.
+ */
+const DOT_ALL = 's';
+
+/**
+ * Allow "^" and "$" in regular expressions to match at line
+ * boundaries instead of just the beginning and end of the string.
+ */
+const MULTILINE = 'm';
+
+const FIXTURES = path.resolve(__dirname, '../../__fixtures__/scripts/lint');
+const MODULES = path.join(FIXTURES, 'modules');
+const FRONTEND_JS_WEB = path.join(MODULES, 'apps/frontend-js/frontend-js-web');
+const SEGMENTS_WEB = path.join(MODULES, 'apps/segments/segments-web');
+const ROGUE_PROJECT = path.join(MODULES, 'apps/rogue/project');
+const NON_PROJECT = path.join(FIXTURES, 'somewhere/subtree/with/a/lock/file');
+
 describe('scripts/lint.js', () => {
-	it('logs a message when no appropriate globs are provided', () => {
+	let cwd;
+	let globs;
+
+	beforeEach(() => {
+		cwd = process.cwd();
+		globs = ['**/*.js'];
+	});
+
+	afterEach(() => {
+		process.chdir(cwd);
+	});
+
+	/**
+	 * Helper to avoid some verbose repeated mock set-up.
+	 */
+	function run(callback) {
 		jest.resetModules();
 
 		jest.isolateModules(() => {
 			jest.mock('../../src/utils/log');
+			jest.mock('../../src/utils/spawnSync');
 
-			jest.mock('../../src/utils/getMergedConfig', () => {
+			// Use [] here to avoid unwanted hoisting by
+			// babel-plugin-jest-hoist.
+			jest['mock']('../../src/utils/getMergedConfig', () => {
 				return () => {
-					return ['**/*.jsp'];
+					return globs;
 				};
 			});
 
 			const lint = require('../../src/scripts/lint');
 			const log = require('../../src/utils/log');
+			const spawnSync = require('../../src/utils/spawnSync');
 
+			callback({lint, log, spawnSync});
+		});
+	}
+
+	/**
+	 * Helper to extract an argument that was passed to a mock `spawnSync` call.
+	 */
+	function get(mock, optionName) {
+		expect(mock.mock.calls.length).toBe(1);
+
+		const call = mock.mock.calls[0];
+		const [command, args] = call;
+
+		expect(command).toBe('eslint');
+
+		const index = args.indexOf(optionName);
+
+		expect(index).not.toBe(-1);
+		expect(args.length).toBeGreaterThan(index + 1);
+
+		return args[index + 1];
+	}
+
+	/**
+	 * Helper to read the contents of the generated `--ignore-path` file.
+	 */
+	function getIgnores() {
+		let contents;
+
+		run(({lint, spawnSync}) => {
 			lint();
 
-			expect(log).toBeCalledWith(
-				expect.stringContaining('No globs applicable')
+			const ignore = get(spawnSync, '--ignore-path');
+
+			contents = fs.readFileSync(ignore).toString();
+		});
+
+		return contents;
+	}
+
+	describe('when no appropriate globs are provided', () => {
+		beforeEach(() => {
+			globs = ['**/*.jsp'];
+		});
+
+		it('logs a message', () => {
+			run(({lint, log}) => {
+				lint();
+
+				expect(log).toBeCalledWith(
+					expect.stringContaining('No globs applicable')
+				);
+			});
+		});
+
+		it('does not spawn "eslint"', () => {
+			run(({lint, spawnSync}) => {
+				lint();
+
+				expect(spawnSync).not.toBeCalled();
+			});
+		});
+	});
+
+	describe('when running from the top-level "modules/"  directory', () => {
+		beforeEach(() => {
+			process.chdir(MODULES);
+		});
+
+		it('spawns "eslint"', () => {
+			run(({lint, spawnSync}) => {
+				lint();
+
+				expect(spawnSync).toBeCalledWith('eslint', expect.any(Array));
+			});
+		});
+
+		describe('combining all .eslintignore files together', () => {
+			let contents;
+
+			beforeEach(() => {
+				contents = getIgnores();
+			});
+
+			it('concatenates the files in order', () => {
+				expect(contents).toMatch(
+					new RegExp(
+						[
+							'This is the top-level',
+							'A project-level \\.eslintignore',
+							'Another project-level \\.eslintignore'
+						].join('.+'),
+						DOT_ALL
+					)
+				);
+			});
+
+			it('relativizes project-specific patterns', () => {
+				expect(contents).toMatch(
+					new RegExp(
+						'^/apps/segments/segments-web/\\*\\*/legacy/\\*$',
+						MULTILINE
+					)
+				);
+			});
+
+			it('preserves negation prefix in project-specific patterns', () => {
+				expect(contents).toMatch(
+					new RegExp(
+						'^!/apps/segments/segments-web/src/stuff/\\*\\.js$',
+						MULTILINE
+					)
+				);
+			});
+		});
+	});
+
+	describe('when running from a project without an .eslintignore', () => {
+		let contents;
+
+		beforeEach(() => {
+			process.chdir(FRONTEND_JS_WEB);
+
+			contents = getIgnores();
+		});
+
+		it('uses the top-level .eslintignore', () => {
+			expect(contents).toContain('This is the top-level');
+		});
+
+		it('does not include .eslintignore patterns from other projects', () => {
+			expect(contents).not.toContain('project-level .eslintignore');
+		});
+	});
+
+	describe('when running from a project with an .eslintignore', () => {
+		let contents;
+
+		beforeEach(() => {
+			process.chdir(SEGMENTS_WEB);
+
+			contents = getIgnores();
+		});
+
+		it('concatenates the top-level and project-level patterns', () => {
+			expect(contents).toMatch(
+				new RegExp(
+					[
+						'This is the top-level',
+						'Another project-level \\.eslintignore'
+					].join('.+'),
+					DOT_ALL
+				)
 			);
+		});
+
+		it('does not include .eslintignore patterns from other projects', () => {
+			expect(contents).not.toContain('A project-level .eslintignore');
+		});
+	});
+
+	describe('when running from a project with a local yarn.lock', () => {
+		// We're not supposed to have any projects like this, but we want to
+		// test to prove that our detection of the top-level "modules/" folder
+		// isn't fooled by a "yarn.lock" in an unexpected location.
+
+		beforeEach(() => {
+			process.chdir(ROGUE_PROJECT);
+		});
+
+		it('still correctly finds the .eslintignore in the top-level', () => {
+			const contents = getIgnores();
+
+			expect(contents).toContain('This is the top-level');
+		});
+
+		it('logs a message about the unexpected yarn.lock', () => {
+			run(({lint, log}) => {
+				lint();
+
+				expect(log).toBeCalledWith(
+					expect.stringMatching(
+						new RegExp(
+							[
+								'Found a yarn\\.lock',
+								'but it is not the "modules/" root'
+							].join('.+')
+						)
+					)
+				);
+			});
+		});
+	});
+
+	describe('when running outside of the top-level "modules/" directory', () => {
+		// Again, this isn't supposed to happen, but we want to test that we
+		// don't get fooled by the presence of a "yarn.lock" in an unexpected
+		// location.
+
+		beforeEach(() => {
+			process.chdir(NON_PROJECT);
+		});
+
+		it('logs a message about missing top-level "modules/" directory', () => {
+			run(({lint, log}) => {
+				lint();
+
+				expect(log).toBeCalledWith(
+					expect.stringContaining('Unable to find "modules/" root')
+				);
+			});
+		});
+
+		it('uses creates and uses an empty .eslintignore', () => {
+			const contents = getIgnores();
+
+			expect(contents).toBe('');
 		});
 	});
 });

--- a/packages/liferay-npm-scripts/test/scripts/lint.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint.js
@@ -219,6 +219,12 @@ describe('scripts/lint.js', () => {
 		it('does not include .eslintignore patterns from other projects', () => {
 			expect(contents).not.toContain('A project-level .eslintignore');
 		});
+
+		it('does not relativize project-specific patterns', () => {
+			expect(contents).toMatch(
+				new RegExp('^\\*\\*/legacy/\\*$', MULTILINE)
+			);
+		});
 	});
 
 	describe('when running from a project with a local yarn.lock', () => {


### PR DESCRIPTION
Two things here:

Firstly, we need a hack in order to be able to target just "*.es.js" files with ESLint without torpedoing the use of Prettier on all files.

Secondly, by design, apparently, ESLint won't let you have more than one .eslintignore file. It will only look in the current directory, unless you pass an explicit `--ignore-path` option. If you do that, or it finds an .eslintignore in the current directory, it will skip over any local "eslintIgnore" property that might exist in the package.json too.

However, we kind of need this ability because we run `liferay-npm-scripts lint` in two modes:

1. From the "modules/" root, where we lint everything in the repo.
2. From individual subproject directories, like "modules/apps/segments/segments-web".

In both cases, we want to provide some very broad config that applies to the whole repo -- eg. ignore all `*.js` files but lint all `*.es.js` ones; for more context on that see: https://issues.liferay.com/browse/LPS-97079 and related tickets.

But then we want to provide more granular overrides at the per-project level so that we can slowly tighten the screws and increase our lint coverage of the entire repo.

This is an inglorious hack, but hopefully the comments and code explain it sufficiently.

Tested this with [this diff applied in my liferay-portal checkout](https://gist.github.com/wincent/2513be083a8c273417d5d7747aaf9cdc).