### PR TITLE
fix: don't choke on stale .babelrc files (#242)

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/src/utils/deepMerge.js
@@ -174,7 +174,22 @@ function babelMerge(key) {
 			);
 		};
 	} else {
-		return combineMerge;
+		return function(target, source, options) {
+			if (Array.isArray(target) && Array.isArray(source)) {
+				return combineMerge(target, source, options);
+			} else if (
+				options.isMergeableObject(target) &&
+				options.isMergeableObject(source)
+			) {
+				return merge(target, source, options);
+			} else {
+				throw new Error(
+					'babelMerge(): ' +
+						'Cannot merge without two mergeable objects: ' +
+						'please check for a stale .babelrc files'
+				);
+			}
+		};
 	}
 }
 

--- a/packages/liferay-npm-scripts/src/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/src/utils/deepMerge.js
@@ -186,7 +186,7 @@ function babelMerge(key) {
 				throw new Error(
 					'babelMerge(): ' +
 						'Cannot merge without two mergeable objects: ' +
-						'please check for a stale .babelrc files'
+						'please check that the .babelrc file is well-formed'
 				);
 			}
 		};

--- a/packages/liferay-npm-scripts/test/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/test/utils/deepMerge.js
@@ -279,6 +279,77 @@ describe('deepMerge()', () => {
 			});
 		});
 
+		it("doesn't break when a stale .babelrc file is left on disk", () => {
+			// This is the original project-local .babelrc config.
+			const project = {
+				presets: ['@babel/preset-react']
+			};
+
+			// This is the config provided by liferay-npm-scripts.
+			const defaults = {
+				overrides: [
+					{
+						presets: [
+							[
+								'@babel/preset-env',
+								{
+									targets: {
+										node: '10.15'
+									}
+								}
+							]
+						],
+						test: '**/test/**/*.js'
+					}
+				],
+				plugins: [
+					'@babel/proposal-class-properties',
+					'@babel/proposal-object-rest-spread'
+				],
+				presets: ['@babel/preset-env']
+			};
+
+			// This should be the result of merging "defaults" and "project"; imagine that
+			// it could be left on disk if the build gets interrupted.
+			const stale = {
+				overrides: [
+					{
+						presets: [
+							[
+								'@babel/preset-env',
+								{
+									targets: {
+										node: '10.15'
+									}
+								}
+							]
+						],
+						test: '**/test/**/*.js'
+					}
+				],
+				plugins: [
+					'@babel/proposal-class-properties',
+					'@babel/proposal-object-rest-spread'
+				],
+				presets: ['@babel/preset-env', '@babel/preset-react']
+			};
+
+			expect(
+				deepMerge([defaults, project], deepMerge.MODE.BABEL)
+			).toEqual(stale);
+
+			let duplicate;
+
+			expect(() => {
+				duplicate = deepMerge(
+					[defaults, project],
+					deepMerge.MODE.BABEL
+				);
+			}).not.toThrow();
+
+			expect(duplicate).toEqual(stale);
+		});
+
 		it('complains about malformed plugin names', () => {
 			expect(() => {
 				deepMerge(


### PR DESCRIPTION
As explained in the related issue, we have a few places around where we use `finally` to do cleanup of temporary files we leave on the filesystem.

That deals nicely with errors but if you interrupt a build with Ctrl-C the `finally` block(s) won't run. The stale config files (eg. a merged `.babelrc`) that get left behind can cause the next run to fail with a confusing stack trace, usually deep in the bowels of the `deepMerge()` function along the lines of `target.slice()` is not a function.

We should deal with this in depth:

1. Make `deepMerge()` resilient to being run on a previously merged config.
2. Detect a stale merged config file on disk and report the problem to the user in a way that they can understand the fix.
3. Install a sig handler that does clean-up even when a build is interrupted.

This PR does 1, and in a way 2 (because if it has a problem merging it throws an error advising people to check for stale `.babelrc` file(s)).

I'll follow up with another PR for item 3.

Closes: https://github.com/liferay/liferay-npm-tools/issues/242