### PR TITLE
feat: handling globbing internally for ESLint

### DIFF
--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/frontend-js/frontend-js-aui-web/.eslintignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/frontend-js/frontend-js-aui-web/.eslintignore
@@ -1,3 +1,0 @@
-# A project-level .eslintignore.
-
-**/secret/*.es.js

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/frontend-js/frontend-js-web/.gitignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/frontend-js/frontend-js-web/.gitignore
@@ -1,1 +1,0 @@
-# This folder is an example of a project without a local .eslintignore.

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/rogue/project/yarn.lock
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/rogue/project/yarn.lock
@@ -1,3 +1,0 @@
-# Not really a lockfile, and projects aren't supposed to have their own
-# lockfiles, but we want to make sure the code doesn't misidentify a directory
-# like this one as being the top-level.

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/segments/segments-web/src/index.es.js
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/segments/segments-web/src/index.es.js
@@ -1,0 +1,11 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+function sample() {
+	return null;
+}
+
+module.exports = sample;

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/somewhere/subtree/with/a/lock/file/.gitignore
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/somewhere/subtree/with/a/lock/file/.gitignore
@@ -1,1 +1,0 @@
-# This is the directory where we will start the upwards traversal.

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/somewhere/subtree/yarn.lock
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/somewhere/subtree/yarn.lock
@@ -1,1 +1,0 @@
-# Not really a yarn.lock file, just a placeholder.

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -4,15 +4,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+const eslint = require('eslint');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 
+const expandGlobs = require('../utils/expandGlobs');
 const filterGlobs = require('../utils/filterGlobs');
 const findRoot = require('../utils/findRoot');
 const getMergedConfig = require('../utils/getMergedConfig');
 const log = require('../utils/log');
-const spawnSync = require('../utils/spawnSync');
+const preprocessGlob = require('../utils/preprocessGlob');
+const readIgnoreFile = require('../utils/readIgnoreFile');
+const {SpawnError} = require('../utils/spawnSync');
 
 const DEFAULT_OPTIONS = {
 	fix: false,
@@ -25,134 +28,6 @@ const DEFAULT_OPTIONS = {
 const EXTENSIONS = ['.js', '.ts', '.tsx'];
 
 /**
- * Scan for ignore files at locations of the form:
- *
- *      apps/[group]/[project]/.eslintignore
- *
- * inside the modules root (ie. "modules/").
- */
-function findProjectIgnoreFiles(root) {
-	const cwd = `current working directory (${process.cwd()})`;
-
-	if (!root) {
-		log(`Unable to find "modules/" root from ${cwd}`);
-		return [];
-	}
-
-	const apps = path.join(root, 'apps');
-
-	try {
-		if (!fs.statSync(apps).isDirectory()) {
-			log(`"modules/apps/" in ${cwd} is not a directory`);
-			return [];
-		}
-	} catch (_error) {
-		log(`Unable to find "modules/apps/" from ${cwd}`);
-		return [];
-	}
-
-	const entries = fs.readdirSync(apps).sort();
-
-	return entries.reduce((acc, entry) => {
-		const directory = path.join(apps, entry);
-
-		if (fs.statSync(directory).isDirectory()) {
-			const projects = fs.readdirSync(directory).sort();
-
-			projects.forEach(project => {
-				const ignore = path.join(directory, project, '.eslintignore');
-
-				if (fs.existsSync(ignore)) {
-					acc.push(ignore);
-				}
-			});
-		}
-
-		return acc;
-	}, []);
-}
-
-/**
- * ESLint only allows for a single .eslintignore file, and only in the current
- * directory. In liferay-portal, however, we want the flexibility to have a
- * top-level .eslintignore under "modules/apps/" and then project-specific ones
- * that apply when running from a project subdirectory.
- *
- * When running from the modules root, we start with the top-level .eslintignore
- * file and concatenate all sub-project .eslintignore files after relativizing
- * the paths appropriately.
- *
- * When running from a specific project we just prepend the top-level
- * .eslintignore, without peforming any relativization.
- *
- * @see https://eslint.org/docs/user-guide/configuring
- */
-function getIgnoreFilePath() {
-	const ignores = fs.existsSync('.eslintignore')
-		? [fs.readFileSync('.eslintignore').toString()]
-		: [];
-
-	const root = findRoot();
-
-	if (process.cwd() === root) {
-		findProjectIgnoreFiles(root).forEach(file => {
-			const directory = path.relative('', path.dirname(file));
-			const lines = fs
-				.readFileSync(file)
-				.toString()
-				.split(/[\r\n]+/);
-
-			// Make patterns relative to the "modules/" root.
-			const patterns = lines.map(line => {
-				const match = line.match(/^\s*(\S.+)$/);
-
-				if (match) {
-					if (match[1].startsWith('#')) {
-						// Comment.
-						return line;
-					} else if (match[1].startsWith('!')) {
-						// Negated pattern.
-						return (
-							'!' + path.join('/', directory, match[1].slice(1))
-						);
-					} else {
-						// Normal pattern.
-						return path.join('/', directory, match[1]);
-					}
-				} else {
-					return line;
-				}
-			});
-
-			ignores.push(patterns.join('\n'));
-		});
-	} else if (root) {
-		// Prepend "modules/.eslintignore"
-		const rootIgnore = path.join(root, '.eslintignore');
-
-		if (fs.existsSync(rootIgnore)) {
-			ignores.unshift(fs.readFileSync(rootIgnore).toString());
-		} else {
-			log(`Did not find expected .eslintignore at ${root}`);
-		}
-	} else {
-		log(`Unable to find "modules/" root`);
-	}
-
-	const contents = ignores.join('\n');
-
-	const directory = fs.mkdtempSync(
-		path.join(os.tmpdir(), 'liferay-npm-scripts-')
-	);
-
-	const file = path.join(directory, '.eslintignore');
-
-	fs.writeFileSync(file, contents);
-
-	return file;
-}
-
-/**
  * ESLint wrapper.
  */
 function lint(options = {}) {
@@ -161,11 +36,11 @@ function lint(options = {}) {
 		...options
 	};
 
-	const config = fix
+	const unfilteredGlobs = fix
 		? getMergedConfig('npmscripts', 'fix')
 		: getMergedConfig('npmscripts', 'check');
 
-	const globs = filterGlobs(config, ...EXTENSIONS);
+	const globs = filterGlobs(unfilteredGlobs, ...EXTENSIONS);
 
 	if (!globs.length) {
 		const extensions = EXTENSIONS.join(', ');
@@ -177,26 +52,88 @@ function lint(options = {}) {
 		return;
 	}
 
-	const configPath = path.join(process.cwd(), 'TEMP-eslint-config.json');
+	const root = findRoot();
+	const ignoreFile = path.join(root || '.', '.eslintignore');
 
-	fs.writeFileSync(configPath, JSON.stringify(getMergedConfig('eslint')));
+	const ignores = fs.existsSync(ignoreFile) ? readIgnoreFile(ignoreFile) : [];
 
-	try {
-		const ignorePath = getIgnoreFilePath();
+	// Turn "{src,test}/*" into ["src/*", "test/*"]:
+	const preprocessedGlobs = [];
 
-		const args = [
-			'--config',
-			configPath,
-			'--ignore-path',
-			ignorePath,
-			fix ? '--fix' : null,
-			quiet ? '--quiet' : null,
-			...globs
-		].filter(Boolean);
+	globs.forEach(glob => preprocessedGlobs.push(...preprocessGlob(glob)));
 
-		spawnSync('eslint', args);
-	} finally {
-		fs.unlinkSync(configPath);
+	const paths = expandGlobs(preprocessedGlobs, ignores);
+
+	const config = getMergedConfig('eslint');
+
+	const CLIEngine = eslint.CLIEngine;
+
+	const cli = new CLIEngine({
+		baseConfig: config,
+
+		// Note that "fix: true" here does not actually write to the filesystem
+		// (that happens below).
+		//
+		// - "fix: true": means fixes are not reported in the list of problems;
+		//   results with possible fixes have an "output" property.
+		// - "fix: false": means that they are reported; results with possible
+		//   fixes do not have an "output" property, but
+		//   `report.fixableErrorCount` and `report.fixableWarningCount` will be
+		//   set.
+		fix
+	});
+
+	const report = cli.executeOnFiles(paths);
+
+	let fixed = 0;
+
+	if (fix) {
+		fixed = report.results.reduce((count, result) => {
+			return result.output ? count + 1 : count;
+		}, 0);
+
+		// This is what actually writes to the file-system.
+		CLIEngine.outputFixes(report);
+	}
+
+	// TODO: could pass "junit" in CI
+	const formatter = cli.getFormatter();
+
+	if (quiet) {
+		const errors = CLIEngine.getErrorResults(report.results);
+
+		log(formatter(errors));
+	} else {
+		log(formatter(report.results));
+	}
+
+	const plural = (word, count) => (count === 1 ? word : `${word}s`);
+
+	const summary = [
+		`ESLint checked ${paths.length} ${plural('file', paths.length)}`,
+		`found ${report.errorCount} ${plural('error', report.errorCount)}`,
+		`found ${report.warningCount} ${plural('warning', report.warningCount)}`
+	];
+
+	const autofixable = report.fixableWarningCount + report.fixableErrorCount;
+
+	if (autofixable) {
+		summary.push(
+			`${autofixable} ${plural(
+				'issue',
+				autofixable
+			)} are potentially fixable with lint:fix`
+		);
+	}
+
+	if (fixed) {
+		summary.push(`fixed issues in ${fixed} ${plural('file', fixed)}`);
+	}
+
+	if (report.errorCount) {
+		throw new SpawnError(summary.join(', '));
+	} else {
+		log(summary.join(', '));
 	}
 }
 

--- a/packages/liferay-npm-scripts/test/scripts/lint.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint.js
@@ -4,26 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const fs = require('fs');
 const path = require('path');
-
-/**
- * Allow "." in regular expressions to match newlines.
- */
-const DOT_ALL = 's';
-
-/**
- * Allow "^" and "$" in regular expressions to match at line
- * boundaries instead of just the beginning and end of the string.
- */
-const MULTILINE = 'm';
 
 const FIXTURES = path.resolve(__dirname, '../../__fixtures__/scripts/lint');
 const MODULES = path.join(FIXTURES, 'modules');
-const FRONTEND_JS_WEB = path.join(MODULES, 'apps/frontend-js/frontend-js-web');
-const SEGMENTS_WEB = path.join(MODULES, 'apps/segments/segments-web');
-const ROGUE_PROJECT = path.join(MODULES, 'apps/rogue/project');
-const NON_PROJECT = path.join(FIXTURES, 'somewhere/subtree/with/a/lock/file');
 
 describe('scripts/lint.js', () => {
 	let cwd;
@@ -45,8 +29,8 @@ describe('scripts/lint.js', () => {
 		jest.resetModules();
 
 		jest.isolateModules(() => {
+			jest.mock('eslint');
 			jest.mock('../../src/utils/log');
-			jest.mock('../../src/utils/spawnSync');
 
 			// Use [] here to avoid unwanted hoisting by
 			// babel-plugin-jest-hoist.
@@ -56,48 +40,12 @@ describe('scripts/lint.js', () => {
 				};
 			});
 
+			const eslint = require('eslint');
 			const lint = require('../../src/scripts/lint');
 			const log = require('../../src/utils/log');
-			const spawnSync = require('../../src/utils/spawnSync');
 
-			callback({lint, log, spawnSync});
+			callback({eslint, lint, log});
 		});
-	}
-
-	/**
-	 * Helper to extract an argument that was passed to a mock `spawnSync` call.
-	 */
-	function get(mock, optionName) {
-		expect(mock.mock.calls.length).toBe(1);
-
-		const call = mock.mock.calls[0];
-		const [command, args] = call;
-
-		expect(command).toBe('eslint');
-
-		const index = args.indexOf(optionName);
-
-		expect(index).not.toBe(-1);
-		expect(args.length).toBeGreaterThan(index + 1);
-
-		return args[index + 1];
-	}
-
-	/**
-	 * Helper to read the contents of the generated `--ignore-path` file.
-	 */
-	function getIgnores() {
-		let contents;
-
-		run(({lint, spawnSync}) => {
-			lint();
-
-			const ignore = get(spawnSync, '--ignore-path');
-
-			contents = fs.readFileSync(ignore).toString();
-		});
-
-		return contents;
 	}
 
 	describe('when no appropriate globs are provided', () => {
@@ -116,10 +64,12 @@ describe('scripts/lint.js', () => {
 		});
 
 		it('does not spawn "eslint"', () => {
-			run(({lint, spawnSync}) => {
+			run(({eslint, lint}) => {
 				lint();
 
-				expect(spawnSync).not.toBeCalled();
+				expect(
+					eslint.CLIEngine.prototype.executeOnFiles
+				).not.toBeCalled();
 			});
 		});
 	});
@@ -129,160 +79,34 @@ describe('scripts/lint.js', () => {
 			process.chdir(MODULES);
 		});
 
-		it('spawns "eslint"', () => {
-			run(({lint, spawnSync}) => {
+		it('spawns "eslint" and prints a report', () => {
+			run(({eslint, lint, log}) => {
+				eslint.CLIEngine.prototype.getFormatter.mockReturnValue(
+					() => 'report...'
+				);
+
+				const executeOnFiles = eslint.CLIEngine.prototype.executeOnFiles.mockReturnValue(
+					() => {
+						return {
+							results: []
+						};
+					}
+				);
+
 				lint();
 
-				expect(spawnSync).toBeCalledWith('eslint', expect.any(Array));
-			});
-		});
+				expect(executeOnFiles).toBeCalledWith([
+					'apps/segments/segments-web/src/index.es.js'
+				]);
 
-		describe('combining all .eslintignore files together', () => {
-			let contents;
+				// This is the report from ESLint's formatter.
+				expect(log).toBeCalledWith('report...');
 
-			beforeEach(() => {
-				contents = getIgnores();
-			});
-
-			it('concatenates the files in order', () => {
-				expect(contents).toMatch(
-					new RegExp(
-						[
-							'This is the top-level',
-							'A project-level \\.eslintignore',
-							'Another project-level \\.eslintignore'
-						].join('.+'),
-						DOT_ALL
-					)
-				);
-			});
-
-			it('relativizes project-specific patterns', () => {
-				expect(contents).toMatch(
-					new RegExp(
-						'^/apps/segments/segments-web/\\*\\*/legacy/\\*$',
-						MULTILINE
-					)
-				);
-			});
-
-			it('preserves negation prefix in project-specific patterns', () => {
-				expect(contents).toMatch(
-					new RegExp(
-						'^!/apps/segments/segments-web/src/stuff/\\*\\.js$',
-						MULTILINE
-					)
-				);
-			});
-		});
-	});
-
-	describe('when running from a project without an .eslintignore', () => {
-		let contents;
-
-		beforeEach(() => {
-			process.chdir(FRONTEND_JS_WEB);
-
-			contents = getIgnores();
-		});
-
-		it('uses the top-level .eslintignore', () => {
-			expect(contents).toContain('This is the top-level');
-		});
-
-		it('does not include .eslintignore patterns from other projects', () => {
-			expect(contents).not.toContain('project-level .eslintignore');
-		});
-	});
-
-	describe('when running from a project with an .eslintignore', () => {
-		let contents;
-
-		beforeEach(() => {
-			process.chdir(SEGMENTS_WEB);
-
-			contents = getIgnores();
-		});
-
-		it('concatenates the top-level and project-level patterns', () => {
-			expect(contents).toMatch(
-				new RegExp(
-					[
-						'This is the top-level',
-						'Another project-level \\.eslintignore'
-					].join('.+'),
-					DOT_ALL
-				)
-			);
-		});
-
-		it('does not include .eslintignore patterns from other projects', () => {
-			expect(contents).not.toContain('A project-level .eslintignore');
-		});
-
-		it('does not relativize project-specific patterns', () => {
-			expect(contents).toMatch(
-				new RegExp('^\\*\\*/legacy/\\*$', MULTILINE)
-			);
-		});
-	});
-
-	describe('when running from a project with a local yarn.lock', () => {
-		// We're not supposed to have any projects like this, but we want to
-		// test to prove that our detection of the top-level "modules/" folder
-		// isn't fooled by a "yarn.lock" in an unexpected location.
-
-		beforeEach(() => {
-			process.chdir(ROGUE_PROJECT);
-		});
-
-		it('still correctly finds the .eslintignore in the top-level', () => {
-			const contents = getIgnores();
-
-			expect(contents).toContain('This is the top-level');
-		});
-
-		it('logs a message about the unexpected yarn.lock', () => {
-			run(({lint, log}) => {
-				lint();
-
+				// This is our summary line.
 				expect(log).toBeCalledWith(
-					expect.stringMatching(
-						new RegExp(
-							[
-								'Found a yarn\\.lock',
-								'but it is not the "modules/" root'
-							].join('.+')
-						)
-					)
+					expect.stringContaining('ESLint checked 1 file')
 				);
 			});
-		});
-	});
-
-	describe('when running outside of the top-level "modules/" directory', () => {
-		// Again, this isn't supposed to happen, but we want to test that we
-		// don't get fooled by the presence of a "yarn.lock" in an unexpected
-		// location.
-
-		beforeEach(() => {
-			process.chdir(NON_PROJECT);
-		});
-
-		it('logs a message about missing top-level "modules/" directory', () => {
-			run(({lint, log}) => {
-				lint();
-
-				expect(log).toBeCalledWith(
-					expect.stringContaining('Unable to find "modules/" root')
-				);
-			});
-		});
-
-		it('uses creates and uses an empty .eslintignore', () => {
-			const contents = getIgnores();
-
-			expect(contents).toBe('');
 		});
 	});
 });


### PR DESCRIPTION
Analog to what we did with Prettier in:

https://github.com/liferay/liferay-npm-tools/pull/141

I removed all the `findProjectIgnoreFiles()` stuff because we never ended up actually using it in liferay-portal, so it is unneeded complexity. (In the end we went with inline suppressions and created tickets to get rid of those.)

As before, tested in liferay-portal with a diff like this:

https://gist.github.com/wincent/dd173f939ba5b1c3b5906bffc4ba99a5

(see that one includes some formatting changes caused by our increased Prettier coverage).