### PR TITLE
feat: don't let signals leave stale files lying around (#242)

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -9,6 +9,7 @@ const CWD = process.cwd();
 const fs = require('fs');
 const path = require('path');
 
+const SignalHandler = require('../utils/SignalHandler');
 const getMergedConfig = require('../utils/getMergedConfig');
 const moveToTemp = require('../utils/moveToTemp');
 const removeFromTemp = require('../utils/removeFromTemp');
@@ -42,6 +43,10 @@ function compileBabel() {
  * `liferay-npm-bundler` executable.
  */
 function runBundler() {
+	const {dispose} = SignalHandler.onExit(() => {
+		removeFromTemp('.npmbundlerrc');
+	});
+
 	try {
 		moveToTemp('.npmbundlerrc');
 
@@ -53,7 +58,7 @@ function runBundler() {
 
 		fs.unlinkSync(RC_PATH);
 	} finally {
-		removeFromTemp('.npmbundlerrc');
+		dispose();
 	}
 }
 

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -6,6 +6,7 @@
 
 const fs = require('fs');
 
+const SignalHandler = require('../utils/SignalHandler');
 const getMergedConfig = require('../utils/getMergedConfig');
 const log = require('../utils/log');
 const {buildSoy, cleanSoy, soyExists} = require('../utils/soy');
@@ -23,6 +24,10 @@ module.exports = function(arrArgs = []) {
 	const CONFIG_PATH = 'TEMP_jest.config.json';
 
 	fs.writeFileSync(CONFIG_PATH, JSON.stringify(JEST_CONFIG));
+
+	const {dispose} = SignalHandler.onExit(() => {
+		fs.unlinkSync(CONFIG_PATH);
+	});
 
 	try {
 		if (useSoy) {
@@ -56,6 +61,6 @@ module.exports = function(arrArgs = []) {
 			cleanSoy();
 		}
 	} finally {
-		fs.unlinkSync(CONFIG_PATH);
+		dispose();
 	}
 };

--- a/packages/liferay-npm-scripts/src/utils/SignalHandler.js
+++ b/packages/liferay-npm-scripts/src/utils/SignalHandler.js
@@ -1,0 +1,67 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const log = require('./log');
+
+let installed = false;
+
+let index = 0;
+
+const callbacks = new Map();
+
+const SIGNALS = {
+	SIGHUP: 1,
+	SIGINT: 2,
+	SIGQUIT: 3,
+	SIGTERM: 15
+};
+
+const SignalHandler = {
+	install() {
+		if (!installed) {
+			Object.keys(SIGNALS).forEach(signal => {
+				process.on(signal, handleSignal);
+			});
+
+			installed = true;
+		}
+	},
+
+	onExit(callback) {
+		SignalHandler.install();
+
+		return getDisposable(callback, index++);
+	}
+};
+
+function getDisposable(callback, id) {
+	callbacks.set(id, callback);
+
+	return {
+		dispose() {
+			callback();
+
+			callbacks.delete(id);
+		}
+	};
+}
+
+function handleSignal(signal) {
+	log(`Received ${signal}`);
+
+	/* eslint-disable-next-line no-for-of-loops/no-for-of-loops */
+	for (const callback of callbacks.values()) {
+		try {
+			callback();
+		} catch (error) {
+			log(`Caught error in signal callback: ${error}`);
+		}
+	}
+
+	process.exit(128 + SIGNALS[signal]);
+}
+
+module.exports = SignalHandler;

--- a/packages/liferay-npm-scripts/src/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/src/utils/spawnSync.js
@@ -34,7 +34,7 @@ function spawnSync(command, args = [], options = {}) {
 	);
 	const executable = fs.existsSync(localCommand) ? localCommand : command;
 
-	const {error, status} = spawn.sync(executable, args, {
+	const {error, signal, status} = spawn.sync(executable, args, {
 		stdio: 'inherit',
 		...options
 	});
@@ -53,6 +53,13 @@ function spawnSync(command, args = [], options = {}) {
 				executable,
 				args
 			)} failed with error ${error}`
+		);
+	} else if (signal) {
+		throw new Error(
+			`Command ${getDescription(
+				executable,
+				args
+			)} killed by signal ${signal}`
 		);
 	}
 }

--- a/packages/liferay-npm-scripts/src/utils/withBabelConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/withBabelConfig.js
@@ -7,6 +7,7 @@
 const fs = require('fs');
 
 const getMergedConfig = require('./getMergedConfig');
+const SignalHandler = require('../utils/SignalHandler');
 const moveToTemp = require('../utils/moveToTemp');
 const removeFromTemp = require('../utils/removeFromTemp');
 
@@ -30,12 +31,16 @@ function removeBabelConfig() {
  * state.
  */
 function withBabelConfig(callback) {
+	const {dispose} = SignalHandler.onExit(() => {
+		removeBabelConfig();
+	});
+
 	try {
 		setBabelConfig();
 
 		callback();
 	} finally {
-		removeBabelConfig();
+		dispose();
 	}
 }
 


### PR DESCRIPTION
Two parts to this:

1. Add a `SignalHandler` module that sets up signal handlers and provides a mechanism for registering callbacks that should be executed when a signal is received.
2. Make sure we do something about signals in child processes in `spawnSync()`.

In practice we don't really need "1"; "2" is enough to turn interrupts (eg. Ctrl-C) received while running subprocesses like Babel into error which we can catch, and which get handled by our `finally` blocks. I can remove "1" if people don't like the complexity of it; including it for now "just in case".

Companion to: https://github.com/liferay/liferay-npm-tools/pull/243