### PR TITLE
feat: force the use of a "test" NODE_ENV when running jest

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -34,18 +34,16 @@ module.exports = function(arrArgs = []) {
 			NODE_ENV: 'test'
 		};
 
-		if (process.env.NODE_ENV !== 'test') {
-			log('Using NODE_ENV: "test"');
+		const {NODE_ENV} = process.env;
 
-			if (process.env.NODE_ENV) {
-				log(
-					'',
-					'Jest requires a NODE_ENV of "test", so the pre-existing',
-					`NODE_ENV of ${JSON.stringify(
-						process.env.NODE_ENV
-					)} was overridden`
-				);
-			}
+		if (!NODE_ENV || NODE_ENV === 'test') {
+			log('Using NODE_ENV: "test"');
+		} else {
+			log(
+				`Overriding pre-existing NODE_ENV: ${JSON.stringify(
+					NODE_ENV
+				)} → "test"`
+			);
 		}
 
 		withBabelConfig(() => {

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -7,6 +7,7 @@
 const fs = require('fs');
 
 const getMergedConfig = require('../utils/getMergedConfig');
+const log = require('../utils/log');
 const {buildSoy, cleanSoy, soyExists} = require('../utils/soy');
 const spawnSync = require('../utils/spawnSync');
 const withBabelConfig = require('../utils/withBabelConfig');
@@ -28,8 +29,29 @@ module.exports = function(arrArgs = []) {
 			buildSoy();
 		}
 
+		const env = {
+			...process.env,
+			NODE_ENV: 'test'
+		};
+
+		if (process.env.NODE_ENV !== 'test') {
+			log('Using NODE_ENV: "test"');
+
+			if (process.env.NODE_ENV) {
+				log(
+					'',
+					'Jest requires a NODE_ENV of "test", so the pre-existing',
+					`NODE_ENV of ${JSON.stringify(
+						process.env.NODE_ENV
+					)} was overridden`
+				);
+			}
+		}
+
 		withBabelConfig(() => {
-			spawnSync('jest', ['--config', CONFIG_PATH, ...arrArgs.slice(1)]);
+			spawnSync('jest', ['--config', CONFIG_PATH, ...arrArgs.slice(1)], {
+				env
+			});
 		});
 
 		if (useSoy) {

--- a/packages/liferay-npm-scripts/src/utils/log.js
+++ b/packages/liferay-npm-scripts/src/utils/log.js
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-function log(message) {
+function log(...messages) {
 	// eslint-disable-next-line no-console
-	console.log(message);
+	messages.forEach(message => console.log(message));
 }
 
 module.exports = log;

--- a/packages/liferay-npm-scripts/src/utils/setEnv.js
+++ b/packages/liferay-npm-scripts/src/utils/setEnv.js
@@ -25,9 +25,13 @@ const log = require('./log');
  */
 function setEnv(env) {
 	if (process.env.NODE_ENV) {
-		log(`Using pre-existing NODE_ENV: ${process.env.NODE_ENV}`);
+		log(
+			`Using pre-existing NODE_ENV: ${JSON.stringify(
+				process.env.NODE_ENV
+			)}`
+		);
 	} else {
-		log(`Using NODE_ENV: ${env}`);
+		log(`Using NODE_ENV: ${JSON.stringify(env)}`);
 		process.env.NODE_ENV = env;
 	}
 }


### PR DESCRIPTION
Due to recent changes in liferay-portal, we started setting an explicit NODE_ENV of "production" by default, which meant that Jest's usual behavior of assuming "test" no longer worked, and tests broke.

We resolved that in https://github.com/liferay/liferay-portal/commit/0741aabb5d201578a0 but in this commit we want to make ourselves 100% resilient to any future changes in the way `liferay-npm-scripts test` is invoked by always setting a NODE_ENV of "test", no matter what.

Here's what you see with no NODE_ENV:

    $ yarn test
    $ liferay-npm-scripts test
    Using NODE_ENV: "test"

And if NODE_ENV is "test":

    $ env NODE_ENV=test yarn test
    $ liferay-npm-scripts test
    Using NODE_ENV: "test"

And if NODE_ENV is anything else:

    $ env NODE_ENV=development yarn test
    $ liferay-npm-scripts test
    Overriding pre-existing NODE_ENV: "development" → "test"

Test plan: `yarn add` this package in portal and run tests with various NODE_ENV settings; see them pass.