### PR TITLE
fix(scripts): make async work in tests again

### DIFF
--- a/packages/liferay-npm-scripts/src/jest/transformBabel.js
+++ b/packages/liferay-npm-scripts/src/jest/transformBabel.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-module.exports = require('babel-jest').createTransformer({
-	presets: ['@babel/preset-env']
-});
+const fs = require('fs');
+
+const config = JSON.parse(fs.readFileSync('.babelrc').toString());
+
+module.exports = require('babel-jest').createTransformer(config);


### PR DESCRIPTION
Fixes the problem where any use of `async` in tests would lead to:

    ReferenceError: regeneratorRuntime is not defined

Thanks to `@babel/preset-env` and our use of a recent "targets" configuration for test files, we should be able to use `async` without any transforms (our version of Node, v10.15.1, supports `async` directly), but I believe I broke that in 3c5a9c5c217e167394d1771136d8.

That commit had the effect of partially (but not totally) neutralizing our Babel config because our overrides (which explicitly set the target to `"node": "10.15"`) were getting blowing away by the transform which just uses vanilla `@babel/preset-env` without options.

This change here makes sure that we always pass the merged user config directly to Jest's `createTransformer()` call. It's also possible that we could get rid of this `transformBabel.js` transform entirely, but it does provide us with a useful additional introspection point for debugging purposes, so I suggest we keep it around, at least for now.

Test plan: apply this change in liferay-portal and see that `async` can again be used in the tests.