### PR TITLE
style: use double quotes for JSX attributes

### DIFF
--- a/packages/liferay-npm-scripts/src/config/prettier.json
+++ b/packages/liferay-npm-scripts/src/config/prettier.json
@@ -1,7 +1,7 @@
 {
 	"bracketSpacing": false,
 	"endOfLine": "lf",
-	"jsxSingleQuote": true,
+	"jsxSingleQuote": false,
 	"singleQuote": true,
 	"tabWidth": 4,
 	"trailingComma": "none",


### PR DESCRIPTION
Due to request here:

https://github.com/brianchandotcom/liferay-portal/pull/75741#issuecomment-511581392

Related internal ticket:

https://issues.liferay.com/browse/LPS-98277