### PR TITLE
feat(scripts): configure ESLint to treat jest like node

### DIFF
--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -34,7 +34,8 @@ module.exports = {
 		{
 			files: ['**/test/**/*.js'],
 			env: {
-				jest: true
+				jest: true,
+				node: true
 			}
 		}
 	],


### PR DESCRIPTION
As discussed [here](https://github.com/wincent/liferay-portal/pull/13/commits/2f86ef7c28554f0924be470d93068766bba1715a#r300623290).

In liferay-portal, we basically run all our Jest scripts in NodeJS.

There are exactly two usages of Karma that in theory could end up running anywhere:

- modules/apps/analytics/analytics-client-js
- modules/apps/portal-search/portal-search-web

In practice, it looks like they'll run in ChromeHeadless for analytics-client-js, and Firefox for portal-search-web, via:

https://github.com/kenjiheigel/liferay-karma-config

As those are minority usages, and we want all tests to run via `liferay-npm-scripts` moving forward, I think this change is acceptably imprecise, and will allow us to get rid of some lint suppressions.