### PR TITLE
feat: allow for compound patterns in extensions in globs

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -5,16 +5,10 @@
  */
 
 const fs = require('fs');
-const path = require('path');
 const prettier = require('prettier');
-const expandGlobs = require('../utils/expandGlobs');
-const filterChangedFiles = require('../utils/filterChangedFiles');
-const filterGlobs = require('../utils/filterGlobs');
-const findRoot = require('../utils/findRoot');
 const getMergedConfig = require('../utils/getMergedConfig');
+const getPaths = require('../utils/getPaths');
 const log = require('../utils/log');
-const preprocessGlob = require('../utils/preprocessGlob');
-const readIgnoreFile = require('../utils/readIgnoreFile');
 const {SpawnError} = require('../utils/spawnSync');
 
 const DEFAULT_OPTIONS = {
@@ -26,6 +20,8 @@ const DEFAULT_OPTIONS = {
  */
 const EXTENSIONS = ['.js', '.scss'];
 
+const IGNORE_FILE = '.prettierignore';
+
 /**
  * Prettier wrapper.
  */
@@ -35,40 +31,15 @@ function format(options = {}) {
 		...options
 	};
 
-	const unfilteredGlobs = check
+	const globs = check
 		? getMergedConfig('npmscripts', 'check')
 		: getMergedConfig('npmscripts', 'fix');
 
-	const globs = filterGlobs(unfilteredGlobs, ...EXTENSIONS);
+	const paths = getPaths(globs, EXTENSIONS, IGNORE_FILE);
 
-	if (!globs.length) {
-		const extensions = EXTENSIONS.join(', ');
-
-		log(
-			`No globs applicable to ${extensions} files specified: globs can be configured via npmscripts.config.js`
-		);
-
+	if (!paths.length) {
 		return;
 	}
-
-	const root = findRoot();
-	const ignoreFile = path.join(root || '.', '.prettierignore');
-
-	const ignores = fs.existsSync(ignoreFile) ? readIgnoreFile(ignoreFile) : [];
-
-	// Match Prettier behavior and ignore node_modules by default.
-	if (ignores.indexOf('node_modules/**') === -1) {
-		ignores.unshift('node_modules/**');
-	}
-
-	// Turn "{src,test}/*" into ["src/*", "test/*"]:
-	const preprocessedGlobs = [];
-
-	globs.forEach(glob => preprocessedGlobs.push(...preprocessGlob(glob)));
-
-	const expandedGlobs = expandGlobs(preprocessedGlobs, ignores);
-
-	const paths = filterChangedFiles(expandedGlobs);
 
 	const config = getMergedConfig('prettier');
 

--- a/packages/liferay-npm-scripts/src/utils/getPaths.js
+++ b/packages/liferay-npm-scripts/src/utils/getPaths.js
@@ -1,0 +1,61 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const expandGlobs = require('../utils/expandGlobs');
+const filterChangedFiles = require('../utils/filterChangedFiles');
+const filterGlobs = require('../utils/filterGlobs');
+const findRoot = require('../utils/findRoot');
+const log = require('../utils/log');
+const preprocessGlob = require('../utils/preprocessGlob');
+const readIgnoreFile = require('../utils/readIgnoreFile');
+
+/**
+ * Given a set of `globs`, the file `extensions` we are interested
+ * in, and the name of an `ignoreFile` (eg. '.prettierignore' or
+ * '.eslintignore'), returns a list of matching files on the file
+ * system.
+ */
+function getPaths(globs, extensions, ignoreFile) {
+	const root = findRoot();
+
+	ignoreFile = path.join(root || '.', ignoreFile);
+
+	const ignores = fs.existsSync(ignoreFile) ? readIgnoreFile(ignoreFile) : [];
+
+	// Match Prettier behavior and ignore node_modules by default.
+	if (ignores.indexOf('node_modules/**') === -1) {
+		ignores.unshift('node_modules/**');
+	}
+
+	// Turn "{src,test}/*" into ["src/*", "test/*"]:
+	globs = [].concat(...globs.map(glob => preprocessGlob(glob)));
+
+	// Filter out globs that don't apply to `extensions`.
+	globs = filterGlobs(globs, ...extensions);
+
+	if (!globs.length) {
+		log(
+			`No globs applicable to ${extensions.join(
+				', '
+			)} files specified: globs can be configured via npmscripts.config.js`
+		);
+
+		return [];
+	}
+
+	// Actually traverse the file system.
+	let paths = expandGlobs(globs, ignores);
+
+	// Potentially reduce file list to only files changed on the current branch.
+	paths = filterChangedFiles(paths);
+
+	return paths;
+}
+
+module.exports = getPaths;


### PR DESCRIPTION
Back in ancient history before we knew that we were going to have to implement our own glob expansion, we made a basic `filterGlobs()` function that would take some globs like:

    ['**/*.js', '**/*.css', '**/*.foo']

And filter them down to a subset:

    ['**/*.js', '**/*.css']

To keep things simple, we didn't add support for globs that used compound patterns in their extensions (eg. `'**/*.{js,jsx}'`).

Later on, we were forced to implement our own globbing, and part of that was building a function (`preprocessGlob()`) that could preprocess complex globs (eg. `'{src,test}/**/*.js'`) and transform them into a list of simpler globs (eg. `['src/**/*.js', 'test/**/*.js']`).

Looking at the code now, I see that there's no reason to require globs to have simple extensions any more; we can support compound patterns in globs by swapping the order of operations from:

- `filterGlobs()` then `preprocessGlob()`; to:
- `preprocessGlob()` then `filterGlobs()`

I made that change in both `format.js` and `lint.js`, and then decided it was time to refactor them to extract out the common functionality into a new `getPaths()` module. The only difference between the two files in the previous implementation was that `format.js` ignored "node_modules" by default even if not explicitly configured to do so (in order to match the Prettier behavior). So, the new `getPaths()` function does this too, seeing as it is harmless to apply the same default exclusion to ESLint as well.