### PR TITLE
fix: search up as high as liferay-portal "root" for user config

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
@@ -90,7 +90,7 @@ function getMergedConfig(type, property) {
 		case 'prettier':
 			mergedConfig = deepMerge([
 				require('../config/prettier'),
-				getUserConfig('prettier')
+				getUserConfig('prettier', {upwards: true})
 			]);
 			break;
 

--- a/packages/liferay-npm-scripts/src/utils/getUserConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getUserConfig.js
@@ -4,15 +4,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const CWD = process.cwd();
 const cosmiconfig = require('cosmiconfig');
+const findRoot = require('./findRoot');
 
 /**
  * Helper to get configuration via `cosmiconfig`
  * @param {string} moduleName Name of user config file
  */
 module.exports = function(moduleName) {
-	const explorer = cosmiconfig(moduleName, {stopDir: CWD});
+	const stopDir = findRoot() || process.cwd();
+
+	const explorer = cosmiconfig(moduleName, {stopDir});
 
 	const result = explorer.searchSync();
 

--- a/packages/liferay-npm-scripts/src/utils/getUserConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getUserConfig.js
@@ -10,9 +10,10 @@ const findRoot = require('./findRoot');
 /**
  * Helper to get configuration via `cosmiconfig`
  * @param {string} moduleName Name of user config file
+ * @param {object} whether to walk up looking for config if needed
  */
-module.exports = function(moduleName) {
-	const stopDir = findRoot() || process.cwd();
+module.exports = function(moduleName, options = {}) {
+	const stopDir = (options.upwards && findRoot()) || process.cwd();
 
 	const explorer = cosmiconfig(moduleName, {stopDir});
 


### PR DESCRIPTION
We just noticed that when you run the "format" task from a project directory, it doesn't consult the ".prettierrc.js" at the top level.

This is because we tell cosmiconfig not to walk up above the current directory. It seems reasonable that we should be able to safely walk up as high as the "root" (ie. the directory containing the "yarn.lock" file) though.