### PR TITLE
feat(scripts): add @testing-library/user-event

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -22,6 +22,7 @@
 		"@babel/preset-react": "7.0.0",
 		"@testing-library/jest-dom": "4.0.0",
 		"@testing-library/react": "8.0.5",
+		"@testing-library/user-event": "4.1.0",
 		"babel-eslint": "^10.0.2",
 		"babel-loader": "8.0.6",
 		"cosmiconfig": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,6 +897,16 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@testing-library/dom@5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.1.1.tgz#091a30b1ca058080bf432cd1aeb2b7c646022f97"
+  integrity sha512-twpAkqomsI0xeOLehijOAmPxeKvs6+WZC/6/nXD0+HNQupP3OZeZho/PBlNhrGL+8nQWiPjdvmxeyU0tq+hctA==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
 "@testing-library/dom@^5.5.4":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.6.0.tgz#18a7c162a6a79964e731ad7b810022a28218047c"
@@ -930,6 +940,13 @@
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@testing-library/dom" "^5.5.4"
+
+"@testing-library/user-event@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-4.1.0.tgz#f039fc10b2c5f7dfd82896e25450a86e3b05684b"
+  integrity sha512-INS0lbelHSlYmaZi78XTXghvwqi1J9S2SSYgvKKdMhzI479Z5mW5oGDCguePU+KwHY5pAXTHZKmweQBeQ5IaSA==
+  dependencies:
+    "@testing-library/dom" "5.1.1"
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"


### PR DESCRIPTION
This should probably have been included in the initial PR that bundled our test dependencies (#164). This one was requested [here](https://github.com/liferay/liferay-frontend-guidelines/issues/49#issuecomment-510459340) and it seems like a worthy candidate for inclusion for a few reasons:

- It is an official package in the `@testing-library` organization, so we can expect a comparable level of support to that which the other `@testing-library` packages receive, and we've already opted to depend on (ie. trust) those.
- The package is a (literally) [very thin wrapper](https://github.com/testing-library/user-event/blob/251f287995c8a71/src/index.js) around the `fireEvent()` API, easily audited.
- The library encourages us to test what really matters (product behavior, often initiated by user activity) -- eg. typing into an input field -- with an expressive and ergonomic API, as opposed to having to deal with low-level browser implementation details, such as what order keydown/keypress/keyup/change events fire in.

One thing to note: until this PR lands upstream, this change adds a bit of duplication to the yarn.lock:

    https://github.com/testing-library/user-event/pull/136

Once that goes in we can update to remove the duplicate version of `@testing-library/dom`.