### PR TITLE
chore(scripts): correct license type in liferay-npm-scripts package.json

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -6,7 +6,7 @@
 	"author": {
 		"name": "Bryce Osterhaus"
 	},
-	"license": "MIT",
+	"license": "BSD-3-Clause",
 	"files": [
 		"bin",
 		"src"


### PR DESCRIPTION
Everything else in the repo -- the top-level LICENSE.txt, the copyright headers, the other package.json files -- thinks the license is BSD-3-Clause, not MIT.