### PR TITLE
refactor(scripts): simplify Jest config set-up

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const CWD = process.cwd();
-
-const fs = require('fs');
-const path = require('path');
-
 const getMergedConfig = require('../utils/getMergedConfig');
 const {buildSoy, cleanSoy, soyExists} = require('../utils/soy');
 const spawnSync = require('../utils/spawnSync');
@@ -22,21 +17,17 @@ const JEST_CONFIG = getMergedConfig('jest');
 module.exports = function(arrArgs = []) {
 	const useSoy = soyExists();
 
-	const CONFIG_PATH = path.join(CWD, 'TEMP_jest.config.json');
-
-	fs.writeFileSync(CONFIG_PATH, JSON.stringify(JEST_CONFIG));
+	const CONFIG = JSON.stringify(JEST_CONFIG);
 
 	if (useSoy) {
 		buildSoy();
 	}
 
 	withBabelConfig(() => {
-		spawnSync('jest', ['--config', CONFIG_PATH, ...arrArgs.slice(1)]);
+		spawnSync('jest', ['--config', CONFIG, ...arrArgs.slice(1)]);
 	});
 
 	if (useSoy) {
 		cleanSoy();
 	}
-
-	fs.unlinkSync(CONFIG_PATH);
 };


### PR DESCRIPTION
Reading the `jest --help` output just now I see this:

```
  --config, -c     The path to a jest config file specifying how to
                   find and execute tests. If no rootDir is set in
                   the config, the directory containing the config
                   file is assumed to be the rootDir for the
                   project.This can also be a JSON encoded value
                   which Jest will use as configuration.   [string]
```

This means that we can simplify our config management by just passing it in as string. No need to mess with temporary files on the filesystem.