### PR TITLE
feat(scripts): improve Prettier summary output

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -108,17 +108,16 @@ function format(options = {}) {
 	});
 
 	const files = count => (count === 1 ? 'file' : 'files');
+	const have = count => (count === 1 ? 'has' : 'have');
 
-	const summary = [
-		`Prettier checked ${checked} ${files(checked)}`,
-		`found ${bad} ${files(bad)} with problems`
-	];
+	const summary = [`Prettier checked ${checked} ${files(checked)}`];
 
 	if (fixed) {
 		summary.push(`fixed ${fixed} ${files(fixed)}`);
 	}
 
 	if (bad) {
+		summary.push(`${bad} ${files(bad)} ${have(bad)} problems`);
 		throw new SpawnError(summary.join(', '));
 	} else {
 		log(summary.join(', '));


### PR DESCRIPTION
As explained [here](https://github.com/liferay/liferay-npm-tools/pull/175#issuecomment-513144786), the summary output can be a bit confusing because it was made to be consistent with ESLint (which can report confusing things like "found 0 issues, fixed 10 issues" -- this makes it sound like it fixed issues that it didn't find). We can't easily change the ESLint summary because it is baked into the reporter, but we can change the Prettier one.

With this small tweak we now have these kinds of output that are hopefully totally clear:

- When checking (or fixing) and there are no problems:

     Prettier checked 1461 files

- When checking and 1 or 2 files have formatting problems or syntax errors:

     Prettier checked 1461 files, 1 file has problems
     Prettier checked 1461 files, 2 files have problems

- When fixing and 1 or 2 files have problems:

    Prettier checked 1461 files, fixed 1 file
    Prettier checked 1461 files, fixed 2 files

- When fixing and 1 file has a problem and 1 has a syntax error:

    Prettier checked 1461 files, fixed 1 file, 1 file has problems