### PR TITLE
feat: add liferay-changelog-generator

### DIFF
--- a/packages/liferay-changelog-generator/.yarnrc
+++ b/packages/liferay-changelog-generator/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "liferay-changelog-generator/v"
+version-git-message "liferay-changelog-generator/v%s"

--- a/packages/liferay-changelog-generator/README.md
+++ b/packages/liferay-changelog-generator/README.md
@@ -1,0 +1,50 @@
+# liferay-changelog-generator
+
+> A crude and unsophisticated script for generating or updating CHANGELOG.md based on the local Git history. It was born out of [frustration with other tools](https://github.com/liferay/liferay-js-themes-toolkit/issues/221) that were limited by GitHub API throttling or unable to cope with repos with multiple active branches.
+
+In the name of simplicity, it assumes that you are using a recent version of Node (ie. it uses modern JS with no transpilation), and it has no external dependencies other than `git`.
+
+The generated changelog is based on the merge commits produced by GitHub, which means that the quality of the changelog depends on the quality of the pull request titles (please see [the recommendations](https://github.com/liferay/liferay-frontend-guidelines/blob/master/general/commit_messages.md) for producing high quality commit messages and PR titles in the [liferay-frontend-guidelines](https://github.com/liferay/liferay-frontend-guidelines) repo). Additionally, if you create merge commits by hand rather than using GitHub, or if you push changes without creating merges, the results may be suboptimal.
+
+Operates in two modes:
+
+-   Invoked as `changelog.js --version=x.y.z`: will update the existing CHANGELOG.md in preparation for the "x.y.z" release by looking at changes made since the previous release and prepending them to the top.
+-   Invoked as `changelog.js --regenerate --version=x.y.z`: will regenerate and overwrite the existing CHANGELOG.md, in preparation for the "x.y.z" release.
+
+The idea is that is you ever want to make edits by hand you can, and the way you preserve them over time is by running `git add --patch` to selectively apply newly generated changes while keeping previous manual edits intact.
+
+## Installation
+
+Either:
+
+-   Install globally: `yarn global add liferay-changelog-generator`; or:
+-   Add to a project: `yarn add --dev liferay-changelog-generator`; or:
+-   Use the latest without installing: `npx liferay-changelog-generator` (see below for usage).
+
+## Usage
+
+```
+liferay-changelog-generator [option...]
+
+Options:
+  --force                      [optional: disable safety checks]
+  --from=FROM                  [default: previous tag]
+  --to=TO                      [default: HEAD]
+  --help
+  --no-update-tags             [optional: disable tag prefetching]
+  --outfile=FILE               [default: ./CHANGELOG.md]
+  --remote-url=REPOSITORY_URL  [default: inferred]
+  --regenerate                 [optional: replace entire changelog]
+  --version=VERSION            [required: version being released]
+```
+
+## Example projects using liferay-changelog-generator
+
+-   [Alloy Editor](https://github.com/liferay/alloy-editor) ([CHANGELOG](https://github.com/liferay/alloy-editor/blob/master/CHANGELOG.md)).
+-   [eslint-config-liferay](https://github.com/liferay/eslint-config-liferay) ([CHANGELOG](https://github.com/liferay/eslint-config-liferay/blob/master/CHANGELOG.md)).
+-   [liferay-js-themes-toolkit](https://github.com/liferay/liferay-js-themes-toolkit) ([CHANGELOG](https://github.com/liferay/liferay-js-themes-toolkit/blob/master/CHANGELOG.md)).
+
+## Known limitations
+
+-   Doesn't currently do anything special with Conventional Commit metadata (but it [easily could](https://github.com/liferay/liferay-js-themes-toolkit/issues/258)).
+-   Doesn't currently separate changes by package when used in a monorepo.

--- a/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js
+++ b/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const main = require('../src');
+
+main(...process.argv).catch(err => {
+	process.stderr.write(`${err}\n`);
+	process.exit(1);
+});

--- a/packages/liferay-changelog-generator/package.json
+++ b/packages/liferay-changelog-generator/package.json
@@ -1,0 +1,26 @@
+{
+	"bin": {
+		"liferay-changelog-generator": "./bin/liferay-changelog-generator.js"
+	},
+	"description": "Generates changelogs based on the Git commit graph",
+	"files": [
+		"bin",
+		"src"
+	],
+	"homepage": "https://github.com/liferay/liferay-npm-tools/packages/liferay-changelog-generator",
+	"license": "BSD-3-Clause",
+	"main": "index.js",
+	"name": "liferay-changelog-generator",
+	"private": false,
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-npm-tools",
+		"directory": "packages/liferay-changelog-generator"
+	},
+	"scripts": {
+		"postversion": "node ../../publish.js",
+		"preversion": "cd ../.. && yarn ci",
+		"test": "echo 'No tests currently defined for liferay-changelog-generator'"
+	},
+	"version": "1.0.0"
+}

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -1,0 +1,528 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const readFileAsync = util.promisify(fs.readFile);
+const writeFileAsync = util.promisify(fs.writeFile);
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const RESET = '\x1b[0m';
+const YELLOW = '\x1b[33m';
+
+/**
+ * Log a line to stderr.
+ */
+function log(...args) {
+	process.stderr.write(`${args.join('\n')}\n`);
+}
+
+/**
+ * Log a line to stderr, using green formatting.
+ */
+function info(...args) {
+	log(`${GREEN}${args.join('\n')}${RESET}`);
+}
+
+/**
+ * Log a line to stderr, using error formatting.
+ */
+function error(...args) {
+	log(`${RED}error: ${args.join('\n')}${RESET}`);
+}
+
+/**
+ * Log a line to stderr, using warning formatting.
+ */
+function warn(...args) {
+	log(`${YELLOW}warning: ${args.join('\n')}${RESET}`);
+}
+
+/**
+ * Run `command` and return its stdout (via a Promise).
+ */
+function run(command, ...args) {
+	return new Promise((resolve, reject) => {
+		child_process.execFile(command, args, (err, stdout, stderr) => {
+			if (err) {
+				const invocation = `${command} ${args.join(' ')}`;
+				log(
+					`command: ${invocation}`,
+					`stdout: ${stdout}`,
+					`stderr: ${stderr}`
+				);
+				reject(new Error(`Command: "${invocation}" failed: ${err}`));
+			} else {
+				resolve(stdout);
+			}
+		});
+	});
+}
+
+/**
+ * Convenience wrapper for running a Git command and returning its output (via a
+ * Promise).
+ */
+function git(...args) {
+	return run('git', ...args);
+}
+
+/**
+ * Return the date corresponding to the supplied `commitish`.
+ */
+async function getDate(commitish) {
+	const timestamp = (await git(
+		'log',
+		-'1',
+		commitish,
+		'--pretty=format:%at'
+	)).trim();
+
+	return new Date(+timestamp * 1000);
+}
+
+async function getPreviousReleasedVersion(before) {
+	const describe = await git(
+		'describe',
+		'--abbrev=0',
+		'--tags',
+		`${before}~`
+	);
+	return describe.trim();
+}
+
+async function getChanges(from, to) {
+	const range = from ? `${from}..${to}` : to;
+	const changes = await git(
+		'log',
+		'--merges',
+		range,
+		'--pretty=format:%B',
+		'-z'
+	);
+
+	if (changes.length) {
+		return changes
+			.split('\0')
+			.map(message => {
+				const [subject, description] = message.split(/\n+/);
+				const metadata = subject.match(/Merge pull request #(\d+)/);
+				const number = metadata ? metadata[1] : NaN;
+				return description ? {description, number} : null;
+			})
+			.filter(Boolean);
+	} else {
+		warn(`No merges detected from ${from} to ${to}!`);
+		return [];
+	}
+}
+
+/**
+ * Returns the URL of the remote repository, or `null` if it cannot be
+ * determined.
+ */
+async function getRemote(options) {
+	if (options.remote) {
+		return options.remote;
+	}
+
+	const remotes = await git('remote', '-v');
+	const lines = remotes.split('\n');
+
+	for (let i = 0; i < lines.length; i++) {
+		const match = lines[i].match(
+			/\bgithub\.com[/:]liferay\/(\S+?)(?:\.git)?\s/i
+		);
+		if (match) {
+			return `https://github.com/liferay/${match[1]}`;
+		}
+	}
+
+	warn(
+		'Unable to determine remote repository URL!',
+		'Please specify one with --remote-url=REPOSITORY_URL'
+	);
+	return null;
+}
+
+/**
+ * Escape `string` suitable for embedding in a Markdown document.
+ */
+function escape(string) {
+	// At the moment, not escaping some special Markdown characters (such as *,
+	// backticks etc) as they may prove useful.
+	return string
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+}
+
+function linkToComparison(from, to, remote) {
+	if (remote && from) {
+		return `[Full changelog](${remote}/compare/${from}...${to})`;
+	} else {
+		return null;
+	}
+}
+
+function linkToPullRequest(number, remote) {
+	if (isNaN(number)) {
+		return null;
+	} else if (remote) {
+		const url = `${remote}/pull/${number}`;
+		return `[\\#${number}](${url})`;
+	} else {
+		return `#${number}`;
+	}
+}
+
+function linkToVersion(version, remote) {
+	if (remote) {
+		return `[${version}](${remote}/tree/${version})`;
+	} else {
+		return version;
+	}
+}
+
+async function formatChanges(changes, remote) {
+	return changes
+		.map(({description, number}) => {
+			const link = linkToPullRequest(number, remote);
+			if (link) {
+				return `- ${escape(description)} (${link})`;
+			} else {
+				return `- ${escape(description)}`;
+			}
+		})
+		.join('\n');
+}
+
+/**
+ * Prints `message` in a silly banner like this:
+ *  ____________________
+ * (_)                  `
+ *   |                  |
+ *   |   changelog.js   |
+ *   |   ============   |
+ *   |                  |
+ *   |   Reporting      |
+ *   |   for duty!      |
+ *   |                  |
+ *   |__________________|
+ *   (_)_________________)
+ *
+ */
+function printBanner(message) {
+	const lines = message.split('\n').map(line => line.trim());
+
+	const width = lines.reduce((max, line) => {
+		return Math.max(max, line.length);
+	}, 0);
+
+	const TEMPLATE = [
+		[' _____', '_', '___  '],
+		['(_)   ', ' ', '   ` '],
+		['  |   ', '*', '   | '],
+		['  |___', '_', '___| '],
+		['  (_)_', '_', '____)']
+	];
+
+	let banner = '';
+
+	TEMPLATE.forEach(([left, middle, right]) => {
+		if (middle === '*') {
+			lines.forEach(line => {
+				banner +=
+					left +
+					line +
+					' '.repeat(width - line.length) +
+					right +
+					'\n';
+			});
+		} else {
+			banner += left + middle.repeat(width) + right + '\n';
+		}
+	});
+
+	log(banner);
+}
+
+function relative(filePath) {
+	return path.relative('.', filePath);
+}
+
+function printUsage() {
+	log(
+		'',
+		`${relative(__filename)} [option...]`,
+		'',
+		'Options:',
+		'  --force                      [optional: disable safety checks]',
+		'  --from=FROM                  [default: previous tag]',
+		'  --to=TO                      [default: HEAD]',
+		'  --help',
+		'  --no-update-tags             [optional: disable tag prefetching]',
+		'  --outfile=FILE               [default: ./CHANGELOG.md]',
+		'  --remote-url=REPOSITORY_URL  [default: inferred]',
+		'  --regenerate                 [optional: replace entire changelog]',
+		'  --version=VERSION            [required: version being released]'
+	);
+}
+
+function option(name) {
+	if (name.endsWith('=')) {
+		return new RegExp(`^(?:--{1,2})${name}(.+)`);
+	} else {
+		return new RegExp(`^(?:--{0,2})${name}$`);
+	}
+}
+
+const NUMBER_PREFIX_REGEX = /^\d/;
+const V_PREFIX_REGEX = /^v\d/;
+
+/**
+ * Make sure `version` starts with "v", if that's the convention in this
+ * project, and vice versa: remove an unwanted prefix, if that is not the
+ * convention.
+ */
+async function normalizeVersion(version, {force}) {
+	const tags = (await git('tag', '-l')).trim().split('\n');
+
+	// Calculate a "coefficient" that reflects the likelihood that this repo
+	// uses a "v" prefix by convention.
+	const coefficient = tags.reduce((current, tag) => {
+		return current + (V_PREFIX_REGEX.test(tag) ? 1 : -1);
+	}, 0);
+
+	const hasPrefix = V_PREFIX_REGEX.test(version);
+	const hasNumber = NUMBER_PREFIX_REGEX.test(version);
+
+	if (coefficient > 0 && !hasPrefix) {
+		if (force || !hasNumber) {
+			warn(`Version "${version}" is missing expected "v" prefix`);
+		} else {
+			warn(
+				`Adding expected "v" prefix to version "${version}"`,
+				'use --force to disable this coercion'
+			);
+			return `v${version}`;
+		}
+	} else if (coefficient < 0 && hasPrefix) {
+		if (force) {
+			warn(`Version "${version}" has unexpected "v" prefix`);
+		} else if (version.length > 1) {
+			warn(
+				`Removing unexpected "v" prefix from "${version}"`,
+				'use --force to disable this coercion'
+			);
+			return version.slice(1);
+		}
+	}
+
+	return version;
+}
+
+function parseArgs(args) {
+	const options = {
+		outfile: './CHANGELOG.md',
+		to: 'HEAD',
+		updateTags: true
+	};
+
+	let match;
+	args.forEach(arg => {
+		match = arg.match(option('force'));
+		if (match) {
+			options.force = true;
+			return;
+		}
+
+		match = arg.match(option('help'));
+		if (match) {
+			printUsage();
+			process.exit();
+		}
+
+		match = arg.match(option('outfile='));
+		if (match) {
+			options.outfile = match[1];
+			return;
+		}
+
+		match = arg.match(option('from='));
+		if (match) {
+			options.from = match[1];
+			return;
+		}
+
+		match = arg.match(option('(no-)?update-tags'));
+		if (match) {
+			options.updateTags = !match[1];
+			return;
+		}
+
+		match = arg.match(option('remote-url='));
+		if (match) {
+			options.remote = match[1];
+			return;
+		}
+
+		match = arg.match(option('regenerate'));
+		if (match) {
+			options.regenerate = true;
+			return;
+		}
+
+		match = arg.match(option('to='));
+		if (match) {
+			options.to = match[1];
+			return;
+		}
+
+		match = arg.match(option('version='));
+		if (match) {
+			options.version = match[1];
+			return;
+		}
+
+		error(`Unrecognized argument ${arg}; see --help for available options`);
+		return null;
+	});
+
+	if (!options.version) {
+		error('Missing required option: --version; see --help for usage');
+		return null;
+	}
+
+	return options;
+}
+
+function formatDate(date) {
+	const year = date.getFullYear();
+	const month = (date.getMonth() + 1).toString().padStart(2, '0');
+	const day = date
+		.getDate()
+		.toString()
+		.padStart(2, '0');
+	return `${year}-${month}-${day}`;
+}
+
+async function generate({from, to, date, remote, version}) {
+	const changes = await getChanges(from, to);
+
+	const header = `## ${linkToVersion(version, remote)} (${formatDate(date)})`;
+
+	const comparisonLink = linkToComparison(from, version, remote);
+
+	const changeList = await formatChanges(changes, remote);
+
+	return (
+		[header, comparisonLink, changeList].filter(Boolean).join('\n\n') + '\n'
+	);
+}
+
+async function main(_node, _script, ...args) {
+	const options = parseArgs(args);
+	if (!options) {
+		process.exit(1);
+	}
+	const {outfile, to, updateTags} = options;
+
+	printBanner(`
+		changelog.js
+		============
+
+		Reporting
+		for duty!
+	`);
+
+	if (updateTags) {
+		try {
+			info('Fetching remote tags: run with --no-update-tags to skip');
+			await git('remote', 'update');
+		} catch (err) {
+			warn('Failed to update tags: run with --no-update-tags to skip');
+		}
+	}
+
+	const version = await normalizeVersion(options.version, options);
+
+	const remote = await getRemote(options);
+	let from = await getPreviousReleasedVersion(to);
+	const date = await getDate(to);
+	let contents = await generate({
+		date,
+		from,
+		remote,
+		to,
+		version
+	});
+
+	let written = 0;
+	if (options.regenerate) {
+		while (from && from !== options.from) {
+			let previousVersion = null;
+			try {
+				previousVersion = await getPreviousReleasedVersion(from);
+			} catch (err) {
+				// This will be the last chunk we generate.
+				info('No more tags found (this is not an error) 🦄');
+			}
+
+			const date = await getDate(from);
+			const chunk = await generate({
+				date,
+				from: previousVersion,
+				remote,
+				to: from,
+				version: from
+			});
+			contents += '\n' + chunk;
+
+			from = previousVersion;
+		}
+
+		await writeFileAsync(outfile, contents);
+		written = contents.length;
+	} else {
+		let previousContents = '';
+		try {
+			previousContents = (await readFileAsync(outfile)).toString();
+		} catch (error) {
+			warn(`Cannot read previous file ${outfile}; will create anew.`);
+		}
+
+		if (previousContents.indexOf(`[${version}]`) !== -1) {
+			const message = [
+				`${outfile} already contains a reference to ${version}.`,
+				'Did you mean to regenerate using the --regenerate switch?'
+			];
+			if (options.force) {
+				warn(...message);
+			} else {
+				error(
+					...message,
+					'Alternatively, proceed anyway by using the --force switch.'
+				);
+				process.exit(1);
+			}
+		}
+
+		const newContents = [contents, previousContents]
+			.filter(Boolean)
+			.join('\n');
+		await writeFileAsync(outfile, newContents);
+		written = newContents.length;
+	}
+
+	info(`Wrote ${outfile} ${written} bytes ✨`);
+}
+
+module.exports = main;


### PR DESCRIPTION
Basically took the changelog generator that we have been using in a few places (from [here](https://github.com/liferay/liferay-js-themes-toolkit/blob/640ec3bf73cc87a34eea90c4673e1881e3401be8/scripts/changelog.js))  and turned it into an NPM package. It has zero dependencies, and you can easily use it without adding it as a dependency (ie. with `npx liferay-changelog-generator`), so I hope this can make our life better without plunging us any deeper into the "Thousands-Of-Packages-Nightmare" in which we currently languish.

Once this is merged and published I'll remove it from liferay-js-themes-toolkit and update our various "CONTRIBUTING" guides to refer to this instead. There are a couple of known limitations listed in the README that I'd like to address soon too. 