### PR TITLE
feat: make failed publishes more obvious

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -160,6 +160,8 @@ function printBanner(...lines) {
 	log(['', ...lines, ''].join('\n\n'));
 }
 
+let exitStatus = 0;
+
 main()
 	.catch(error => {
 		printBanner(
@@ -167,9 +169,13 @@ main()
 			error.message,
 			'Please try publishing manually as per CONTRIBUTING.md.'
 		);
+
+		exitStatus = 1;
 	})
 	.finally(() => {
 		if (readline) {
 			readline.close();
 		}
+
+		process.exit(exitStatus);
 	});

--- a/publish.js
+++ b/publish.js
@@ -165,7 +165,7 @@ let exitStatus = 0;
 main()
 	.catch(error => {
 		printBanner(
-			'Failed to automatically publish package due to:',
+			'Failed to automatically publish package! ❌',
 			error.message,
 			'Please try publishing manually as per CONTRIBUTING.md.'
 		);


### PR DESCRIPTION
Yesterday I saw a publish fail with this message:

    Failed to automatically publish package due to:

    run(): command `yarn publish --non-interactive --otp 501636` exited with status 1

(I think because my OTP token expired by the time the command actually got to talking to the registry servers).

However, the exit status of the process itself it still 0, so it is easy to overlook this message.

If we have an error, let's exit with a status of 1 instead. And also let's include a "cross mark" emoji

    Failed to automatically publish package! ❌

    run(): command `yarn publish --non-interactive --otp 501636` exited with status 1

to mirror the success output (which uses a check mark):

    Done! ✅

    You can sanity-check that the package is correctly listed here:

    https://www.npmjs.com/package/liferay-npm-scripts
