### PR TITLE
feat: handling globbing internally for Prettier

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -5,9 +5,11 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 const prettier = require('prettier');
 const expandGlobs = require('../utils/expandGlobs');
 const filterGlobs = require('../utils/filterGlobs');
+const findRoot = require('../utils/findRoot');
 const getMergedConfig = require('../utils/getMergedConfig');
 const log = require('../utils/log');
 const preprocessGlob = require('../utils/preprocessGlob');
@@ -48,9 +50,10 @@ function format(options = {}) {
 		return;
 	}
 
-	// TODO: only exists at top level; refactor to share logic with
-	// .eslintignore handling.
-	const ignores = readIgnoreFile('.prettierignore');
+	const root = findRoot();
+	const ignoreFile = path.join(root || '.', '.prettierignore');
+
+	const ignores = fs.existsSync(ignoreFile) ? readIgnoreFile(ignoreFile) : [];
 
 	// Match Prettier behavior and ignore node_modules by default.
 	if (ignores.indexOf('node_modules/**') === -1) {

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -9,6 +9,7 @@ const os = require('os');
 const path = require('path');
 
 const filterGlobs = require('../utils/filterGlobs');
+const findRoot = require('../utils/findRoot');
 const getMergedConfig = require('../utils/getMergedConfig');
 const log = require('../utils/log');
 const spawnSync = require('../utils/spawnSync');
@@ -22,33 +23,6 @@ const DEFAULT_OPTIONS = {
  * File extensions that ESLint can process.
  */
 const EXTENSIONS = ['.js', '.ts', '.tsx'];
-
-/**
- * Attempt to locate the "modules/" root directory in the liferay-portal repo by
- * walking up the tree looking for a yarn.lock.
- */
-function findRoot() {
-	let directory = process.cwd();
-
-	while (directory) {
-		if (fs.existsSync(path.join(directory, 'yarn.lock'))) {
-			if (path.basename(directory) === 'modules') {
-				return directory;
-			} else {
-				log(
-					`Found a yarn.lock in ${directory}, but it is not the "modules/" root`
-				);
-			}
-		}
-
-		if (path.dirname(directory) === directory) {
-			// Can't go any higher.
-			directory = null;
-		} else {
-			directory = path.dirname(directory);
-		}
-	}
-}
 
 /**
  * Scan for ignore files at locations of the form:

--- a/packages/liferay-npm-scripts/src/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/expandGlobs.js
@@ -1,0 +1,163 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+const getRegExpForGlob = require('./getRegExpForGlob');
+
+/**
+ * Given a list of glob patterns and a list of ignore patterns, returns a list
+ * of matching files, searching in the current dirctory.
+ */
+function expandGlobs(matchGlobs, ignoreGlobs = []) {
+	const ignorers = [];
+	const matchers = matchGlobs.map(getRegExpForGlob);
+	const results = [];
+
+	// If any matchers are negated, move them into the "ignores" list.
+	for (let i = matchers.length - 1; i >= 0; i--) {
+		if (matchers[i].negated) {
+			// Make a copy of the regular expression without the "negated" flag.
+			ignorers.unshift(getRegExpForGlob(matchGlobs[i].slice(1)));
+		}
+	}
+
+	// Make note of index of the last negation. (If a file has been
+	// ignored, we can stop testing it as soon as we get past the last
+	// negation.)
+	let lastNegationIndex = 0;
+
+	ignorers.push(
+		...ignoreGlobs.map((glob, index) => {
+			const regExp = getRegExpForGlob(glob);
+
+			if (regExp.negated) {
+				lastNegationIndex = ignorers.length + index;
+			}
+
+			return regExp;
+		})
+	);
+
+	// As a special case, if we see an ignore glob like "a/b/c/**" past the
+	// lastNegationIndex we can short-circuit.
+	const prunable = new Map();
+	const seen = [];
+
+	for (let i = lastNegationIndex; i < ignorers.length; i++) {
+		const glob = ignorers[i].glob;
+
+		const match = glob.match(/^([^!*]+)\/\*\*$/);
+
+		if (match) {
+			const base = match[1];
+
+			// Warn about overlapping ignore patterns. This check is O(n^2) but
+			// n is expected to be tiny (approx. 10).
+			seen.forEach(previous => {
+				if (
+					previous.startsWith(base) ||
+					base.startsWith(previous) ||
+					previous.endsWith(base) ||
+					base.endsWith(previous)
+				) {
+					throw new Error(
+						`Redundant ignore patterns (\`${previous}\`, \`${base}\`) detected`
+					);
+				}
+			});
+
+			seen.push(base);
+
+			const components = base.split('/');
+
+			// For fast lookup later on, given "a/b/c", produce this trie:
+			//
+			//     c -> b -> a -> true
+			//
+			let current = prunable;
+
+			for (let j = components.length - 1; j >= 0; j--) {
+				const component = components[j];
+
+				if (!current.has(component)) {
+					if (j) {
+						current.set(component, new Map());
+					} else {
+						// Mark the root with "true".
+						current.set(component, true);
+					}
+				}
+
+				current = current.get(component);
+			}
+		}
+	}
+
+	function traverse(directory) {
+		const entries = fs.readdirSync(directory);
+		entries.forEach(entry => {
+			const file = path.join(directory, entry);
+
+			// Check trie to see whether entire subtree can be pruned.
+			let trie = prunable;
+			let current = file;
+
+			while (current !== '.') {
+				trie = trie.get(path.basename(current));
+
+				if (trie === true) {
+					return;
+				} else if (!trie) {
+					break;
+				}
+
+				current = path.dirname(current);
+			}
+
+			let ignored = false;
+
+			for (let i = 0; i < ignorers.length; i++) {
+				const ignorer = ignorers[i];
+
+				if (ignored ^ ignorer.negated) {
+					// File is ignored, but ignorer is not a negation;
+					// or file is not ignored, and ignorer is a negation.
+					continue;
+				}
+
+				if (ignorer.test(file)) {
+					if (ignorer.negated) {
+						// File got unignored.
+						ignored = false;
+					} else {
+						// File is provisionally ignored, for now.
+						ignored = true;
+					}
+				}
+
+				if (ignored && i >= lastNegationIndex) {
+					// File got definitively ignored.
+					return;
+				}
+			}
+
+			const stat = fs.statSync(file);
+
+			if (stat.isDirectory()) {
+				traverse(file);
+			} else if (matchers.some(matcher => matcher.test(file))) {
+				results.push(file);
+			}
+		});
+	}
+
+	traverse('.');
+
+	return results;
+}
+
+module.exports = expandGlobs;

--- a/packages/liferay-npm-scripts/src/utils/findRoot.js
+++ b/packages/liferay-npm-scripts/src/utils/findRoot.js
@@ -1,0 +1,38 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+const log = require('./log');
+
+/**
+ * Attempt to locate the "modules/" root directory in the liferay-portal repo by
+ * walking up the tree looking for a yarn.lock.
+ */
+function findRoot() {
+	let directory = process.cwd();
+
+	while (directory) {
+		if (fs.existsSync(path.join(directory, 'yarn.lock'))) {
+			if (path.basename(directory) === 'modules') {
+				return directory;
+			} else {
+				log(
+					`Found a yarn.lock in ${directory}, but it is not the "modules/" root`
+				);
+			}
+		}
+
+		if (path.dirname(directory) === directory) {
+			// Can't go any higher.
+			directory = null;
+		} else {
+			directory = path.dirname(directory);
+		}
+	}
+}
+
+module.exports = findRoot;

--- a/packages/liferay-npm-scripts/src/utils/getRegExpForGlob.js
+++ b/packages/liferay-npm-scripts/src/utils/getRegExpForGlob.js
@@ -1,0 +1,97 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Helper function for scanning and consuming a "prefix" at the beginning of
+ * a glob pattern.
+ *
+ * Returns `true` if the prefix was consumed.
+ */
+function scan(prefix, state) {
+	if (typeof prefix === 'string') {
+		if (state.input.startsWith(prefix)) {
+			state.input = state.input.slice(prefix.length);
+			state.lastMatch = prefix;
+			return true;
+		}
+
+		return false;
+	} else {
+		let pattern = prefix.source;
+
+		if (!pattern.startsWith('^')) {
+			pattern = '^' + pattern;
+		}
+
+		const match = state.input.match(new RegExp(pattern));
+
+		if (match) {
+			state.input = state.input.slice(match[0].length);
+			state.lastMatch = match[0];
+			return true;
+		}
+
+		return false;
+	}
+}
+
+function escape(pattern) {
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+	return pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Returns a regular expression equivalent to the supplied `glob`.
+ *
+ * Semantics match those described in `man 5 gitignore`.
+ */
+function getRegExpForGlob(glob) {
+	let pattern = '';
+
+	const state = {
+		input: glob,
+		lastMatch: null
+	};
+
+	const negated = scan('!', state);
+
+	const anchored = scan('/', state);
+
+	if (!anchored && !state.input.startsWith('**/')) {
+		// Unless anchored, all patterns implicitly match anywhere in the
+		// hierarchy.
+		state.input = `**/${state.input}`;
+	}
+
+	while (state.input.length) {
+		if (scan('/**/', state)) {
+			pattern += '/([^/]+/)*';
+		} else if (scan('**/', state)) {
+			pattern += '([^/]+/)*';
+		} else if (scan('/**', state)) {
+			pattern += '.+';
+		} else if (scan('**', state)) {
+			pattern += '[^/]*';
+		} else if (scan('*', state)) {
+			pattern += '[^/]*';
+		} else if (scan(/[^/*]+/, state)) {
+			pattern += escape(state.lastMatch);
+		} else if (scan('/', state)) {
+			pattern += escape('/');
+		}
+	}
+
+	const result = new RegExp(`^${pattern}$`);
+	result.glob = glob;
+
+	if (negated) {
+		result.negated = true;
+	}
+
+	return result;
+}
+
+module.exports = getRegExpForGlob;

--- a/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
+++ b/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
@@ -1,0 +1,93 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Tools like Prettier and ESLint support a narrow version of globbing (like the
+ * one described in `man 5 gitignore`) for use in "ignore" files, and a broader
+ * version with some additional features (such as support for "{a,b}"
+ * variations) on the command-line.
+ *
+ * This function takes an "extended" glob (that may contain "{a,b}" sequences)
+ * and turns it into an array of one or more globs corresponding to the
+ * variations.
+ */
+function preprocessGlob(glob) {
+	// This function considers each "{}" to be a "hole" in the template (the
+	// glob), to be filled in with permutations of the substitutions defined
+	// inside the braces.
+	const template = [''];
+	const substitutions = [];
+
+	let bracketCount = 0;
+
+	for (let i = 0; i < glob.length; i++) {
+		const char = glob[i];
+
+		if (char === '{') {
+			bracketCount++;
+
+			if (bracketCount > 1) {
+				throw new Error(`Nested "{" found in glob \`${glob}\``);
+			}
+
+			substitutions.push('');
+		} else if (char === '}') {
+			bracketCount--;
+
+			if (bracketCount !== 0) {
+				throw new Error(`Unbalanced "}" found in glob \`${glob}\``);
+			}
+
+			const index = substitutions.length - 1;
+			if (substitutions[index] === '') {
+				// There were no substitutions at all; braces are literal.
+				substitutions.pop();
+				template[template.length - 1] += '{}';
+			} else {
+				substitutions[index] = substitutions[index].split(',');
+				template.push('');
+			}
+		} else if (bracketCount === 0) {
+			// We are capturing normal text.
+			const index = template.length - 1;
+
+			template[index] = template[index] + char;
+		} else {
+			// We are capturing substitution(s).
+			const index = substitutions.length - 1;
+			substitutions[index] += char;
+		}
+	}
+
+	if (bracketCount) {
+		throw new Error(`Unbalanced "{" found in glob \`${glob}\``);
+	}
+
+	return permute(template, substitutions);
+}
+
+function permute(template, substitutions) {
+	const [first, ...rest] = template;
+
+	if (!rest.length && !substitutions.length) {
+		// Recursion base case (nothing left to substitute).
+		return [first];
+	}
+
+	const permutations = [];
+
+	(substitutions[0] || []).forEach(substitution => {
+		permutations.push(
+			...permute(rest, substitutions.slice(1)).map(
+				result => first + substitution + result
+			)
+		);
+	});
+
+	return permutations;
+}
+
+module.exports = preprocessGlob;

--- a/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
+++ b/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
@@ -53,7 +53,6 @@ function preprocessGlob(glob) {
 		} else if (bracketCount === 0) {
 			// We are capturing normal text.
 			const index = template.length - 1;
-
 			template[index] = template[index] + char;
 		} else {
 			// We are capturing substitution(s).

--- a/packages/liferay-npm-scripts/src/utils/readIgnoreFile.js
+++ b/packages/liferay-npm-scripts/src/utils/readIgnoreFile.js
@@ -1,0 +1,33 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+
+const BLANK_LINES = /^\s*$/;
+const COMMENTS = /^\s*#/;
+const LINE_SEPARATORS = /[\n\r]+/;
+
+/**
+ * Loose implementation of an "ignore-file" reader based on `man 5 gitignore`.
+ *
+ * Differences include:
+ *
+ * - Both trailing and leading whitespace are ignored, allowing lines to be
+ *   indented to form sections (in Git, only trailing whitespace is ignored).
+ * - Backslash-escaping of special characeters (eg. "#") is not implemented.
+ */
+function readIgnoreFile(file) {
+	return fs
+		.readFileSync(file)
+		.toString()
+		.split(LINE_SEPARATORS)
+		.filter(line => {
+			return !COMMENTS.test(line) && !BLANK_LINES.test(line);
+		})
+		.map(line => line.trim());
+}
+
+module.exports = readIgnoreFile;

--- a/packages/liferay-npm-scripts/test/scripts/format.js
+++ b/packages/liferay-npm-scripts/test/scripts/format.js
@@ -11,17 +11,21 @@ const path = require('path');
 describe('scripts/format.js', () => {
 	let cwd;
 	let format;
-	let spawnSync;
+	let prettier;
 	let temp;
+
+	const source = 'alert("hello");';
 
 	beforeEach(() => {
 		cwd = process.cwd();
 		temp = fs.mkdtempSync(path.join(os.tmpdir(), 'format-'));
 		process.chdir(temp);
+		fs.mkdirSync('src');
+		fs.writeFileSync('src/example.js', source);
 
-		jest.mock('../../src/utils/spawnSync');
+		jest.mock('prettier');
 		format = require('../../src/scripts/format');
-		spawnSync = require('../../src/utils/spawnSync');
+		prettier = require('prettier');
 	});
 
 	afterEach(() => {
@@ -31,7 +35,10 @@ describe('scripts/format.js', () => {
 
 	it('invokes prettier', () => {
 		format();
-		expect(spawnSync).toHaveBeenCalledWith('prettier', expect.anything());
+		expect(prettier.check).toHaveBeenCalledWith(
+			source,
+			expect.objectContaining({filepath: 'src/example.js'})
+		);
 	});
 
 	describe('when no globs are configured', () => {
@@ -50,7 +57,6 @@ describe('scripts/format.js', () => {
 			jest.mock('../../src/utils/log');
 			format = require('../../src/scripts/format');
 			log = require('../../src/utils/log');
-			spawnSync = require('../../src/utils/spawnSync');
 		});
 
 		it('logs a message indicating how to configure globs', () => {
@@ -60,9 +66,9 @@ describe('scripts/format.js', () => {
 			);
 		});
 
-		it('does not run prettier', () => {
+		it('does not invoke prettier', () => {
 			format();
-			expect(spawnSync).not.toHaveBeenCalled();
+			expect(prettier.check).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/liferay-npm-scripts/test/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/expandGlobs.js
@@ -1,0 +1,174 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const expandGlobs = require('../../src/utils/expandGlobs');
+const preprocessGlob = require('../../src/utils/preprocessGlob');
+
+const FIXTURES = `
+	.eslintrc.js
+	.prettierrc.js
+	apps/app-builder/app-builder-web/.eslintrc.js
+	apps/change-tracking/change-tracking-change-lists-configuration-web/src/main/resources/META-INF/resources/css/main.scss
+	apps/change-tracking/change-tracking-change-lists-indicator-web/src/main/resources/META-INF/resources/js/ChangeListsIndicator.es.js
+	apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/css/main.scss
+	apps/document-library/document-library-web/build/npm/npmRunBuild/outputs/META-INF/resources/document_library/js/main.js
+	apps/document-library/document-library-web/classes/META-INF/resources/node_modules/document-library-web$uuid@3.3.2/lib/v35.js
+	apps/fragment/fragment-demo-data-creator-impl/src/main/resources/com/liferay/fragment/demo/data/creator/internal/dependencies/fragment1/demo.js
+	apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/fragments/fragments/card/index.js
+	apps/frontend-css/frontend-css-web/classes/META-INF/resources/taglib/_header.scss
+	apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/main.scss
+	apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/misc/swfobject.js
+	apps/frontend-theme-porygon/frontend-theme-porygon/build/css/_clay_custom.scss
+	apps/frontend-theme-porygon/frontend-theme-porygon/build/css/clay/components/_input-groups.scss
+	apps/journal/journal-web/build/npm/npmRunBuild/outputs/META-INF/resources/js/DDMTemplatesManagementToolbarDefaultEventHandler.es.js
+	apps/journal/journal-web/classes/META-INF/resources/node_modules/journal-web$lodash.escape@4.0.1/index.js
+	apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMStructuresManagementToolbarDefaultEventHandler.es.js
+	apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/actions/updateRowColumnsNumber.es.js
+	apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/test/resources/com/liferay/portal/portlet/bridge/soy/internal/dependencies/ES6Command.es.js
+	node_modules/domain-browser/.eslintrc.js
+	node_modules/pako/lib/zlib/gzheader.js
+	node_modules/worker-farm/lib/farm.js
+	npmscripts.config.js
+	sdk/gradle-plugins-theme-builder/src/gradleTest/classic/src/main/webapp/css/liferay-font-awesome/scss/_path-alloy.scss
+	util/portal-tools-soy-builder/src/test/resources/com/liferay/portal/tools/soy/builder/commands/dependencies/build_soy/expected/hello_world.soy.js
+	util/sass-compiler-jni/src/test/resources/com/liferay/sass/compiler/jni/internal/dependencies/sass-spec/35_varargs_false/input.scss
+`
+	.trim()
+	.split(/\s+/);
+
+const PORTAL_GLOBS = [
+	'/*.js',
+	'/.*.js',
+	'/apps/*/*/*.js',
+	'/apps/*/*/.*.js',
+	'/apps/*/*/{src,test}/**/*.es.js',
+	'/apps/*/*/{src,test}/**/*.js',
+	'/apps/*/*/{src,test}/**/*.scss'
+].reduce((acc, glob) => acc.concat(preprocessGlob(glob)), []);
+
+const PORTAL_IGNORE_GLOBS = [
+	'*.js',
+	'!*.es.js',
+	'!.eslintrc.js',
+	'!npmscripts.config.js',
+	'!.prettierrc.js',
+	'*.soy.js',
+	'build/**',
+	'classes/**',
+	'css/clay/**',
+	'node_modules/**',
+	'zippableResources/**',
+	'sdk/**',
+	'/copyright.js',
+	'apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/test/resources/com/liferay/portal/portlet/bridge/soy/internal/dependencies/**/*.js',
+	'apps/fragment/fragment-demo-data-creator-impl/src/main/resources/com/liferay/fragment/demo/data/creator/internal/dependencies/**/*.js',
+	'apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/**/*.js',
+	'/yarn-*.js'
+];
+
+describe('expandGlobs()', () => {
+	let cwd;
+
+	beforeAll(() => {
+		cwd = process.cwd();
+
+		const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'scripts-'));
+		process.chdir(directory);
+
+		FIXTURES.forEach(fixture => {
+			const dirname = path.dirname(fixture);
+
+			fs.mkdirSync(dirname, {recursive: true});
+
+			fs.writeSync(fs.openSync(fixture, 'w'), '');
+		});
+	});
+
+	afterAll(() => {
+		process.chdir(cwd);
+	});
+
+	it('can match all files', () => {
+		const matches = expandGlobs(['*']);
+
+		expect(matches).toEqual(FIXTURES);
+	});
+
+	it('can match a subset of files', () => {
+		const matches = expandGlobs(['.eslintrc.js']);
+
+		expect(matches).toEqual([
+			'.eslintrc.js',
+			'apps/app-builder/app-builder-web/.eslintrc.js',
+			'node_modules/domain-browser/.eslintrc.js'
+		]);
+	});
+
+	it('excludes ignored files', () => {
+		const matches = expandGlobs(['*'], ['sdk/**']);
+
+		const filtered = FIXTURES.filter(entry => !entry.startsWith('sdk'));
+
+		expect(matches).toEqual(filtered);
+	});
+
+	it('respects negated ignore patterns', () => {
+		const matches = expandGlobs(['*.js'], ['*.js', '!*.es.js']);
+
+		const filtered = FIXTURES.filter(entry => entry.endsWith('.es.js'));
+
+		expect(matches).toEqual(filtered);
+	});
+
+	it('treats negated match patterns as non-negated ignores', () => {
+		const matches = expandGlobs(['*.js', '!*.js'], ['!*.es.js']);
+
+		const filtered = FIXTURES.filter(entry => entry.endsWith('.es.js'));
+
+		expect(matches).toEqual(filtered);
+	});
+
+	it('handles complex arrays of globs and negations', () => {
+		const matches = expandGlobs(PORTAL_GLOBS, PORTAL_IGNORE_GLOBS);
+
+		expect(matches).toEqual([
+			'.eslintrc.js',
+			'.prettierrc.js',
+			'apps/app-builder/app-builder-web/.eslintrc.js',
+			'apps/change-tracking/change-tracking-change-lists-configuration-web/src/main/resources/META-INF/resources/css/main.scss',
+			'apps/change-tracking/change-tracking-change-lists-indicator-web/src/main/resources/META-INF/resources/js/ChangeListsIndicator.es.js',
+			'apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/css/main.scss',
+			'apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/main.scss',
+			'apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMStructuresManagementToolbarDefaultEventHandler.es.js',
+			'apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/actions/updateRowColumnsNumber.es.js',
+			'npmscripts.config.js'
+		]);
+	});
+
+	it('complains about redundant ignore patterns', () => {
+		expect(() =>
+			expandGlobs([], ['build/css/clay/**', 'build/**'])
+		).toThrow(/Redundant ignore patterns/);
+		expect(() =>
+			expandGlobs([], ['build/**', 'build/css/clay/**'])
+		).toThrow(/Redundant ignore patterns/);
+		expect(() => expandGlobs([], ['build/**', 'build/**'])).toThrow(
+			/Redundant ignore patterns/
+		);
+		expect(() => expandGlobs([], ['a/b/c/**', 'x/a/b/c/**'])).toThrow(
+			/Redundant ignore patterns/
+		);
+		expect(() => expandGlobs([], ['x/a/b/c/**', 'a/b/c/**'])).toThrow(
+			/Redundant ignore patterns/
+		);
+		expect(() => expandGlobs([], ['a/b/c/**', 'a/b/c/**'])).toThrow(
+			/Redundant ignore patterns/
+		);
+	});
+});

--- a/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js
+++ b/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js
@@ -1,0 +1,227 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const getRegExpForGlob = require('../../src/utils/getRegExpForGlob');
+
+expect.extend({
+	toMatchGlob(file, glob) {
+		const pass = getRegExpForGlob(glob).test(file);
+		return {
+			message() {
+				const predicate = pass ? 'not to match' : 'to match';
+				return `expected path ${file} ${predicate} glob ${glob}`;
+			},
+			pass
+		};
+	}
+});
+
+describe('getRegExpForGlob()', () => {
+	describe('"foo"', () => {
+		it('matches at any level of the hierarchy', () => {
+			expect('foo').toMatchGlob('foo');
+			expect('a/b/foo').toMatchGlob('foo');
+
+			expect('bar').not.toMatchGlob('foo');
+			expect('a/b/bar').not.toMatchGlob('foo');
+		});
+	});
+
+	describe('"*"', () => {
+		it('matches zero or more of any character except slash', () => {
+			expect('a/b/foo').toMatchGlob('*');
+			expect('a/b/foo').toMatchGlob('foo*');
+			expect('a/b/foo.js').toMatchGlob('*');
+			expect('a/b/foo.js').toMatchGlob('*.js');
+
+			expect('a/b/foo.jsp').not.toMatchGlob('*.js');
+			expect('a/b/foo/bar').not.toMatchGlob('foo*');
+		});
+	});
+
+	describe('"/foo"', () => {
+		// From `man 5 gitignore`:
+		//
+		//     A leading slash matches the beginning of the
+		//     pathname. For example, "/*.c" matches "cat-file.c" but not
+		//     "mozilla-sha1/sha1.c".
+
+		it('matches at the beginning of the pathname', () => {
+			expect('foo').toMatchGlob('/foo');
+			expect('bar/foo').not.toMatchGlob('/foo');
+
+			expect('cat-file.c').toMatchGlob('/*.c');
+			expect('mozilla-sha1/sha1.c').not.toMatchGlob('/*.c');
+		});
+	});
+
+	describe('"**/"', () => {
+		// From `man 5 gitignore`:
+		//
+		//     A leading "**" followed by a slash means match in all
+		//     directories. For example, "**/foo" matches file or directory
+		//     "foo" anywhere, the same as pattern "foo". "**/foo/bar" matches
+		//     file or directory "bar" anywhere that is directly under
+		//     directory "foo".
+
+		it('matches leading directories', () => {
+			expect('a/b/foo').toMatchGlob('**/foo');
+			expect('a/b/bar').not.toMatchGlob('**/foo');
+
+			expect('a/b/foo/bar').toMatchGlob('**/foo/bar');
+			expect('a/b/foo').not.toMatchGlob('**/foo/bar');
+			expect('a/b/bar').not.toMatchGlob('**/foo/bar');
+		});
+
+		it('matches at the top level', () => {
+			expect('foo').toMatchGlob('**/foo');
+			expect('bar').not.toMatchGlob('**/foo');
+		});
+	});
+
+	describe('"/**"', () => {
+		// From `man 5 gitignore`:
+		//
+		//     A trailing "/**" matches everything inside. For example,
+		//     "abc/**" matches all files inside directory "abc", relative to
+		//     the location of the .gitignore file, with infinite depth.
+
+		it('matches at the top level', () => {
+			expect('foo').toMatchGlob('/**');
+			expect('foo/a').not.toMatchGlob('/**');
+			expect('foo/a/b').not.toMatchGlob('/**');
+
+			expect('foo/a').toMatchGlob('foo/**');
+			expect('foo/a/b').toMatchGlob('foo/**');
+		});
+
+		it('matches below the top level', () => {
+			expect('a/b/foo/a').toMatchGlob('foo/**');
+			expect('a/b/foo/a/b').toMatchGlob('foo/**');
+
+			expect('a/b/bar').not.toMatchGlob('foo/**');
+			expect('a/b/foo').not.toMatchGlob('foo/**');
+		});
+	});
+
+	describe('"/**/"', () => {
+		// From `man 5 gitignore`:
+		//
+		//     A slash followed by two consecutive asterisks then a slash
+		//     matches zero or more directories. For example, "a/**/b" matches
+		//     "a/b", "a/x/b", "a/x/y/b" and so on.
+
+		it('matches zero or more directories at the top level', () => {
+			expect('a/b').toMatchGlob('a/**/b');
+			expect('a/x/b').toMatchGlob('a/**/b');
+			expect('a/x/y/b').toMatchGlob('a/**/b');
+		});
+
+		it('matches zero or more directories below the top level', () => {
+			expect('foo/bar/a/b').toMatchGlob('a/**/b');
+			expect('foo/bar/a/x/b').toMatchGlob('a/**/b');
+			expect('foo/bar/a/x/y/b').toMatchGlob('a/**/b');
+		});
+	});
+
+	describe('"**"', () => {
+		// From `man 5 gitignore`:
+		//
+		//     Other consecutive asterisks are considered regular asterisks
+		//     and will match according to the previous rules.
+
+		it('behaves like an asterisk', () => {
+			expect('a/b/foo').toMatchGlob('**');
+			expect('a/b/foo').toMatchGlob('foo**');
+			expect('a/b/foo.js').toMatchGlob('**');
+			expect('a/b/foo.js').toMatchGlob('**.js');
+
+			expect('a/b/foo.jsp').not.toMatchGlob('**.js');
+			expect('a/b/foo/bar').not.toMatchGlob('foo**');
+		});
+	});
+
+	describe('"!"', () => {
+		it('marks the pattern as negated', () => {
+			expect(getRegExpForGlob('!foo').negated).toBe(true);
+			expect(getRegExpForGlob('foo').negated).not.toBe(false);
+		});
+
+		it('can still be used to match', () => {
+			expect('foo').toMatchGlob('!foo');
+			expect('bar').not.toMatchGlob('!foo');
+		});
+	});
+
+	// prettier-ignore
+	it('handles real glob patterns from liferay-portal', () => {
+		// These taken from liferay-portal as of ced3d6d93c8721ae09ea2c2c88.
+		expect('apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js')
+			.toMatchGlob('**/*.js');
+		expect('apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js')
+			.not.toMatchGlob('!**/*.es.js');
+
+		expect('apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DefaultEventHandler.es.js')
+			.toMatchGlob('**/*.js');
+		expect('apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DefaultEventHandler.es.js')
+			.toMatchGlob('!**/*.es.js');
+
+		expect('apps/layout/layout-content-page-editor-web/.eslintrc.js').
+			toMatchGlob('!**/*/.eslintrc.js');
+		expect('apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DefaultEventHandler.es.js')
+			.not.toMatchGlob('!**/*/.eslintrc.js');
+
+		expect('apps/asset/asset-list-web/npmscripts.config.js')
+			.toMatchGlob('!**/*/npmscripts.config.js');
+		expect('apps/layout/layout-content-page-editor-web/.eslintrc.js')
+			.not.toMatchGlob('!**/*/npmscripts.config.js');
+
+		expect('.prettierrc.js')
+			.toMatchGlob('!.prettierrc.js');
+		expect('apps/layout/layout-content-page-editor-web/.eslintrc.js')
+			.not.toMatchGlob('!.prettierrc.js');
+
+		expect('util/portal-tools-soy-builder/src/test/resources/com/liferay/portal/tools/soy/builder/commands/dependencies/build_soy/expected/hello_world.soy.js')
+			.toMatchGlob('**/*.soy.js');
+
+		expect('apps/frontend-editor/frontend-editor-ckeditor-web/build/unzipped-jar/META-INF/resources/_diffs/plugins/media/dialogs/video.js')
+			.toMatchGlob('**/build/**/*');
+
+		expect('apps/deprecated/social-activity-web/classes/META-INF/resources/js/main.js')
+			.toMatchGlob('**/classes/**/*');
+
+		expect('apps/frontend-theme-porygon/frontend-theme-porygon/build/css/clay/atlas/_variables.scss')
+			.toMatchGlob('**/css/clay/**/*');
+
+		expect('apps/asset/asset-list-web/build/npm/npmRunBuild/outputs/META-INF/resources/node_modules/asset-list-web$uuid@3.3.2/v4.js')
+			.toMatchGlob('**/node_modules/**/*');
+		expect('node_modules/jsdom/lib/jsdom/vm-shim.js')
+			.toMatchGlob( '**/node_modules/**/*');
+
+		expect('apps/site/site-buildings-site-initializer/src/main/zippableResources/fragments/buildings/spacer/index.js')
+			.toMatchGlob('**/zippableResources/**/*');
+
+		expect('sdk/gradle-plugins-node/src/gradleTest/npmRunTest/scripts/test.js')
+			.toMatchGlob('**/sdk/**/*');
+
+		expect('copyright.js')
+			.toMatchGlob('/copyright.js');
+		expect('npmscripts.config.js')
+			.not.toMatchGlob('/copyright.js');
+
+		expect('apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/test/resources/com/liferay/portal/portlet/bridge/soy/internal/dependencies/ES6Command.es.js')
+			.toMatchGlob('apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/test/resources/com/liferay/portal/portlet/bridge/soy/internal/dependencies/**/*.js');
+
+		expect('apps/fragment/fragment-demo-data-creator-impl/src/main/resources/com/liferay/fragment/demo/data/creator/internal/dependencies/fragment1/demo.js')
+			.toMatchGlob('apps/fragment/fragment-demo-data-creator-impl/src/main/resources/com/liferay/fragment/demo/data/creator/internal/dependencies/**/*.js');
+
+		expect('apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/fragments/fragments/card/index.js').
+			toMatchGlob('apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/**/*.js');
+
+		expect('yarn-1.13.0.js')
+			.toMatchGlob('/yarn-*.js');
+	});
+});

--- a/packages/liferay-npm-scripts/test/utils/preprocessGlob.js
+++ b/packages/liferay-npm-scripts/test/utils/preprocessGlob.js
@@ -1,0 +1,47 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const preprocessGlob = require('../../src/utils/preprocessGlob');
+
+describe('preprocessGlob()', () => {
+	it('returns a glob without "{...}" unchanged', () => {
+		expect(preprocessGlob('a/b/c/**.js')).toEqual(['a/b/c/**.js']);
+	});
+
+	it('returns a glob for each item inside "{...}"', () => {
+		expect(preprocessGlob('a/{foo}/c')).toEqual(['a/foo/c']);
+		expect(preprocessGlob('a/{foo,bar}/c')).toEqual(['a/foo/c', 'a/bar/c']);
+	});
+
+	it('handles empty segments inside of "{...}"', () => {
+		expect(preprocessGlob('a/{b,}')).toEqual(['a/b', 'a/']);
+		expect(preprocessGlob('a/{,b}')).toEqual(['a/', 'a/b']);
+	});
+
+	it('creates permutations for patterns with multiple "{...}"', () => {
+		expect(preprocessGlob('a/{b,c,d}/e/{f,g}')).toEqual([
+			'a/b/e/f',
+			'a/b/e/g',
+			'a/c/e/f',
+			'a/c/e/g',
+			'a/d/e/f',
+			'a/d/e/g'
+		]);
+	});
+
+	it('treats totally empty braces ("{}") literally', () => {
+		expect(preprocessGlob('foo{}bar')).toEqual(['foo{}bar']);
+	});
+
+	it('throws an error for unbalanced braces', () => {
+		expect(() => preprocessGlob('aaa{aaa')).toThrow(/Unbalanced "{"/);
+		expect(() => preprocessGlob('bbb}bbb')).toThrow(/Unbalanced "}"/);
+	});
+
+	it('throws an error for nested braces', () => {
+		expect(() => preprocessGlob('aa{aa{aa')).toThrow(/Nested "{"/);
+	});
+});


### PR DESCRIPTION
In this commit we handle globbing internally for Prettier (future commit will do the same for ESLint, but I want to make things at least somewhat readable by splitting this up), which means that we can switch from spawning the `prettier` executable to calling its API directly internally.

Motivation:

- Frontend checks got turned off in CI because they were global.
- We need to be able to target a subset of files in CI.
- That is difficult because we are relying on how two different tools (ESLint and Prettier) deal with two kinds of globs each ("include" globs passed on the command line and "exclude" globs passed in via .eslintirgnore/.prettierignore files).
- ESLint is using one glob engine and supporting utilities (minimatch, is-glob, and glob-parent), and these in turn depend on is-extglob, brace-expansion, and balanced-match.
- Prettier has its own glob engine.
- So we have multiple kinds of globs, multiple semantic differences, implementation differences and edge cases, and we were trying to navigate those by following a "lowest common denominator" approach.
- Additionally, we had the historical constraint that `liferay-npm-scripts` should accept a single set of globs for formatting and linting (and `csf` did the same, for all filetypes), and another self-imposed restriction that we wanted to apply different rules for selecting files to lint (ie. "modern" JS) and files to format (ie. all JS).
- Finally, both tools have major quirks about empty file lists -- that is, if the combination of all the above criteria ends up being that in a particular project everything gets ignored, then they will hard-fail -- requiring us to apply awkward workarounds (like listing both `*.es.js` and `*.js` in our globs even though that looks redundant).

For more, see: https://issues.liferay.com/browse/LPS-97644

So, with that context out the way, this commit:

- Isolates us from differences between the tools' globbing behaviors.
- Switches us to programmatic invocation (which will allow us to bypass command line argument length limits).
- Enables us to produce quieter output in CI.
- Is as fast or faster than the previous implementation due to shortcircuiting.
- Provides a model for how we could use Prettier inside csf in the future (which would enable us to format JS inside .jsp files).
- Enables us to be more flexible with whitespace in our ".prettierignore" file, making it similar to "portal-impl/src/portal.properties" in liferay-portal (a request Brian made).

Obviously this is a big change and a bit of a work in progress, so expect it to evolve in future commits, but I have tested it in liferay-portal with this diff:

https://gist.github.com/wincent/7fcc71cda45cdad7098692b38388d9a3