### PR TITLE
fix: Revert "refactor(scripts): simplify Jest config set-up" (#176)

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -26,17 +26,19 @@ module.exports = function(arrArgs = []) {
 
 	fs.writeFileSync(CONFIG_PATH, JSON.stringify(JEST_CONFIG));
 
-	if (useSoy) {
-		buildSoy();
+	try {
+		if (useSoy) {
+			buildSoy();
+		}
+
+		withBabelConfig(() => {
+			spawnSync('jest', ['--config', CONFIG_PATH, ...arrArgs.slice(1)]);
+		});
+
+		if (useSoy) {
+			cleanSoy();
+		}
+	} finally {
+		fs.unlinkSync(CONFIG_PATH);
 	}
-
-	withBabelConfig(() => {
-		spawnSync('jest', ['--config', CONFIG_PATH, ...arrArgs.slice(1)]);
-	});
-
-	if (useSoy) {
-		cleanSoy();
-	}
-
-	fs.unlinkSync(CONFIG_PATH);
 };

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+const CWD = process.cwd();
+
+const fs = require('fs');
+const path = require('path');
+
 const getMergedConfig = require('../utils/getMergedConfig');
 const {buildSoy, cleanSoy, soyExists} = require('../utils/soy');
 const spawnSync = require('../utils/spawnSync');
@@ -17,17 +22,21 @@ const JEST_CONFIG = getMergedConfig('jest');
 module.exports = function(arrArgs = []) {
 	const useSoy = soyExists();
 
-	const CONFIG = JSON.stringify(JEST_CONFIG);
+	const CONFIG_PATH = path.join(CWD, 'TEMP_jest.config.json');
+
+	fs.writeFileSync(CONFIG_PATH, JSON.stringify(JEST_CONFIG));
 
 	if (useSoy) {
 		buildSoy();
 	}
 
 	withBabelConfig(() => {
-		spawnSync('jest', ['--config', CONFIG, ...arrArgs.slice(1)]);
+		spawnSync('jest', ['--config', CONFIG_PATH, ...arrArgs.slice(1)]);
 	});
 
 	if (useSoy) {
 		cleanSoy();
 	}
+
+	fs.unlinkSync(CONFIG_PATH);
 };

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const CWD = process.cwd();
-
 const fs = require('fs');
-const path = require('path');
 
 const getMergedConfig = require('../utils/getMergedConfig');
 const {buildSoy, cleanSoy, soyExists} = require('../utils/soy');
@@ -22,7 +19,7 @@ const JEST_CONFIG = getMergedConfig('jest');
 module.exports = function(arrArgs = []) {
 	const useSoy = soyExists();
 
-	const CONFIG_PATH = path.join(CWD, 'TEMP_jest.config.json');
+	const CONFIG_PATH = 'TEMP_jest.config.json';
 
 	fs.writeFileSync(CONFIG_PATH, JSON.stringify(JEST_CONFIG));
 


### PR DESCRIPTION
Reported here:

https://github.com/liferay/liferay-npm-tools/issues/176

On Windows, test runs fail:

    $ yarn test
    yarn run v1.15.2
    $ liferay-npm-scripts test
    The system cannot find the file specified.
    Command L:\repo\master-portal-dev\modules\node_modules\liferay-npm-scripts\node_modules\.bin\jest --config {...} exited with code 1
    error Command failed with exit code 1.

(Edited for brevity: the config elided with "..." is about 2k characters long.)

Seems that we are running into the limit described here:

https://devblogs.microsoft.com/oldnewthing/?p=41553

> If you are using the ShellExecute/Ex function, then you become subject
> to the INTERNET_MAX_URL_LENGTH (around 2048) command line length limit
> imposed by the ShellExecute/Ex functions.

So, let's just revert the commit and go back to how we were doing it before. I was able to repro the failure and also confirm that reverting fixes the problem. The contents of the config itself are fine; it's just the length that is an issue.

This reverts commit 01932ef4c0531ca58d2c474bf8d6de490cce9020.

Closes: https://github.com/liferay/liferay-npm-tools/issues/176