### PR TITLE
chore(scripts): update liferay-npm-bundler-preset-liferay-dev dep

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -45,7 +45,7 @@
 		"liferay-lang-key-dev-loader": "^1.0.3",
 		"liferay-npm-bridge-generator": "2.12.0",
 		"liferay-npm-bundler": "2.12.0",
-		"liferay-npm-bundler-preset-liferay-dev": "1.6.0",
+		"liferay-npm-bundler-preset-liferay-dev": "1.7.0",
 		"liferay-theme-tasks": "9.4.0",
 		"metal-tools-soy": "4.3.2",
 		"minimist": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9018,6 +9018,14 @@ liferay-frontend-common-css@^1.0.4:
   resolved "https://registry.yarnpkg.com/liferay-frontend-common-css/-/liferay-frontend-common-css-1.0.4.tgz#e4d73e406020d907c909bcacb2700a52fa1c7f16"
   integrity sha1-5Nc+QGAg2QfJCbyssnAKUvocfxY=
 
+liferay-jest-junit-reporter@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/liferay-jest-junit-reporter/-/liferay-jest-junit-reporter-1.0.1.tgz#20e9c8a690017c6e3659a0bf15e7c6534d31c9e7"
+  integrity sha512-qR0mhDu7Qn5QfnTTlPWz1AtkSIHcPgN752anhARQY1olXEH+3/97W3SeCAzP3KPR1tLnhVezwxk6XHZiXk3q/w==
+  dependencies:
+    strip-ansi "^5.0.0"
+    xml "^1.0.1"
+
 liferay-lang-key-dev-loader@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/liferay-lang-key-dev-loader/-/liferay-lang-key-dev-loader-1.0.3.tgz#d4a1c96e5303e9c3039a475ed680b8df214024f1"


### PR DESCRIPTION
Note the change to the yarn.lock file: this is because we have prepared a beta release of liferay-jest-junit-reporter (1.1.0-beta.1) in a268cb4 but haven't done a non-beta release yet; it's still being tested - see:

https://github.com/liferay/liferay-npm-tools/pull/201

While that's pending, and because liferay-npm-scripts still depends on 1.0.1, v1.0.1 of the package gets added back explicitly to the lockfile.