### PR TITLE
refactor(scripts): remove now-unnecessary ESLint workaround

### DIFF
--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -8,25 +8,7 @@ const clay = require('./dependencies/clay');
 const liferay = require('./dependencies/liferay');
 const metal = require('./dependencies/metal');
 
-/**
- * We need to (redundantly) include both "*.es.js" and "*.js" in the JS
- * globs in order to pacify ESLint. If we use "*.js" alone, then it will
- * complain if we try to use an `.eslintignore` file with contents like
- * this:
- *
- *      *.js
- *      !*.es.js
- *
- * ie. if the intent is to lint only "modern" ("*.es.js") files, and we
- * pass just "*.js" as a glob, ESLint will error:
- *
- *      You are linting "*.js", but all of the files matching the glob
- *      pattern "*.js" are ignored.
- *
- * With this hack, we can still run Prettier over all "*.js", but focus ESLint
- * on "*.es.js" alone.
- */
-const JS_GLOBS = ['{src,test}/**/*.es.js', '{src,test}/**/*.js'];
+const JS_GLOBS = ['{src,test}/**/*.js'];
 
 module.exports = {
 	build: {


### PR DESCRIPTION
Because we do our own globbing and make explicit calls to the ESLint API, we no longer need this workaround.

Tested in liferay-portal:

  Before:

    Prettier checked 1450 files, found 1 file with problems
    ESLint checked 551 files, found 0 errors, found 4 warnings

  After:

    Prettier checked 1450 files, found 1 file with problems
    ESLint checked 551 files, found 0 errors, found 4 warnings

Also note that I tested in a module that has 0 ".es.js" files, and saw that ESLint didn't complain:

  eg. in modules/apps/analytics/analytics-client-js

    Prettier checked 30 files, found 0 files with problems
    ESLint checked 0 files, found 0 errors, found 0 warnings