### PR TITLE
chore: remove redundant .prettierrc

### DIFF
--- a/packages/liferay-npm-scripts/.prettierrc
+++ b/packages/liferay-npm-scripts/.prettierrc
@@ -1,6 +1,0 @@
-{
-	"bracketSpacing": false,
-	"singleQuote": true,
-	"tabWidth": 4,
-	"useTabs": true
-}


### PR DESCRIPTION
The one we have at the top-level should suffice.