### PR TITLE
refactor: remove unnecessary ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,21 +2,10 @@
 	"env": {
 		"browser": true,
 		"node": true,
-		"es6": true,
 		"jest": true
 	},
 	"parserOptions": {
 		"ecmaVersion": 2018
 	},
-	"extends": "liferay",
-	"rules": {
-		"no-unused-vars": ["error", {"ignoreRestSiblings": true}],
-		"no-mixed-spaces-and-tabs": ["error", "smart-tabs"],
-		"notice/notice": [
-			"error",
-			{
-				"templateFile": "copyright.js"
-			}
-		]
-	}
+	"extends": "liferay"
 }


### PR DESCRIPTION
We can drop all this because we already get equivalent (and standardized!) config from eslint-config-liferay.