### PR TITLE
fix(scripts): stop ESLint's spurious "ignored by default" warnings

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -80,7 +80,11 @@ function lint(options = {}) {
 		//   fixes do not have an "output" property, but
 		//   `report.fixableErrorCount` and `report.fixableWarningCount` will be
 		//   set.
-		fix
+		fix,
+
+		// Avoid spurious warnings of the form, "File ignored by
+		// default. Use a negated ignore pattern ... to override"
+		ignorePattern: '!*'
 	});
 
 	const report = cli.executeOnFiles(paths);


### PR DESCRIPTION
We explicitly manage the list of paths that we want to lint and pass that to ESLint's programmatic interface, but it still complains about files like ".eslintrc.js" because it is ignored by default (along with other dot files, apparently: see https://github.com/eslint/eslint/issues/6645).

The warnings look like this:

    0:0 warning File ignored by default. Use a negated ignore pattern
    (like "--ignore-pattern '!<relative/path/to/filename>'") to override

By passing in a negated "ignorePattern" configuration of "!*" we can avoid those warnings. This will fix about 8 spurious warnings in a run across all of liferay-portal.

Related: https://issues.liferay.com/browse/LPS-97876