### PR TITLE
feat(scripts)!: drop `--no-eslintrc` from invocation

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -211,7 +211,6 @@ function lint(options = {}) {
 		const ignorePath = getIgnoreFilePath();
 
 		const args = [
-			'--no-eslintrc',
 			'--config',
 			configPath,
 			'--ignore-path',


### PR DESCRIPTION
Our original intent here was to apply the same linting config everywhere, and force it to be that way via `--no-eslintrc`.

Given our change of plans (in which we're rolling out the linting gradually and with exceptions) we'll very much need to have the ability to apply per-directory overrides. So we have to remove the switch.