### PR TITLE
feat(scripts): tweak lint config for use in IDEs

### DIFF
--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -44,5 +44,6 @@ module.exports = {
 			jsx: true
 		},
 		ecmaVersion: 2018
-	}
+	},
+	root: true
 };


### PR DESCRIPTION
At the moment, liferay-portal has an `.eslintrc.js` in the top-level `modules/` folder that only contains a `root: true` property and nothing else.

When `liferay-npm-scripts` runs, it will look for a "local" user config and merge it with the one that we provide, writing the result to a temporary file that gets passed to ESLint via the `--config` option.

So, one of three things happens:

1. You run it from `modules/`, and you get a config file that contains the base plus `root: true`.
2. You run it from `modules/apps/*/*`, and you get a config file that contains the base plus your local config; because ESLint will walk up the tree looking for parent configs, it will eventually stop when it sees `root: true` in the `modules/` directory.
3. Your editor runs it for you. Depending on where you are it might only find the top-level config, which is basically empty, or it will wind up find a project-local one that may or may not contain something very useful (because most of the actually useful stuff is in the base).

With this change, and a corresponding one in liferay-portal, we effectively move the `root: true` out of `modules/` and into the base config. Additionally, in the config in `modules/` we try to `require` the base config.

What this means:

1. Run from `modules/`, we merge the config there (which is now just the `require`-ed base config) with the base config, which is the same as just using the base config directly. `root: true` applies, so this is the same effect as before via different means.
2. Run from `modules/apps/*/*` we merge your local config with the base; ESLint walks up looking for parent configs, but these have a lower precedence than ones passed in via `--config`, so anything in the merged config will trump stuff in the top-level (which just references the base anyway); again `root: true` applies, so the effects are the same.
3. From an editor, the result should be much more useful now. ESLint will use the base config with `root: true`, unless you haven't run `ant all` or `ant setup-sdk` yet, in which case we cause the IDE to print advice that you should do the set-up (tested this in VSCode).
