### PR TITLE
fix(publish): loosen upstream remote regex

### DIFF
--- a/packages/liferay-js-publish/src/index.js
+++ b/packages/liferay-js-publish/src/index.js
@@ -142,7 +142,7 @@ function confirm(prompt, answer = 'y', matcher = YES_REGEX) {
 	return promise;
 }
 
-const UPSTREAM_REPO_REGEX = /\bgithub\.com[/:]liferay\/liferay-npm-tools(?:\.git)?/i;
+const UPSTREAM_REPO_REGEX = /\bgithub\.com[/:]liferay\/[a-z-]+(?:\.git)?/i;
 
 function getRemote() {
 	const remotes = git('remote', '-v').split('\n');


### PR DESCRIPTION
When testing this with eslint-config-liferay, discovered that we were being juuuuust a little bit too strict in here.

This won't catch repos under the Metal org, but basically everything that we're actively developing is under "liferay/" so this is probably good.