### PR TITLE
fix: make release commit messages satisfy Semantic Pull Requests bot

### DIFF
--- a/packages/liferay-changelog-generator/.yarnrc
+++ b/packages/liferay-changelog-generator/.yarnrc
@@ -1,3 +1,3 @@
 # Make `yarn version` produce the right commit message and tag for this package.
 version-tag-prefix "liferay-changelog-generator/v"
-version-git-message "liferay-changelog-generator/v%s"
+version-git-message "chore: prepare liferay-changelog-generator/v%s"

--- a/packages/liferay-jest-junit-reporter/.yarnrc
+++ b/packages/liferay-jest-junit-reporter/.yarnrc
@@ -1,3 +1,3 @@
 # Make `yarn version` produce the right commit message and tag for this package.
 version-tag-prefix "liferay-jest-junit-reporter/v"
-version-git-message "liferay-jest-junit-reporter/v%s"
+version-git-message "chore: prepare liferay-jest-junit-reporter/v%s"

--- a/packages/liferay-npm-bundler-preset-liferay-dev/.yarnrc
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/.yarnrc
@@ -1,3 +1,3 @@
 # Make `yarn version` produce the right commit message and tag for this package.
 version-tag-prefix "liferay-npm-bundler-preset-liferay-dev/v"
-version-git-message "liferay-npm-bundler-preset-liferay-dev/v%s"
+version-git-message "chore: prepare liferay-npm-bundler-preset-liferay-dev/v%s"

--- a/packages/liferay-npm-scripts/.yarnrc
+++ b/packages/liferay-npm-scripts/.yarnrc
@@ -1,3 +1,3 @@
 # Make `yarn version` produce the right commit message and tag for this package.
 version-tag-prefix "liferay-npm-scripts/v"
-version-git-message "liferay-npm-scripts/v%s"
+version-git-message "chore: prepare liferay-npm-scripts/v%s"


### PR DESCRIPTION
It will complain if there is no "type:" prefix in the release commit message.

Example here:

https://github.com/liferay/liferay-npm-tools/pull/263