### PR TITLE
feat(preset): add "/" import config for frontend-js-react-web

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -80,6 +80,7 @@
 				"vm-browserify": ">=0.0.4"
 			},
 			"frontend-js-react-web": {
+				"/": ">=1.0.0",
 				"classnames": ">=2.2.6",
 				"formik": ">=1.4.3",
 				"prop-types": ">=15.7.2",


### PR DESCRIPTION
In service of [LPS-99399](https://issues.liferay.com/browse/LPS-99399) we want to be offer a standard way to mount React apps in liferay-portal which will take care of common needs like:

- Establishing context(s).
- Subscribing to "~destropyPortlet~destroyPortlet" events and automatically calling `unmountComponentAtNode()`.
- etc

The logical place for this will be inside the "frontend-js-react-web" module, so we need configuration to make it easy to `import` from there, which is what this commit adds.