### PR TITLE
fix(scripts): make file glob expansion work on Windows

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/expandGlobs.js
@@ -100,7 +100,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = []) {
 	function traverse(directory) {
 		const entries = fs.readdirSync(directory);
 		entries.forEach(entry => {
-			const file = path.join(directory, entry);
+			const file = path.posix.join(directory, entry);
 
 			// Check trie to see whether entire subtree can be pruned.
 			let trie = prunable;


### PR DESCRIPTION
`path.join()` on Windows will produce paths of the form "a\\b\\c" instead of "a/b/c", causing the regular expressions produced by `getRegExpForGlobs()` to not match.

@kresimir-coko verified that the fix in this PR is working for him on Windows.

In a separate PR I'm going to see whether we can reliably run the Travis CI tests on Windows to catch this kind of problem in the future.