### PR TITLE
feat(reporter): include module name at end of classname (#136)

### DIFF
--- a/packages/liferay-jest-junit-reporter/src/index.js
+++ b/packages/liferay-jest-junit-reporter/src/index.js
@@ -37,6 +37,8 @@ module.exports = report => {
 		}
 	};
 
+	const moduleName = generalMetrics._attr.package.substr(0,generalMetrics._attr.package.indexOf('.'))
+
 	const testResults = report.testResults
 		.reduce(
 			(results, suite) =>
@@ -56,7 +58,8 @@ module.exports = report => {
 					_attr: {
 						classname: formatDirectoryPath(
 							path.dirname(testCase.testFilePath)
-						),
+						)
+							.concat('.[',moduleName,']'),
 						name: testCase.fullName,
 						time: testCase.duration / 1000
 					}

--- a/packages/liferay-jest-junit-reporter/src/index.js
+++ b/packages/liferay-jest-junit-reporter/src/index.js
@@ -22,6 +22,9 @@ function formatDirectoryPath(dirPath) {
 }
 
 module.exports = report => {
+	const pkg = formatDirectoryPath(process.cwd());
+	const moduleName = pkg.split('.')[0];
+
 	const generalMetrics = {
 		_attr: {
 			errors: 0,
@@ -29,15 +32,13 @@ module.exports = report => {
 			hostname: '',
 			id: 0,
 			name: 'Jest',
-			package: formatDirectoryPath(process.cwd()),
+			package: pkg,
 			skipped: 0,
 			tests: report.numTotalTests,
 			time: 0,
 			timestamp: report.startTime
 		}
 	};
-
-	const moduleName = generalMetrics._attr.package.substr(0,generalMetrics._attr.package.indexOf('.'))
 
 	const testResults = report.testResults
 		.reduce(
@@ -56,10 +57,9 @@ module.exports = report => {
 			const results = [
 				{
 					_attr: {
-						classname: formatDirectoryPath(
+						classname: `${formatDirectoryPath(
 							path.dirname(testCase.testFilePath)
-						)
-							.concat('.[',moduleName,']'),
+						)}.[${moduleName}]`,
 						name: testCase.fullName,
 						time: testCase.duration / 1000
 					}

--- a/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
+++ b/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
@@ -2,8 +2,8 @@
 
 exports[`liferay-jest-junit-reporter writes a file for a failing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
-<testsuite errors=\\"0\\" failures=\\"1\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
-  <testcase classname=\\"test-module.bar.[reporter-tests]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
+<testsuite errors=\\"0\\" failures=\\"1\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter.reporter-example\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
+  <testcase classname=\\"test-module.bar.[reporter]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
     <failure message=\\"Error: expect(received).toBe(expected) // Object.is equality\\">Error: expect(received).toBe(expected) // Object.is equality
 
 Expected: false
@@ -22,8 +22,8 @@ Received: true
 
 exports[`liferay-jest-junit-reporter writes a file for a passing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
-<testsuite errors=\\"0\\" failures=\\"0\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
-  <testcase classname=\\"test-module.bar.[reporter-tests]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
+<testsuite errors=\\"0\\" failures=\\"0\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter.reporter-example\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
+  <testcase classname=\\"test-module.bar.[reporter]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
   </testcase>
 </testsuite>"
 `;

--- a/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
+++ b/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`liferay-jest-junit-reporter writes a file for a failing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <testsuite errors=\\"0\\" failures=\\"1\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
-  <testcase classname=\\"test-module.bar\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
+  <testcase classname=\\"test-module.bar.[reporter-tests]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
     <failure message=\\"Error: expect(received).toBe(expected) // Object.is equality\\">Error: expect(received).toBe(expected) // Object.is equality
 
 Expected: false
@@ -23,7 +23,7 @@ Received: true
 exports[`liferay-jest-junit-reporter writes a file for a passing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <testsuite errors=\\"0\\" failures=\\"0\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
-  <testcase classname=\\"test-module.bar\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
+  <testcase classname=\\"test-module.bar.[reporter-tests]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
   </testcase>
 </testsuite>"
 `;

--- a/packages/liferay-jest-junit-reporter/test/index.js
+++ b/packages/liferay-jest-junit-reporter/test/index.js
@@ -55,7 +55,10 @@ const passedTestReport = {
 describe('liferay-jest-junit-reporter', () => {
 	beforeEach(() => {
 		// Prevent user-specific context from appearing in snapshots.
-		jest.spyOn(process, 'cwd').mockImplementation(() => 'reporter-tests');
+		jest.spyOn(process, 'cwd').mockImplementation(
+			() =>
+				'/User/liferay-user/code/portal/liferay-portal/modules/apps/reporter/reporter-example'
+		);
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
Originally sent by @john-co here: https://github.com/wincent/liferay-npm-tools/pull/2

My plan is to cut a tagged preview release which we can try out in liferay-portal, although based on what I see in the Jest tests, I think it's going to work.