### PR TITLE
chore: update to eslint-config-liferay v4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "5.16.0",
-		"eslint-config-liferay": "^4.2.0",
+		"eslint-config-liferay": "^4.3.0",
 		"prettier": "1.18.2"
 	},
 	"jest": {

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -27,7 +27,7 @@
 		"cross-spawn": "^6.0.5",
 		"deepmerge": "^3.0.0",
 		"eslint": "5.16.0",
-		"eslint-config-liferay": "^4.2.0",
+		"eslint-config-liferay": "^4.3.0",
 		"glob": "^7.1.3",
 		"jest": "^24.5.0",
 		"liferay-jest-junit-reporter": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3634,10 +3634,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.2.0.tgz#bc46c27cf1e1a12b500fc82ccfd1403eac237567"
-  integrity sha512-Rn1EA8QBQWvwr2A+PuzA2M5RsZNzqGs00AJAMcAWcn+0c4juuxiFnC3CWmUqajyCjaQbSBilXTtgLbJ5yEDs6A==
+eslint-config-liferay@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-4.3.0.tgz#b7b50748ca974c4e096907e14a80cb8a706f6b2c"
+  integrity sha512-1tTZFojMC654FGgQy5HlI7CLvX/GXSTASOWcuXntYC3zbwsjYLLi0WkcOPJhOO/ORbtO6fPFb7ZXJX9zDOr/dA==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"


### PR DESCRIPTION
Of principal interest to us here is the new "liferay/metal" preset that we'll be able to use in liferay-portal to eliminate a fair number of lint suppressions:

https://github.com/liferay/eslint-config-liferay/releases/tag/v4.3.0