### PR TITLE
feat: extract liferay-js-publish package

### DIFF
--- a/packages/liferay-changelog-generator/package.json
+++ b/packages/liferay-changelog-generator/package.json
@@ -18,7 +18,7 @@
 		"directory": "packages/liferay-changelog-generator"
 	},
 	"scripts": {
-		"postversion": "node ../../publish.js",
+		"postversion": "node ../liferay-js-publish/bin/liferay-js-publish.js",
 		"preversion": "cd ../.. && yarn ci",
 		"test": "echo 'No tests currently defined for liferay-changelog-generator'"
 	},

--- a/packages/liferay-jest-junit-reporter/package.json
+++ b/packages/liferay-jest-junit-reporter/package.json
@@ -4,7 +4,7 @@
 	"description": "A JUnit reporter for Jest and Liferay CI",
 	"main": "src/index.js",
 	"scripts": {
-		"postversion": "node ../../publish.js",
+		"postversion": "node ../liferay-js-publish/bin/liferay-js-publish.js",
 		"preversion": "cd ../.. && yarn ci",
 		"test": "jest"
 	},

--- a/packages/liferay-js-publish/.yarnrc
+++ b/packages/liferay-js-publish/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "liferay-js-publish/v"
+version-git-message "chore: prepare liferay-js-publish/v%s"

--- a/packages/liferay-js-publish/README.md
+++ b/packages/liferay-js-publish/README.md
@@ -11,11 +11,16 @@ Simplifying assumptions:
 
 ## Installation
 
+### 1. Install the package
+
 Either:
 
 -   Install globally: `yarn global add liferay-js-publish`; or:
 -   Add to a project: `yarn add --dev liferay-js-publish`; or:
--   Use the latest without installing: `npx liferay-js-publish`.
+
+Note that you can also just use the latest without installing (ie. via `npx liferay-js-publish`). It is safe to use liferay-js-publish as an implicit dependency because we control the package, we maintain all the projects that use the package, and we won't make any breaking changes (or at least, we won't make any undetected breaking changes).
+
+### 2. Create a ".yarnrc" file
 
 Ensure you have a ".yarnrc" file in your package root declaring the desired commit message and tag format. For example, in a monorepo, you probably want to include the package name:
 
@@ -31,9 +36,9 @@ version-tag-prefix "v"
 version-git-message "chore: prepape v%s release"
 ```
 
-## Usage
+If you don't have a ".yarnrc" file, liferay-js-publish will warn you during publishing and require you to type "y" in order to continue.
 
-### 1. Add liferay-js-publish from a "postversion" script in your "package.json".
+### 3. Add liferay-js-publish from a "postversion" script in your "package.json".
 
 Assuming you have a "ci" script that runs tests, you should call that in your "preversion" script as well:
 
@@ -47,7 +52,11 @@ Assuming you have a "ci" script that runs tests, you should call that in your "p
 }
 ```
 
