### PR TITLE
fix: adds missing clay and frontend-js-web dependencies configuration

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -92,7 +92,15 @@
 				"senna": ">=2.6.1"
 			},
 			"frontend-js-web": {
-				"/": ">=1.0.0"
+				"/": ">=1.0.0",
+				"liferay-amd-loader": ">=4.1.0",
+				"lodash.escape": ">=4.0.1",
+				"lodash.groupby": ">=4.6.0",
+				"lodash.isequal": ">=4.5.0",
+				"lodash.memoize": ">=4.1.2",
+				"lodash.unescape": ">=4.0.1",
+				"svg4everybody": ">=2.1.8",
+				"uuid": ">=3.3.2"
 			},
 			"frontend-taglib": {
 				"/": ">=1.0.0"
@@ -130,6 +138,7 @@
 				"@clayui/sticker": ">=3.0.0-milestone.2",
 				"@clayui/table": ">=3.0.0-milestone.2",
 				"@clayui/time-picker": ">=3.0.0-milestone.2",
+				"clay": ">=2.9.0",
 				"clay-alert": ">=2.9.0",
 				"clay-autocomplete": ">=2.9.0",
 				"clay-badge": ">=2.9.0",


### PR DESCRIPTION
We currently have some missing configuration imports in our `preset-dev`. This causes some unnecessary modules to be processed.

Based on a quick estimate, it adds around 8s per module, so fixing this would provide a significant speed boost to build time.

**Test Plan:**
- Build a module in portal using `liferay-npm-scripts` that depends on `frontend-js-web`
- Assert that the resulting `classes/node_modules` does not contain the `frontend-js-web` dependencies (`liferay-amd-loader`, `svg4everybody`...)
