### PR TITLE
chore: update eslint-config-liferay to v4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "5.16.0",
-		"eslint-config-liferay": "^4.1.1",
+		"eslint-config-liferay": "^4.2.0",
 		"prettier": "1.18.2"
 	},
 	"private": true,

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -26,7 +26,7 @@
 		"cross-spawn": "^6.0.5",
 		"deepmerge": "^3.0.0",
 		"eslint": "5.16.0",
-		"eslint-config-liferay": "^4.1.1",
+		"eslint-config-liferay": "^4.2.0",
 		"glob": "^7.1.3",
 		"jest": "^24.5.0",
 		"liferay-jest-junit-reporter": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3576,10 +3576,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.1.1.tgz#865bcc24b472a6cd2a268f0e0464cb411ee585ff"
-  integrity sha512-nxdticVkSLsJwtvmQuEGY+zEB8F/lfViKKMYuusrynyvV9XUhSVfzHhH2bbsjxyjbV/dL+YRP0WsHL6DiIGytA==
+eslint-config-liferay@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.2.0.tgz#bc46c27cf1e1a12b500fc82ccfd1403eac237567"
+  integrity sha512-Rn1EA8QBQWvwr2A+PuzA2M5RsZNzqGs00AJAMcAWcn+0c4juuxiFnC3CWmUqajyCjaQbSBilXTtgLbJ5yEDs6A==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"


### PR DESCRIPTION
This means that copyright headers will be checked/fixed in liferay-portal even when running `yarn checkFormat`/`yarn format` from inside a project subdirectory (ie. "modules/apps/foo/bar"), which is something that product team developers are going to reasonably expect to work.

https://github.com/liferay/eslint-config-liferay/releases/tag/v4.2.0