### PR TITLE
feat: make changelog output identical to Prettier

### DIFF
--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -159,6 +159,7 @@ function escape(string) {
 	// At the moment, not escaping some special Markdown characters (such as *,
 	// backticks etc) as they may prove useful.
 	return string
+		.replace(/_/g, '\\_')
 		.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
 		.replace(/>/g, '&gt;');
@@ -196,9 +197,9 @@ async function formatChanges(changes, remote) {
 		.map(({description, number}) => {
 			const link = linkToPullRequest(number, remote);
 			if (link) {
-				return `- ${escape(description)} (${link})`;
+				return `-   ${escape(description)} (${link})`;
 			} else {
-				return `- ${escape(description)}`;
+				return `-   ${escape(description)}`;
 			}
 		})
 		.join('\n');


### PR DESCRIPTION
See changes made by Prettier to the changelogs in these PRs:

- https://github.com/liferay/liferay-js-themes-toolkit/pull/389/files
- https://github.com/liferay/liferay-js-themes-toolkit/pull/390/files

Specifically: `_` gets escaped, and list items have three trailing spaces instead of one.

Note that this means you can't use "_" to indicate italics in your PR titles ("*" will still work though); I'm not sure that's a very useful thing to do anyway.

Test plan: Regenerate the changelogs in the liferay-js-themes-toolkit repo with these changes and confirm that Prettier agrees with the formatting:

    git reset --hard v8.1.1
    ~/code/liferay-npm-tools/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js --regenerate --version=v8.1.1
    git add -u
    yarn format
    git diff --quiet

    git reset --hard v9.4.0
    ~/code/liferay-npm-tools/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js --regenerate --version=v9.4.0
    git add -u
    yarn format
    git diff --quiet