### PR TITLE
feat: add SignalHandler for managing cleanup

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -9,6 +9,7 @@ const CWD = process.cwd();
 const fs = require('fs');
 const path = require('path');
 
+const SignalHandler = require('../utils/SignalHandler');
 const getMergedConfig = require('../utils/getMergedConfig');
 const moveToTemp = require('../utils/moveToTemp');
 const removeFromTemp = require('../utils/removeFromTemp');
@@ -42,6 +43,10 @@ function compileBabel() {
  * `liferay-npm-bundler` executable.
  */
 function runBundler() {
+	const {dispose} = SignalHandler.onExit(() => {
+		removeFromTemp('.npmbundlerrc');
+	});
+
 	try {
 		moveToTemp('.npmbundlerrc');
 
@@ -53,7 +58,7 @@ function runBundler() {
 
 		fs.unlinkSync(RC_PATH);
 	} finally {
-		removeFromTemp('.npmbundlerrc');
+		dispose();
 	}
 }
 

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -6,6 +6,7 @@
 
 const fs = require('fs');
 
+const SignalHandler = require('../utils/SignalHandler');
 const getMergedConfig = require('../utils/getMergedConfig');
 const log = require('../utils/log');
 const {buildSoy, cleanSoy, soyExists} = require('../utils/soy');
@@ -23,6 +24,10 @@ module.exports = function(arrArgs = []) {
 	const CONFIG_PATH = 'TEMP_jest.config.json';
 
 	fs.writeFileSync(CONFIG_PATH, JSON.stringify(JEST_CONFIG));
+
+	const {dispose} = SignalHandler.onExit(() => {
+		fs.unlinkSync(CONFIG_PATH);
+	});
 
 	try {
 		if (useSoy) {
@@ -56,6 +61,6 @@ module.exports = function(arrArgs = []) {
 			cleanSoy();
 		}
 	} finally {
-		fs.unlinkSync(CONFIG_PATH);
+		dispose();
 	}
 };

--- a/packages/liferay-npm-scripts/src/utils/SignalHandler.js
+++ b/packages/liferay-npm-scripts/src/utils/SignalHandler.js
@@ -1,0 +1,67 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const log = require('./log');
+
+let installed = false;
+
+let index = 0;
+
+const callbacks = new Map();
+
+const SIGNALS = {
+	SIGHUP: 1,
+	SIGINT: 2,
+	SIGQUIT: 3,
+	SIGTERM: 15
+};
+
+const SignalHandler = {
+	install() {
+		if (!installed) {
+			Object.keys(SIGNALS).forEach(signal => {
+				process.on(signal, handleSignal);
+			});
+
+			installed = true;
+		}
+	},
+
+	onExit(callback) {
+		SignalHandler.install();
+
+		return getDisposable(callback, index++);
+	}
+};
+
+function getDisposable(callback, id) {
+	callbacks.set(id, callback);
+
+	return {
+		dispose() {
+			callback();
+
+			callbacks.delete(id);
+		}
+	};
+}
+
+function handleSignal(signal) {
+	log(`Received ${signal}`);
+
+	/* eslint-disable-next-line no-for-of-loops/no-for-of-loops */
+	for (const callback of callbacks.values()) {
+		try {
+			callback();
+		} catch (error) {
+			log(`Caught error in signal callback: ${error}`);
+		}
+	}
+
+	process.exit(128 + SIGNALS[signal]);
+}
+
+module.exports = SignalHandler;

--- a/packages/liferay-npm-scripts/src/utils/withBabelConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/withBabelConfig.js
@@ -7,6 +7,7 @@
 const fs = require('fs');
 
 const getMergedConfig = require('./getMergedConfig');
+const SignalHandler = require('../utils/SignalHandler');
 const moveToTemp = require('../utils/moveToTemp');
 const removeFromTemp = require('../utils/removeFromTemp');
 
@@ -30,12 +31,16 @@ function removeBabelConfig() {
  * state.
  */
 function withBabelConfig(callback) {
+	const {dispose} = SignalHandler.onExit(() => {
+		removeBabelConfig();
+	});
+
 	try {
 		setBabelConfig();
 
 		callback();
 	} finally {
-		removeBabelConfig();
+		dispose();
 	}
 }
 


### PR DESCRIPTION
Add a `SignalHandler` module that sets up signal handlers and provides a mechanism for registering callbacks that should be executed when a signal is received.

Originally sent this as:

https://github.com/liferay/liferay-npm-tools/pull/244

But then I realized it should be split into two bits:

1. This bit, the SignalHandler, may be overkill, and we can decide whether we want the complexity or not.
2. The other bit from #244 was making sure that `spawnSync` turns signals in child processes into errors. That on its own may be enough, and should clearly go in.

Companion to: https://github.com/liferay/liferay-npm-tools/pull/243