### PR TITLE
feat: add "postversion" scripts to automate publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,52 +1,66 @@
 # Release process
 
-At the time of writing we have a pretty informal release process for the packages in this repo. There are obvious improvements that we can and should make, but for now we're starting by documenting the current process. By way of example, here are the steps taken to publish updated packages based on [ff680bb9ebbee](https://github.com/liferay/liferay-npm-tools/commit/ff680bb9ebbee43711bb7bf03d3e852716c54616):
+> **Note:** liferay-npm-scripts can be published independently, but if you update the preset, or the reporter, you need to update liferay-npm-scripts as well, because it depends on the others. When doing this, it is important to publish the packages in order; with liferay-npm-scripts always going last.
+
+To publish a new version of a package:
 
 ```sh
 # Make sure the local "master" branch is up-to-date:
 git checkout master
 git pull --ff-only upstream master
 
-# Update individual package versions:
-# - Note that this time we updated all the packages,
-#   but on many occasions we'll update only one, or two.
-cd packages/liferay-jest-junit-reporter
-yarn version --new-version 1.0.1 # or: yarn version --patch etc
-cd ../liferay-npm-bundler-preset-liferay-dev
-yarn version --new-version 1.1.4
-cd ../liferay-npm-scripts
-yarn version --new-version 1.4.8
-cd ../..
+# See all checks pass locally:
+yarn ci
 
-# Note that if you update the preset, or the reporter,
-# you need to update liferay-npm-scripts as well, because it
-# depends on the others.
+# If any checks fail, fix them, submit a PR, and when it is merged,
+# start again. Otherwise...
+
+# Update the version number:
 cd packages/liferay-npm-scripts
-yarn add liferay-jest-junit-reporter@1.0.1 \
-         liferay-npm-bundler-preset-liferay-dev@1.1.4
-cd ../..
-
-# Ensure lockfile is up-to-date.
-yarn
-
-# Push final commit(s).
-git push upstream master.
-
-# Update and publish the stable branch and tags.
-git checkout stable
-git pull upstream --ff-only stable
-git merge --ff-only master
-git push upstream stable --follow-tags
-
-# Publish packages in order; liferay-npm-scripts must
-# always go last because it depends on the others.
-(cd packages/liferay-jest-junit-reporter && yarn publish)
-(cd packages/liferay-npm-bundler-preset-liferay-dev && yarn publish)
-(cd packages/liferay-npm-scripts && yarn publish)
+yarn version --minor # or --major, or --patch
 ```
+
+Running `yarn version` has the following effects:
+
+-   The "preversion" script will run, which effectively runs `yarn ci` again.
+-   The "package.json" gets updated with the new version number.
+-   A tagged commit is created.
+-   The "postversion" script will run, which automatically does `git push` and performs a `yarn publish`, prompting for confirmation along the way.
 
 After the release, you can confirm that the packages are correctly listed in the NPM registry:
 
 -   https://www.npmjs.com/package/liferay-jest-junit-reporter
 -   https://www.npmjs.com/package/liferay-npm-bundler-preset-liferay-dev
 -   https://www.npmjs.com/package/liferay-npm-scripts
+
+## Publishing manually
+
+If the "postversion" script cannot complete for any reason, it will print a message saying why, and advising you:
+
+> Please try publishing manually as per the CONTRIBUTING.md.
+
+Here are the steps that the "postversion" script is actually trying to perform:
+
+```sh
+# Check you are on the master branch
+git rev-parse --abbrev-ref HEAD
+
+# Check worktree is clean
+git diff --quite
+
+# Update upstream "master"
+git push upstream master
+
+# Merge "master" into "stable"
+git checkout stable
+git merge --ff-only master
+
+# Update upstream "stable"
+git push upstream stable --follow-tags
+
+# Return to the "master" branch
+git checkout master
+
+# Actually publish
+yarn publish
+```

--- a/packages/liferay-jest-junit-reporter/package.json
+++ b/packages/liferay-jest-junit-reporter/package.json
@@ -4,6 +4,7 @@
 	"description": "A JUnit reporter for Jest and Liferay CI",
 	"main": "src/index.js",
 	"scripts": {
+		"postversion": "node ../../publish.js",
 		"preversion": "cd ../.. && yarn ci",
 		"test": "jest"
 	},

