### PR TITLE
refactor: implement improvements from JSP formatting review

### DIFF
--- a/packages/liferay-npm-scripts/src/format/Lexer.js
+++ b/packages/liferay-npm-scripts/src/format/Lexer.js
@@ -275,6 +275,9 @@ class Lexer {
 
 		/**
 		 * Assigns a name to a matcher.
+		 *
+		 * Once a matcher has a name, other matchers can reference it by name
+		 * using the `a()` or `an()` functions.
 		 */
 		function name(string) {
 			this._description = string;
@@ -306,6 +309,8 @@ class Lexer {
 		/**
 		 * Returns a composite matcher that matches if one of the supplied matchers
 		 * matches.
+		 *
+		 * Conceptually equivalent to the "|" regex special character.
 		 */
 		function oneOf(...matchers) {
 			return {

--- a/packages/liferay-npm-scripts/src/format/README.md
+++ b/packages/liferay-npm-scripts/src/format/README.md
@@ -1,0 +1,29 @@
+# Formatting overview
+
+## Formatting JS in JSP
+
+This document provides a brief table of contents for the main items in [the liferay-npm-scripts/src/format directory](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-npm-scripts/src/format), which is responsible for formatting JS inside JSP files.
+
+The main workhorse is [the `formatJSP()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/formatJSP.js), which takes a JSP source string and returns a string with that preserves the original contents of the JSP but with all the JS content formatted via Prettier. The operations are:
+
+1. Extract blocks of JS (ie. code inside `<script>` and `<aui:script>` tags) using [the `extractJS()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/extractJS.js).
+2. For each block of JS:
+    1. Trim leading and trailing blank lines with [the `trim()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/trim.js).
+    2. Strip the "base indent" (ie. the common indent that all lines within the block share) using [the `dedent()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/dedent.js).
+    3. Turn JSP tags, expressions, scriptlets (etc) — which are not JavaScript — into valid JS placeholders that allow Prettier to parse each block as JavaScript without errors. Peculiar Unicode characters are used in replacements to ensure that the substitutions can be reversed after Prettier has finished formatting. This is done by [the `substituteTags()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/substituteTags.js).
+    4. Strip indents inside JSP tags (eg. `<c:if>`/`</c:if>` tags) using [the `stripIndents()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/stripIndents.js).
+    5. Pad the block with a number of lines containing empty statements so that any errors reported by Prettier correspond to the source line numbers in the original JSP input, using [the `padLines()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/padLines.js).
+    6. Actually format the code via the Prettier API.
+    7. Remove the padding lines inserted in Step 5.
+    8. Swap out the placeholder items inserted in Step 3 for the original JSP tags, expressions and scriptlets, using [the `restoreTags()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/restoreTags.js).
+    9. Restore the base indent that was removed in Step 2, using [the `indent()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/indent.js).
+3. Generate a new source string by inserting the formatted script blocks in place of the original blocks.
+
+### Other files of interest
+
+-   [`Lexer.js`](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/Lexer.js): A generic class for defining lexers (tokenizers) that read an input string and produce a stream of tokens. This is used in the following places:
+    -   [`lex.js`](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/lex.js) Defines a `lex()` function specifically for lexing JSP input based on the JSP and XML specifications.
+    -   `stripIndents()` (linked above) uses a small lexer to find opening and closing JSP tags and strip away the indenting of their contents.
+    -   `restoreTags()` (also linked above) uses another small lexer to scan the formatted JS looking for placeholders that should be replaced with their original contents.
+-   [`toFiller.js`](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/toFiller.js): A function for transforming strings into replacement strings of a corresponding shape. This is used, for example, to create same-shaped JS comments that replace multi-line JSP tags.
+-   [`ReversibleMap.js`](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/ReversibleMap.js): An ES6 `Map` subclass that provides `checkpoint()`, `rollback()`, and `commit()` methods. It is used in the lexer to record arbitrary metadata, and rollback mutations made as the lexer explores possible alternative branches.

--- a/packages/liferay-npm-scripts/src/format/README.md
+++ b/packages/liferay-npm-scripts/src/format/README.md
@@ -4,7 +4,7 @@
 
 This document provides a brief table of contents for the main items in [the liferay-npm-scripts/src/format directory](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-npm-scripts/src/format), which is responsible for formatting JS inside JSP files.
 
-The main workhorse is [the `formatJSP()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/formatJSP.js), which takes a JSP source string and returns a string with that preserves the original contents of the JSP but with all the JS content formatted via Prettier. The operations are:
+The main workhorse is [the `formatJSP()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/formatJSP.js), which takes a JSP source string and returns a string that preserves the original contents of the JSP but with all the JS content formatted via Prettier. The operations are:
 
 1. Extract blocks of JS (ie. code inside `<script>` and `<aui:script>` tags) using [the `extractJS()` function](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/format/extractJS.js).
 2. For each block of JS:

--- a/packages/liferay-npm-scripts/src/format/dedent.js
+++ b/packages/liferay-npm-scripts/src/format/dedent.js
@@ -78,10 +78,9 @@ function dedent(input, tabWidth = 4) {
 		dedented.pop();
 	}
 
-	// Allow caller to check for last-found minimum.
-	dedent.lastMinimum = isFinite(minimum) ? Math.floor(minimum / tabWidth) : 0;
+	const lastMinimum = isFinite(minimum) ? Math.floor(minimum / tabWidth) : 0;
 
-	return dedented.join('\n');
+	return [dedented.join('\n'), lastMinimum];
 }
 
 module.exports = dedent;

--- a/packages/liferay-npm-scripts/src/format/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/format/formatJSP.js
@@ -55,8 +55,7 @@ function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 		);
 
 		// Strip base indent.
-		const dedented = dedent(trimmed);
-		const tabCount = dedent.lastMinimum;
+		const [dedented, tabCount] = dedent(trimmed);
 
 		// Turn JSP tags, expressions (etc) into (valid JS) placeholders.
 		const [substituted, tags] = substituteTags(dedented);

--- a/packages/liferay-npm-scripts/src/format/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/format/formatJSP.js
@@ -31,6 +31,11 @@ function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 		return null;
 	}
 
+	const prettierOptions = {
+		...prettierConfig,
+		parser: 'babel'
+	};
+
 	// TODO: lint for <(aui:)?script> not followed by newline (there are basically none in liferay-portal)
 	const transformed = blocks.map(block => {
 		const {contents, range} = block;
@@ -50,11 +55,7 @@ function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 		// Adjust line numbers for better error reporting.
 		const padded = padLines(stripped, range.start.line - 1);
 
-		const prettierOptions = {
-			...prettierConfig,
-			parser: 'babel'
-		};
-
+		// Actually format.
 		const formatted = prettier.format(padded, prettierOptions);
 
 		// Remove previously inserted padding lines.

--- a/packages/liferay-npm-scripts/src/format/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/format/formatJSP.js
@@ -13,6 +13,7 @@ const padLines = require('./padLines');
 const restoreTags = require('./restoreTags');
 const stripIndents = require('./stripIndents');
 const substituteTags = require('./substituteTags');
+const trim = require('./trim');
 
 const {PADDING_LINE} = padLines;
 
@@ -34,25 +35,8 @@ function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 	const transformed = blocks.map(block => {
 		const {contents, range} = block;
 
-		// Prettier will trim empty first and last lines, but we need to keep
-		// them around (need to preserve typical linebreak after opening tag,
-		// and the indent before closing tag, which is also typically
-		// on a line of its own).
-		let prefix = '';
-
-		let suffix = '';
-
-		const trimmed = contents.replace(
-			/^\s*(\r\n|\n)|(?:\r?\n)([ \t]*$)/g,
-			(match, leadingWhitespace, trailingWhitespace) => {
-				if (leadingWhitespace) {
-					prefix = leadingWhitespace;
-				} else if (trailingWhitespace) {
-					suffix = trailingWhitespace;
-				}
-				return match;
-			}
-		);
+		// Trim leading and trailing whitespace before Prettier eats it.
+		const {prefix, suffix, trimmed} = trim(contents);
 
 		// Strip base indent.
 		const [dedented, tabCount] = dedent(trimmed);

--- a/packages/liferay-npm-scripts/src/format/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/format/formatJSP.js
@@ -72,21 +72,20 @@ function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 		};
 	});
 
-	let result = source;
+	let result = '';
+	let lastIndex = 0;
 
-	for (let i = transformed.length - 1; i >= 0; i--) {
+	for (let i = 0; i < transformed.length; i++) {
 		const {closeTag, contents, openTag, range} = transformed[i];
 		const {index, length} = range;
 
-		result =
-			result.slice(0, index) +
-			openTag +
-			contents +
-			closeTag +
-			result.slice(index + length);
+		result +=
+			source.slice(lastIndex, index) + openTag + contents + closeTag;
+
+		lastIndex = index + length;
 	}
 
-	return result;
+	return result + source.slice(lastIndex);
 }
 
 module.exports = formatJSP;

--- a/packages/liferay-npm-scripts/src/format/index.js
+++ b/packages/liferay-npm-scripts/src/format/index.js
@@ -5,10 +5,10 @@
  */
 
 const fs = require('fs');
-const formatJSP = require('../format/formatJSP');
 const getPaths = require('../utils/getPaths');
 const getMergedConfig = require('../utils/getMergedConfig');
 const log = require('../utils/log');
+const formatJSP = require('./formatJSP');
 
 /**
  * File extensions that we want to process.

--- a/packages/liferay-npm-scripts/src/format/restoreTags.js
+++ b/packages/liferay-npm-scripts/src/format/restoreTags.js
@@ -21,7 +21,7 @@ function restoreTags(source, tags) {
 
 		const ANYTHING = match(/[\s\S]/);
 		const COMMENT = match(/\/\*.*?\*\//);
-		const TAG_REPLACEMENT = match(FILLER);
+		const SELF_CLOSING_TAG_REPLACEMENT = match(FILLER);
 		const CLOSE_TAG_REPLACEMENT = match(CLOSE_TAG);
 		const IDENTIFIER_REPLACEMENT = match(IDENTIFIER);
 		const OPEN_TAG_REPLACEMENT = match(OPEN_TAG);
@@ -30,7 +30,7 @@ function restoreTags(source, tags) {
 
 		return choose({
 			/* eslint-disable sort-keys */
-			TAG_REPLACEMENT,
+			SELF_CLOSING_TAG_REPLACEMENT,
 			OPEN_TAG_REPLACEMENT,
 			CLOSE_TAG_REPLACEMENT,
 			COMMENT,
@@ -64,7 +64,7 @@ function restoreTags(source, tags) {
 				break;
 
 			case 'IDENTIFIER_REPLACEMENT':
-			case 'TAG_REPLACEMENT':
+			case 'SELF_CLOSING_TAG_REPLACEMENT':
 				output += indent + tags[restoreCount++];
 				indent = '';
 				break;

--- a/packages/liferay-npm-scripts/src/format/tagReplacements.js
+++ b/packages/liferay-npm-scripts/src/format/tagReplacements.js
@@ -47,7 +47,7 @@ const validate = tag => {
 //
 //     <foo:tag attr="this">
 //                            ...becomes:
-//     /*ʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃ*>
+//     /*ʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃ*/
 //
 // Even the shortest possible tag has a same-length substitution:
 //

--- a/packages/liferay-npm-scripts/src/format/trim.js
+++ b/packages/liferay-npm-scripts/src/format/trim.js
@@ -1,0 +1,33 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Prettier will trim empty first and last lines, but we need to keep them
+ * around (to preserve the typical linebreak after an opening tag, and the
+ * indent before a closing tag, which is often on a line of its own).
+ */
+function trim(string) {
+	let prefix = '';
+
+	let suffix = '';
+
+	const trimmed = string.replace(
+		/^\s*(\r\n|\n)|(?:\r?\n)([ \t]*$)/g,
+		(match, leadingNewline, trailingHorizontalWhitespace) => {
+			if (leadingNewline) {
+				prefix = leadingNewline;
+			} else if (trailingHorizontalWhitespace) {
+				suffix = trailingHorizontalWhitespace;
+			}
+
+			return match;
+		}
+	);
+
+	return {prefix, suffix, trimmed};
+}
+
+module.exports = trim;

--- a/packages/liferay-npm-scripts/src/format/trim.js
+++ b/packages/liferay-npm-scripts/src/format/trim.js
@@ -23,7 +23,7 @@ function trim(string) {
 				suffix = trailingHorizontalWhitespace;
 			}
 
-			return match;
+			return '';
 		}
 	);
 

--- a/packages/liferay-npm-scripts/test/format/ReversibleMap.js
+++ b/packages/liferay-npm-scripts/test/format/ReversibleMap.js
@@ -13,22 +13,22 @@ describe('ReversibleMap()', () => {
 		map = new ReversibleMap([['a', 1], ['b', 2], ['c', 3]]);
 	});
 
-	describe('pending', () => {
+	describe('undo', () => {
 		it('is a list of operations that reverse previous mutations', () => {
 			map.set('d', 4);
 			map.set('a', 0);
 			map.delete('b');
 			map.clear();
 
-			expect(map.pending.length).toBe(4);
+			expect(map.undo.length).toBe(4);
 
 			expect([...map.entries()]).toEqual([]);
 
-			map.pending[3]();
+			map.undo[3]();
 
 			expect([...map.entries()]).toEqual([['a', 0], ['c', 3], ['d', 4]]);
 
-			map.pending[2]();
+			map.undo[2]();
 
 			expect([...map.entries()]).toEqual([
 				['a', 0],
@@ -37,7 +37,7 @@ describe('ReversibleMap()', () => {
 				['d', 4]
 			]);
 
-			map.pending[1]();
+			map.undo[1]();
 
 			expect([...map.entries()]).toEqual([
 				['a', 1],
@@ -46,7 +46,7 @@ describe('ReversibleMap()', () => {
 				['d', 4]
 			]);
 
-			map.pending[0]();
+			map.undo[0]();
 
 			expect([...map.entries()]).toEqual([['a', 1], ['b', 2], ['c', 3]]);
 		});
@@ -60,7 +60,7 @@ describe('ReversibleMap()', () => {
 			map.checkpoint();
 			map.set('f', 6);
 
-			expect(map.pending.length).toBe(5);
+			expect(map.undo.length).toBe(5);
 
 			expect([...map.entries()]).toEqual([
 				['a', 1],
@@ -74,7 +74,7 @@ describe('ReversibleMap()', () => {
 			// Goes as far back as previous checkpoint (the 2nd) and removes it.
 			map.rollback();
 
-			expect(map.pending.length).toBe(3);
+			expect(map.undo.length).toBe(3);
 
 			expect([...map.entries()]).toEqual([
 				['a', 1],
@@ -87,7 +87,7 @@ describe('ReversibleMap()', () => {
 			// Goes to previous checkpoint (the 1st) and removes it.
 			map.rollback();
 
-			expect(map.pending.length).toBe(1);
+			expect(map.undo.length).toBe(1);
 
 			expect([...map.entries()]).toEqual([
 				['a', 1],
@@ -99,7 +99,7 @@ describe('ReversibleMap()', () => {
 			// Completely flushes the queue (no more checkpoints).
 			map.rollback();
 
-			expect(map.pending.length).toBe(0);
+			expect(map.undo.length).toBe(0);
 
 			expect([...map.entries()]).toEqual([['a', 1], ['b', 2], ['c', 3]]);
 		});
@@ -108,7 +108,7 @@ describe('ReversibleMap()', () => {
 			map.set('d', 4);
 			map.checkpoint();
 
-			expect(map.pending.length).toBe(2);
+			expect(map.undo.length).toBe(2);
 
 			expect([...map.entries()]).toEqual([
 				['a', 1],
@@ -119,7 +119,7 @@ describe('ReversibleMap()', () => {
 
 			map.rollback();
 
-			expect(map.pending.length).toBe(1);
+			expect(map.undo.length).toBe(1);
 
 			expect([...map.entries()]).toEqual([
 				['a', 1],
@@ -130,7 +130,7 @@ describe('ReversibleMap()', () => {
 
 			map.rollback();
 
-			expect(map.pending.length).toBe(0);
+			expect(map.undo.length).toBe(0);
 
 			expect([...map.entries()]).toEqual([['a', 1], ['b', 2], ['c', 3]]);
 		});

--- a/packages/liferay-npm-scripts/test/format/dedent.js
+++ b/packages/liferay-npm-scripts/test/format/dedent.js
@@ -8,27 +8,30 @@ const dedent = require('../../src/format/dedent');
 
 describe('dedent()', () => {
 	it('dedents based on the smallest existing indent (spaces)', () => {
-		expect(dedent('  def foo\n    1\n  end')).toBe('def foo\n  1\nend');
+		const [dedented] = dedent('  def foo\n    1\n  end');
+
+		expect(dedented).toBe('def foo\n  1\nend');
 	});
 
 	it('dedents based on the smallest existing indent (tabs)', () => {
-		expect(dedent('\t\tdef foo\n\t\t\t1\n\t\tend')).toBe(
-			'def foo\n\t1\nend'
-		);
+		const [dedented] = dedent('\t\tdef foo\n\t\t\t1\n\t\tend');
+
+		expect(dedented).toBe('def foo\n\t1\nend');
 	});
 
 	it('handles mixed tabs and spaces', () => {
-		// Common, for example, in source with multiline comments.
-		expect(
-			dedent(`
+		// Mixed tabs and spaces are common, for example, in source with
+		// multiline comments.
+		const [dedented] = dedent(`
 			/**
 			 * This is a comment.
 			 */
 			function fn() {
 				return arguments;
 			}
-		`)
-		).toBe(
+		`);
+
+		expect(dedented).toBe(
 			// prettier-ignore
 			'/**\n' +
 			' * This is a comment.\n' +
@@ -40,42 +43,42 @@ describe('dedent()', () => {
 	});
 
 	it('accepts a custom tabWidth argument', () => {
-		expect(
-			dedent(
-				`
+		const [dedented] = dedent(
+			`
 			function fn() {
 				return;
-	        	} // tab, 8 spaces, tab
+	        	} // tab, 8 spaces, tab, a brace
 		`,
-				8
-			)
-		).toBe(
+			8
+		);
+
+		expect(dedented).toBe(
 			// prettier-ignore
 			'function fn() {\n' +
 			'\treturn;\n' +
-			'} // tab, 8 spaces, tab'
+			'} // tab, 8 spaces, tab, a brace'
 		);
 	});
 
 	it('exposes the minimum indent (tab count) from the last call', () => {
-		dedent('no indent');
+		let [, lastMinimum] = dedent('no indent');
 
-		expect(dedent.lastMinimum).toBe(0);
+		expect(lastMinimum).toBe(0);
 
-		dedent('  less than one tab indent');
+		[, lastMinimum] = dedent('  less than one tab indent');
 
-		expect(dedent.lastMinimum).toBe(0);
+		expect(lastMinimum).toBe(0);
 
-		dedent('\tone tab indent');
+		[, lastMinimum] = dedent('\tone tab indent');
 
-		expect(dedent.lastMinimum).toBe(1);
+		expect(lastMinimum).toBe(1);
 
-		dedent('\t  "1.5" tabs indent');
+		[, lastMinimum] = dedent('\t  "1.5" tabs indent');
 
-		expect(dedent.lastMinimum).toBe(1);
+		expect(lastMinimum).toBe(1);
 
-		dedent('\t\ttwo tabs indent');
+		[, lastMinimum] = dedent('\t\ttwo tabs indent');
 
-		expect(dedent.lastMinimum).toBe(2);
+		expect(lastMinimum).toBe(2);
 	});
 });

--- a/packages/liferay-npm-scripts/test/format/formatJSP.js
+++ b/packages/liferay-npm-scripts/test/format/formatJSP.js
@@ -74,6 +74,23 @@ describe('formatJSP()', () => {
 		expect(() => formatJSP(source)).toThrow(/Unexpected token \(17:1\)/);
 	});
 
+	it('trims unwanted leading blank lines', () => {
+		const source = `
+			<aui:script require="metal-dom/src/dom">
+
+				var dom = metalDomSrcDom.default;
+			</aui:script>
+		`;
+
+		const expected = `
+			<aui:script require="metal-dom/src/dom">
+				var dom = metalDomSrcDom.default;
+			</aui:script>
+		`;
+
+		expect(formatJSP(source)).toBe(expected);
+	});
+
 	describe('formatting entire fixtures', () => {
 		test.each([
 			'configuration.jsp',

--- a/packages/liferay-npm-scripts/test/format/stripIndents.js
+++ b/packages/liferay-npm-scripts/test/format/stripIndents.js
@@ -25,6 +25,8 @@ describe('stripIndents()', () => {
 			</my:tag>
 		`);
 
+		const stripped = stripIndents(source);
+
 		const expected = `
 			//ʃʃʃʃʃʃ
 			var x = 1;
@@ -40,8 +42,6 @@ describe('stripIndents()', () => {
 			var y = 1;
 			/*ʅʅʅʅʅ*/
 		`;
-
-		const stripped = stripIndents(source);
 
 		expect(stripped).toBe(expected);
 	});

--- a/packages/liferay-npm-scripts/test/format/trim.js
+++ b/packages/liferay-npm-scripts/test/format/trim.js
@@ -14,7 +14,7 @@ describe('trim()', () => {
 		expect(trim(input)).toEqual({
 			prefix: '\n',
 			suffix: '',
-			trimmed: '\n\t\t\talert();'
+			trimmed: '\t\t\talert();'
 		});
 	});
 
@@ -25,7 +25,7 @@ describe('trim()', () => {
 		expect(trim(input)).toEqual({
 			prefix: '',
 			suffix: '\t\t',
-			trimmed: 'alert();\n\t\t'
+			trimmed: 'alert();'
 		});
 	});
 
@@ -37,7 +37,7 @@ describe('trim()', () => {
 		expect(trim(input)).toEqual({
 			prefix: '\n',
 			suffix: '\t\t',
-			trimmed: '\n\t\t\talert();\n\t\t'
+			trimmed: '\t\t\talert();'
 		});
 	});
 

--- a/packages/liferay-npm-scripts/test/format/trim.js
+++ b/packages/liferay-npm-scripts/test/format/trim.js
@@ -1,0 +1,51 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const trim = require('../../src/format/trim');
+
+describe('trim()', () => {
+	it('trims leading whitespace', () => {
+		const input = `
+			alert();`;
+
+		expect(trim(input)).toEqual({
+			prefix: '\n',
+			suffix: '',
+			trimmed: '\n\t\t\talert();'
+		});
+	});
+
+	it('trims trailing whitespace', () => {
+		const input = `alert();
+		`;
+
+		expect(trim(input)).toEqual({
+			prefix: '',
+			suffix: '\t\t',
+			trimmed: 'alert();\n\t\t'
+		});
+	});
+
+	it('trims both leading and trailing whitespace', () => {
+		const input = `
+			alert();
+		`;
+
+		expect(trim(input)).toEqual({
+			prefix: '\n',
+			suffix: '\t\t',
+			trimmed: '\n\t\t\talert();\n\t\t'
+		});
+	});
+
+	it('trims nothing when there is nothing to trim', () => {
+		expect(trim('alert();')).toEqual({
+			prefix: '',
+			suffix: '',
+			trimmed: 'alert();'
+		});
+	});
+});


### PR DESCRIPTION
Going to implement some small improvements based on walking through the JSP-formatting code with @julien. ~I have to go, but will finish this later. Still to do:~

- [x] See if the loop at the end of `formatJSP` can do its thing in one pass instead of multiple.
- [x] ~Make unique attribute validity check looser (check names with duplicate values instead of unique names).~ (this was right as it was)
- [x] ~Rename `support/dedent.js` to avoid confusion with the other dedent.~ (I am struggling to come up with a better name, so 🤷‍♂)
- [x] Add a README.