### PR TITLE
fix: make generateSoyDependencies() work with lone dependencies

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
+++ b/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
@@ -33,10 +33,14 @@ function generateSoyDependencies(dependencies) {
 			return resolvedDependency;
 		})
 		.filter(Boolean)
-		.filter(dependencyPath => dependencyPath !== cwd)
-		.join(',');
+		.filter(dependencyPath => dependencyPath !== cwd);
 
-	return `{${stringDependencies}}/src/**/*.soy`;
+	const joinedDependencies =
+		stringDependencies.length === 1
+			? stringDependencies
+			: `{${stringDependencies.join(',')}}`;
+
+	return `${joinedDependencies}/src/**/*.soy`;
 }
 
 module.exports = generateSoyDependencies;


### PR DESCRIPTION
If you had a single dependency like "metal-slider" then we were making a glob like `{path/to/directory/metal-slider}/src/**/*.soy`, which was failing to match anything at all.

For a "{a,b,c}"-style glob to work, it has to have at least two comma-separated items in it. "{a}" will not match "a".

So, in the case that the dependencies list only contains one item, use the item as-is; otherwise, wrap in "{"/"}" and join with commas.