--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -13,6 +13,7 @@
 		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.7.1"
 	},
 	"scripts": {
+		"postversion": "node ../../publish.js",
 		"preversion": "cd ../.. && yarn ci",
 		"test": "echo 'No tests currently defined for liferay-npm-bundler-preset-liferay-dev'"
 	}

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -47,6 +47,7 @@
 		"webpack-dev-server": "^3.3.1"
 	},
 	"scripts": {
+		"postversion": "node ../../publish.js",
 		"preversion": "cd ../.. && yarn ci",
 		"test": "jest"
 	},

--- a/packages/liferay-npm-scripts/src/utils/git.js
+++ b/packages/liferay-npm-scripts/src/utils/git.js
@@ -4,33 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const {spawn} = require('cross-spawn');
+const run = require('./run');
 
 /**
  * Convenience helper for running Git commands.
  */
 function git(...args) {
-	const command = `git ${args.join(' ')}`;
-
-	const {error, signal, status, stdout} = spawn.sync('git', args);
-
-	if (error) {
-		throw error;
-	}
-
-	if (signal) {
-		throw new Error(
-			`git(): command \`${command}\` exited due to signal ${signal}`
-		);
-	}
-
-	if (status) {
-		throw new Error(
-			`git(): command \`${command}\` exited with status ${status}`
-		);
-	}
-
-	return stdout.toString().trim();
+	return run('git', ...args);
 }
 
 module.exports = git;

--- a/packages/liferay-npm-scripts/src/utils/run.js
+++ b/packages/liferay-npm-scripts/src/utils/run.js
@@ -1,0 +1,36 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {spawn} = require('cross-spawn');
+
+/**
+ * Convenience helper for running commands.
+ */
+function run(executable, ...args) {
+	const command = `${executable} ${args.join(' ')}`;
+
+	const {error, signal, status, stdout} = spawn.sync(executable, args);
+
+	if (error) {
+		throw error;
+	}
+
+	if (signal) {
+		throw new Error(
+			`run(): command \`${command}\` exited due to signal ${signal}`
+		);
+	}
+
+	if (status) {
+		throw new Error(
+			`run(): command \`${command}\` exited with status ${status}`
+		);
+	}
+
+	return stdout.toString().trim();
+}
+
+module.exports = run;