-### 2. Prepare and release a new version with `yarn version`
+If you don't have "preversion" and "postversion" scripts, liferay-js-publish will warn you during publishing and require you to type "y" in order to continue.
+
+## Usage
+
+Prepare and release a new version with `yarn version`
 
 ```
 # Either:

--- a/packages/liferay-js-publish/README.md
+++ b/packages/liferay-js-publish/README.md
@@ -1,0 +1,69 @@
+# liferay-js-publish
+
+> A script for publishing an NPM package via `yarn version`.
+
+Simplifying assumptions:
+
+-   You are working in a repository that uses Yarn
+-   You develop on the "master" branch and update "stable" whenever you do a release
+-   You publish using `yarn version`
+-   You are millennial (or pretend to be) and expect your tools to use emoji 😎
+
+## Installation
+
+Either:
+
+-   Install globally: `yarn global add liferay-js-publish`; or:
+-   Add to a project: `yarn add --dev liferay-js-publish`; or:
+-   Use the latest without installing: `npx liferay-js-publish`.
+
+Ensure you have a ".yarnrc" file in your package root declaring the desired commit message and tag format. For example, in a monorepo, you probably want to include the package name:
+
+```
+version-tag-prefix "liferay-fancy-package/v"
+version-git-message "chore: prepape liferay-fancy-package/v%s"
+```
+
+In a single-package repo, something like this might be more appropriate:
+
+```
+version-tag-prefix "v"
+version-git-message "chore: prepape v%s release"
+```
+
+## Usage
+
+### 1. Add liferay-js-publish from a "postversion" script in your "package.json".
+
+Assuming you have a "ci" script that runs tests, you should call that in your "preversion" script as well:
+
+```
+{
+    "scripts": {
+      "ci": "yarn lint && yarn format:check && yarn test",
+      "preversion": "yarn ci"
+      "postversion": "npx liferay-js-publish"
+    }
+}
+```
+
+### 2. Prepare and release a new version with `yarn version`
+
+```
+# Either:
+yarn version --patch # or --minor, or --major
+
+# Or:
+yarn version --new-version x.y.z
+```
+
+## Origins
+
+This was [originally](https://github.com/liferay/liferay-npm-tools/commit/ce2db371cce6fb2fbfbe7795dfe8807cd682e959#diff-d5ba1d0718faa51781762ae13a1c1a4a) just a `publish.js` script in the root of [the liferay-npm-tools repository](https://github.com/liferay/liferay-npm-tools).
+
+Similar to what we did with [liferay-changelog-generator](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-changelog-generator), we extracted it into an NPM package so that it could be used from other projects, such as [eslint-config-liferay](https://github.com/liferay/eslint-config-liferay). The intention for it is to be a very small script with (almost) no dependencies.
+
+## Example projects using liferay-js-publish
+
+-   [eslint-config-liferay](https://github.com/liferay/eslint-config-liferay)
+-   [liferay-npm-tools](https://github.com/liferay/liferay-npm-tools)

--- a/packages/liferay-js-publish/bin/liferay-js-publish.js
+++ b/packages/liferay-js-publish/bin/liferay-js-publish.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+require('../src');

--- a/packages/liferay-js-publish/package.json
+++ b/packages/liferay-js-publish/package.json
@@ -1,0 +1,29 @@
+{
+	"bin": {
+		"liferay-js-publish": "./bin/liferay-js-publish.js"
+	},
+	"description": "Publishes an NPM package via \"yarn version\"",
+	"files": [
+		"bin",
+		"src"
+	],
+	"homepage": "https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-js-publish",
+	"license": "BSD-3-Clause",
+	"main": "index.js",
+	"name": "liferay-js-publish",
+	"private": false,
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-npm-tools",
+		"directory": "packages/liferay-js-publish"
+	},
+	"scripts": {
+		"postversion": "node bin/liferay-js-publish.js",
+		"preversion": "cd ../.. && yarn ci",
+		"test": "echo 'No tests currently defined for liferay-js-publish'"
+	},
+	"version": "0.0.1",
+	"dependencies": {
+		"cross-spawn": "^6.0.5"
+	}
+}

--- a/packages/liferay-js-publish/src/git.js
+++ b/packages/liferay-js-publish/src/git.js
@@ -1,0 +1,16 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const run = require('./run');
+
+/**
+ * Convenience helper for running Git commands.
+ */
+function git(...args) {
+	return run('git', ...args);
+}
+
+module.exports = git;

--- a/packages/liferay-js-publish/src/index.js
+++ b/packages/liferay-js-publish/src/index.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * © 2019 Liferay, Inc. <https://liferay.com>
  *
@@ -9,9 +7,8 @@
 const fs = require('fs');
 const {createInterface} = require('readline');
 
-const git = require('./packages/liferay-npm-scripts/src/utils/git');
-const log = require('./packages/liferay-npm-scripts/src/utils/log');
-const run = require('./packages/liferay-npm-scripts/src/utils/run');
+const git = require('./git');
+const run = require('./run');
 
 /**
  * Intended to be run as a "postversion" script to publish the new version
@@ -157,7 +154,8 @@ function getRemote() {
 }
 
 function printBanner(...lines) {
-	log(['', ...lines, ''].join('\n\n'));
+	// eslint-disable-next-line no-console
+	console.log(['', ...lines, ''].join('\n\n'));
 }
 
 let exitStatus = 0;

--- a/packages/liferay-js-publish/src/run.js
+++ b/packages/liferay-js-publish/src/run.js
@@ -1,0 +1,36 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {spawn} = require('cross-spawn');
+
+/**
+ * Convenience helper for running commands.
+ */
+function run(executable, ...args) {
+	const command = `${executable} ${args.join(' ')}`;
+
+	const {error, signal, status, stdout} = spawn.sync(executable, args);
+
+	if (error) {
+		throw error;
+	}
+
+	if (signal) {
+		throw new Error(
+			`run(): command \`${command}\` exited due to signal ${signal}`
+		);
+	}
+
+	if (status) {
+		throw new Error(
+			`run(): command \`${command}\` exited with status ${status}`
+		);
+	}
+
+	return stdout.toString().trim();
+}
+
+module.exports = run;

--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -20,7 +20,7 @@
 		"directory": "packages/liferay-npm-bundler-preset-liferay-dev"
 	},
 	"scripts": {
-		"postversion": "node ../../publish.js",
+		"postversion": "node ../liferay-js-publish/bin/liferay-js-publish.js",
 		"preversion": "cd ../.. && yarn ci",
 		"test": "echo 'No tests currently defined for liferay-npm-bundler-preset-liferay-dev'"
 	}

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -65,7 +65,7 @@
 		"directory": "packages/liferay-npm-scripts"
 	},
 	"scripts": {
-		"postversion": "node ../../publish.js",
+		"postversion": "node ../liferay-js-publish/bin/liferay-js-publish.js",
 		"preversion": "cd ../.. && yarn ci",
 		"test": "jest"
 	},


### PR DESCRIPTION
As explained in the README.md, this is just packaging up the existing publish.js script so that it can be used from other projects.

Its only dependency is "cross-spawn": 7.0.0 is out and would be a safe upgrade for us, but it doesn't offer anything that we need (all it does is drop support for old NodeJS versions), so let's stick with "^6.0.5", which is what we're already using in liferay-npm-scripts, so as to avoid unnecessary duplication.

Speaking of duplication, the other thing you'll note is that I have a copy-paste of "git.js" and "run.js" in here from "liferay-npm-scripts". It is only a few lines of trivial code, and avoiding the dependency here is desirable because keeping dependencies in sync, even our own, is a headache.