### PR TITLE
test(scripts): suppress log output in formatting tests

### DIFF
--- a/packages/liferay-npm-scripts/test/scripts/format.js
+++ b/packages/liferay-npm-scripts/test/scripts/format.js
@@ -24,6 +24,7 @@ describe('scripts/format.js', () => {
 		fs.writeFileSync('src/example.js', source);
 
 		jest.mock('prettier');
+		jest.mock('../../src/utils/log');
 		format = require('../../src/scripts/format');
 		prettier = require('prettier');
 	});


### PR DESCRIPTION
Before:

    PASS  packages/liferay-npm-scripts/test/scripts/format.js
      ● Console

        console.log packages/liferay-npm-scripts/src/utils/log.js:9
          Prettier checked 1 file, found 0 files with problems, fixed 1 file

After:

    PASS  packages/liferay-npm-scripts/test/scripts/format.js

To avoid possible confusion during version tagging, as described here:

https://github.com/liferay/liferay-npm-tools/pull/175#issuecomment-513147027

- Run `yarn version`.
- "preversion" script runs, including tests, console output is visible.
- "postversion" script runs, which publishes package.
- Developer wonders why we're publishing even though we supposedly had to fix (and should therefore commit) a misformatted file.