--- a/publish.js
+++ b/publish.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const {createInterface} = require('readline');
+
+const git = require('./packages/liferay-npm-scripts/src/utils/git');
+const log = require('./packages/liferay-npm-scripts/src/utils/log');
+const run = require('./packages/liferay-npm-scripts/src/utils/run');
+
+/**
+ * Intended to be run as a "postversion" script to publish the new version
+ * whenever we update a package version by (effectively) running:
+ *
+ *     git push $REMOTE master &&
+ *     git checkout stable &&
+ *     git merge --ff-only master &&
+ *     git push $REMOTE stable --follow-tags &&
+ *     yarn publish
+ *
+ * This is "safe" (enough) because:
+ *
+ * - We run `yarn ci` in the "preversion" script.
+ * - In general, "master" should always be in a releasable (green) state due to
+ *   our use of Travis CI.
+ * - The script includes a number of checks and prompts for confirmation.
+ */
+
+let readline;
+
+async function main() {
+	const branch = git('rev-parse', '--abbrev-ref', 'HEAD');
+
+	if (branch !== 'master') {
+		panic('Not on "master" branch');
+	}
+
+	checkCleanWorktree();
+
+	const remote = getRemote();
+
+	await confirm(`Push to ${remote}/master?`);
+
+	git('push', remote, 'master');
+
+	await confirm('Merge "master" into "stable"?');
+
+	git('checkout', 'stable');
+
+	git('merge', '--ff-only', 'master');
+
+	await confirm(`Push to ${remote}/stable?`);
+
+	git('push', remote, 'stable', '--follow-tags');
+
+	git('checkout', 'master');
+
+	await confirm('Run `yarn publish`?');
+
+	const otp = await confirm('Please enter an OTP token or press ENTER:', '');
+
+	if (otp) {
+		run('yarn', 'publish', '--non-interactive', '--otp', otp);
+	} else {
+		run('yarn', 'publish', '--non-interactive');
+	}
+
+	const packageName = JSON.parse(fs.readFileSync('package.json').toString())
+		.name;
+
+	const url = `https://www.npmjs.com/package/${packageName}`;
+
+	printBanner(
+		'Done! ✅',
+		'You can sanity-check that the package is correctly listed here:',
+		url
+	);
+}
+
+function panic(reason) {
+	throw new Error(`${reason}: too scared to continue 😱`);
+}
+
+function checkCleanWorktree() {
+	try {
+		git('diff', '--quiet');
+	} catch (_error) {
+		panic('Worktree is not clean');
+	}
+}
+
+const YES_REGEX = /^\s*y(es?)?\s*/i;
+
+function confirm(prompt, answer = 'y', matcher = YES_REGEX) {
+	if (!readline) {
+		readline = createInterface({
+			input: process.stdin,
+			output: process.stdout
+		});
+	}
+
+	const promise = new Promise(resolve => {
+		const question = answer === 'y' ? `${prompt} [y/n] ` : `${prompt} `;
+		readline.question(question, resolve);
+	}).then(result => {
+		if (answer === 'y') {
+			if (!result.match(matcher)) {
+				throw new Error('User aborted');
+			}
+		}
+
+		return result;
+	});
+
+	readline.write(answer);
+
+	return promise;
+}
+
+const UPSTREAM_REPO_REGEX = /\bgithub\.com[/:]liferay\/liferay-npm-tools(?:\.git)?/i;
+
+function getRemote() {
+	const remotes = git('remote', '-v').split('\n');
+
+	const upstreams = remotes
+		.map(remote => {
+			const [name, url] = remote.split(/\s+/);
+
+			return [name, url];
+		})
+		.filter(([_name, url]) => {
+			return UPSTREAM_REPO_REGEX.test(url);
+		})
+		.sort((a, b) => {
+			// Sort by URL, preferring `git` over `http` URLs.
+			if (a[1] > b[1]) {
+				return 1;
+			} else if (a[1] < b[1]) {
+				return -1;
+			} else {
+				return 0;
+			}
+		});
+
+	const remote = upstreams[0];
+
+	if (remote) {
+		return remote[0];
+	}
+
+	throw new Error('Unable to determine remote repository URL');
+}
+
+function printBanner(...lines) {
+	log(['', ...lines, ''].join('\n\n'));
+}
+
+main()
+	.catch(error => {
+		printBanner(
+			'Failed to automatically publish package due to:',
+			error.message,
+			'Please try publishing manually as per CONTRIBUTING.md.'
+		);
+	})
+	.finally(() => {
+		if (readline) {
+			readline.close();
+		}
+	});


### PR DESCRIPTION
I have been doing a lot of [releases](https://github.com/liferay/liferay-npm-tools/releases) of late — about 20 in the last month — so I wanted to finally go ahead and add some more automation here which should make the release process both quicker and less error-prone.

This implements the last of the ideas in #50. (Previously we implemented a "preversion" script and ".yarnrc" files to create the appropriate release commits and tags.)

We add a "postversion" script that basically does this:

    # Check you are on the master branch
    git rev-parse --abbrev-ref HEAD

    # Check worktree is clean
    git diff --quite

    # Update upstream "master"
    git push upstream master

    # Merge "master" into "stable"
    git checkout stable
    git merge --ff-only master

    # Update upstream "stable"
    git push upstream stable --follow-tags

    # Return to the "master" branch
    git checkout master

    # Actually publish
    yarn publish

Obviously with abundant checks and guards and prompts along the way.

Test plan: I've sort-of-kind-of tested this as best I can without actually doing a release (ie. by commenting out stuff, or adding `--dry-run` to the `push` invocations, or by not supplying a OTP token to `yarn publish` etc). It might work. Maybe.

Closes: https://github.com/liferay/liferay-npm-tools/issues/50

![automation](https://user-images.githubusercontent.com/7074/61450019-72cf9880-a956-11e9-9f9b-d8cdcd82529b.png)
