### PR TITLE
chore(preset): use loose version requirements to facilitate backporting

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -92,10 +92,10 @@
 				"senna": ">=2.6.1"
 			},
 			"frontend-js-web": {
-				"/": ">=3.0.0"
+				"/": ">=1.0.0"
 			},
 			"frontend-taglib": {
-				"/": ">=4.0.0"
+				"/": ">=1.0.0"
 			},
 			"frontend-taglib-chart": {
 				"clay-charts": ">=2.9.0"


### PR DESCRIPTION
To make it easier to backport liferay-npm-scripts to v7.1.x of liferay-portal, make the version requirements specified in the bundler preset super loose: all that we really care about is that "some version of frontend-js-web and frontend-taglib" are available, it doesn't matter which.

Test plan: `yarn add` my local changes in liferay-portal and deploy "fragment-web". See it still work in "master".