### PR TITLE
chore: prepare liferay-npm-scripts v4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "5.16.0",
-		"eslint-config-liferay": "^4.0.0",
+		"eslint-config-liferay": "^4.1.0",
 		"prettier": "1.18.2"
 	},
 	"private": true,

--- a/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
+++ b/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`liferay-jest-junit-reporter should write a file for a failing test 1`] = `
+exports[`liferay-jest-junit-reporter writes a file for a failing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <testsuite hostname=\\"\\" id=\\"0\\" errors=\\"0\\" failures=\\"1\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
   <testcase classname=\\"test-module.bar\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
@@ -20,7 +20,7 @@ Received: true
 </testsuite>"
 `;
 
-exports[`liferay-jest-junit-reporter should write a file for a passing test 1`] = `
+exports[`liferay-jest-junit-reporter writes a file for a passing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <testsuite hostname=\\"\\" id=\\"0\\" errors=\\"0\\" failures=\\"0\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
   <testcase classname=\\"test-module.bar\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">

--- a/packages/liferay-jest-junit-reporter/test/index.js
+++ b/packages/liferay-jest-junit-reporter/test/index.js
@@ -62,7 +62,7 @@ describe('liferay-jest-junit-reporter', () => {
 		jest.restoreAllMocks();
 	});
 
-	it('should write a file for a passing test', () => {
+	it('writes a file for a passing test', () => {
 		reporter(passedTestReport);
 
 		const xmlWritten = fs.writeFileSync.mock.calls[0][1];
@@ -70,7 +70,7 @@ describe('liferay-jest-junit-reporter', () => {
 		expect(xmlWritten).toMatchSnapshot();
 	});
 
-	it('should write a file for a failing test', () => {
+	it('writes a file for a failing test', () => {
 		reporter(faildTestReport);
 
 		const xmlWritten = fs.writeFileSync.mock.calls[1][1];

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "liferay-npm-scripts",
-	"version": "4.1.0",
+	"version": "4.2.0",
 	"description": "Collection of NPM scripts used for Liferay portlets",
 	"main": "index.js",
 	"author": {

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -26,7 +26,7 @@
 		"cross-spawn": "^6.0.5",
 		"deepmerge": "^3.0.0",
 		"eslint": "5.16.0",
-		"eslint-config-liferay": "^4.0.0",
+		"eslint-config-liferay": "^4.1.0",
 		"glob": "^7.1.3",
 		"jest": "^24.5.0",
 		"liferay-jest-junit-reporter": "1.0.1",

--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -15,7 +15,7 @@ module.exports = {
 		browser: true,
 		es6: true
 	},
-	extends: [require.resolve('eslint-config-liferay')],
+	extends: [require.resolve('eslint-config-liferay/portal')],
 	globals: {
 		AUI: true,
 		CKEDITOR: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3576,10 +3576,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.0.0.tgz#8e52878d7cba62a99d9974ee3172546898504e67"
-  integrity sha512-mgSrQLbU4QtmNSWxry/4TMOMfGynLbz+PD3ae0wTw0pIlEBCXfxtnkLnoR5OfWtnZpuiMyFBQo89PTR3WoGfrA==
+eslint-config-liferay@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.1.0.tgz#632bf0f847215e8e87de5161fddd7ff3c05121c3"
+  integrity sha512-6oYQhyRv9GZMu6ZjWf9QrgZtFGSDXAnZ3KGe/AMD6bfLJAa8WDcWg4rc75BbjzBUNC/Bm3PfpraF0TzZolRkuA==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"


### PR DESCRIPTION
Not going to release an update to liferay-jest-junit-reporter, though, because the only change to it was a test tweak to address lints.

This is just a draft PR to see CI green before tagging and publishing.