### PR TITLE
feat: support async/await in jest tests (#105)

### DIFF
--- a/packages/liferay-npm-scripts/src/config/babel.json
+++ b/packages/liferay-npm-scripts/src/config/babel.json
@@ -3,5 +3,20 @@
 	"plugins": [
 		"@babel/proposal-class-properties",
 		"@babel/proposal-object-rest-spread"
+	],
+	"overrides": [
+		{
+			"test": "**/test/**/*.js",
+			"presets": [
+				[
+					"@babel/preset-env",
+					{
+						"targets": {
+							"node": "current"
+						}
+					}
+				]
+			]
+		}
 	]
 }

--- a/packages/liferay-npm-scripts/src/config/babel.json
+++ b/packages/liferay-npm-scripts/src/config/babel.json
@@ -12,7 +12,7 @@
 					"@babel/preset-env",
 					{
 						"targets": {
-							"node": "current"
+							"node": "10.15"
 						}
 					}
 				]


### PR DESCRIPTION
I created a `babel.test.json` to separate the babel configurations between the test and build scripts. I didn't use the [`const isTest = api.env('test');` in `babel.config.js` example from the jest docs](https://jestjs.io/docs/en/getting-started#using-babel) so we could continue to use the `babelMerge` function in `deepMerge.js` as is.

But I'm also not sure what the implications would be if we only applied the following to the current `babel.json` instead of creating a separate `babel.test.json`.

```
{
	"presets": [
		[
			"@babel/preset-env",
			{
				"targets": {
					"node": "current"
				}
			}
		]
	],
...
```

*Also as an additional note, currently the only place that will have async/await in tests is still in a dev branch yet to be merged in master. https://github.com/thektan/liferay-portal/blob/LPS-96356-fix-frontend-tests/modules/apps/portal-search/portal-search-ranking-web/test/js/components/ResultsRankingForm.js