### PR TITLE
fix: update/remove bad links and add missing links in package.json files

### DIFF
--- a/packages/liferay-jest-junit-reporter/package.json
+++ b/packages/liferay-jest-junit-reporter/package.json
@@ -10,14 +10,12 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/jbalsas/liferay-jest-junit-reporter.git"
+		"url": "https://github.com/liferay/liferay-npm-tools",
+		"directory": "packages/liferay-jest-junit-reporter"
 	},
 	"author": "",
 	"license": "ISC",
-	"bugs": {
-		"url": "https://github.com/jbalsas/liferay-jest-junit-reporter/issues"
-	},
-	"homepage": "https://github.com/jbalsas/liferay-jest-junit-reporter#readme",
+	"homepage": "https://github.com/liferay/liferay-npm-tools/packages/liferay-jest-junit-reporter",
 	"dependencies": {
 		"strip-ansi": "^5.0.0",
 		"xml": "^1.0.1"

--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -12,6 +12,12 @@
 		"liferay-npm-bundler-plugin-replace-browser-modules": "2.12.0",
 		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.12.0"
 	},
+	"homepage": "https://github.com/liferay/liferay-npm-tools/packages/liferay-npm-bundler-preset-liferay-dev",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-npm-tools",
+		"directory": "packages/liferay-npm-bundler-preset-liferay-dev"
+	},
 	"scripts": {
 		"postversion": "node ../../publish.js",
 		"preversion": "cd ../.. && yarn ci",

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -57,6 +57,12 @@
 		"webpack-cli": "^3.3.6",
 		"webpack-dev-server": "^3.7.2"
 	},
+	"homepage": "https://github.com/liferay/liferay-npm-tools/packages/liferay-npm-scripts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-npm-tools",
+		"directory": "packages/liferay-npm-scripts"
+	},
 	"scripts": {
 		"postversion": "node ../../publish.js",
 		"preversion": "cd ../.. && yarn ci",


### PR DESCRIPTION
fix: update/remove bad links and add missing links in package.json files

Mostly so that the links back to the repo from the NPM pages will work:

- https://www.npmjs.com/package/liferay-jest-junit-reporter
- https://www.npmjs.com/package/liferay-npm-bundler-preset-liferay-dev
- https://www.npmjs.com/package/liferay-npm-scripts

I don't think anybody is using the `npm bugs` command on these packages, so the "bugs" link is pretty useless. In any case, `npm bugs` is smart enough to tack "/issues" onto the end of the repo URL anyway.