### PR TITLE
chore(scripts): send build output to "build" instead of "classes" (#272)

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -261,7 +261,7 @@
 		"semver": true,
 		"source-map": true
 	},
-	"output": "classes/META-INF/resources/",
+	"output": "build/node/packageRunBuild/resources",
 	"rules": [
 		{
 			"test": "\\.scss$",

--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -14,7 +14,7 @@ module.exports = {
 	build: {
 		dependencies: [...clay, ...liferay, ...metal],
 		input: 'src/main/resources/META-INF/resources',
-		output: 'classes/META-INF/resources'
+		output: 'build/node/packageRunBuild/resources'
 	},
 	check: [...JS_GLOBS, '{src,test}/**/*.scss'],
 	fix: [...JS_GLOBS, '{src,test}/**/*.scss'],


### PR DESCRIPTION
As per: https://github.com/liferay/liferay-npm-tools/issues/272