### PR TITLE
feat: drop "root: true" from eslint config

### DIFF
--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -27,6 +27,5 @@ module.exports = {
 			jsx: true
 		},
 		ecmaVersion: 2018
-	},
-	root: true
+	}
 };


### PR DESCRIPTION
Normally "root: true" is handy way to prevent unexpected surprises from happening (due to random stuff like having an unrelated ESLint config file in your home directory, and having that conflict with project-local settings).

In our case, however, we don't want to create a "root: true" config in the current directory, but rather in the liferay-portal top-level "modules/" root. That way, we can run `liferay-npm-scripts lint` from the top level and have it well controlled, and we can also run it from a project sub-directory and have it benefit from the configuration cascade (for example all the way up to, but not past, the "modules/" root).

So, this commit removes "root: true" from here, and I'll make the corresponding inverse change in liferay-portal by adding a "root: true" config to the "modules/" root.