### PR TITLE
fix(scripts): remove sometimes ungrammatical wording

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -122,7 +122,7 @@ function lint(options = {}) {
 			`${autofixable} ${plural(
 				'issue',
 				autofixable
-			)} are potentially fixable with lint:fix`
+			)} potentially fixable with lint:fix`
 		);
 	}
 


### PR DESCRIPTION
Just noticed that if we have one autofixable issue we'll print a message like:

    ESLint checked 526 files, found 1 error, found 215 warnings, 1 issue
    are potentially fixable with lint:fix

ie. ("1 issue are").

We do correctly pluralize however:

    ESLint checked 526 files, found 1 error, found 215 warnings, 2
    issues are potentially fixable with lint:fix

Rather than complicating the pluralization code, just drop the "are"; the message still reads coherently, and arguably it's better in the more concise format anyway:

    ESLint checked 526 files, found 1 error, found 215 warnings, 1 issue
    potentially fixable with lint:fix