### PR TITLE
fix: don't let signals leave stale files lying around (#242)

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/src/utils/spawnSync.js
@@ -34,7 +34,7 @@ function spawnSync(command, args = [], options = {}) {
 	);
 	const executable = fs.existsSync(localCommand) ? localCommand : command;
 
-	const {error, status} = spawn.sync(executable, args, {
+	const {error, signal, status} = spawn.sync(executable, args, {
 		stdio: 'inherit',
 		...options
 	});
@@ -53,6 +53,13 @@ function spawnSync(command, args = [], options = {}) {
 				executable,
 				args
 			)} failed with error ${error}`
+		);
+	} else if (signal) {
+		throw new Error(
+			`Command ${getDescription(
+				executable,
+				args
+			)} killed by signal ${signal}`
 		);
 	}
 }


### PR DESCRIPTION
Make sure that signals in child process get caught and turned into errors, so that our `finally` blocks will run and perform their necessary cleanup even when the user interrupts a build with Ctrl-C.

Originally sent this as:

https://github.com/liferay/liferay-npm-tools/pull/244

But that had two parts, so I am splitting it into:

https://github.com/liferay/liferay-npm-tools/pull/245

And this one so that we can decide independently whether we want both or just one. This one should clearly go in; the other one may not be needed but might be nice to have "just in case".

Companion to: https://github.com/liferay/liferay-npm-tools/pull/243