### PR TITLE
fix: swap order of "fix" script ("format" then "lint:fix")

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/fix.js
+++ b/packages/liferay-npm-scripts/src/scripts/fix.js
@@ -9,7 +9,7 @@ const format = require('./format');
 const lint = require('./lint');
 
 function fix() {
-	spawnMultiple(() => format(), () => lint({fix: true}));
+	spawnMultiple(() => lint({fix: true}), () => format());
 }
 
 module.exports = fix;


### PR DESCRIPTION
Previously we ran Prettier then ESLint in our "fix" script which meant that Prettier might wrap the code in a certain way, only to have ESLint change the AST in a way that meant that Prettier would wrap differently on the next run. We should be able to fix that by inverting the order of the fixes.

Note that because we're using `spawnMultiple` an early failure in ESLint won't stop Prettier from running (errors are accumulated and then reported in aggregate at the end).