### PR TITLE
feat: add reminder to publish liferay-npm-scripts

### DIFF
--- a/packages/liferay-jest-junit-reporter/package.json
+++ b/packages/liferay-jest-junit-reporter/package.json
@@ -4,6 +4,7 @@
 	"description": "A JUnit reporter for Jest and Liferay CI",
 	"main": "src/index.js",
 	"scripts": {
+		"postpublish": "echo '***'; echo 'NOTE: Remember to update and publish liferay-npm-scripts'; echo '***'",
 		"postversion": "node ../liferay-js-publish/bin/liferay-js-publish.js",
 		"preversion": "cd ../.. && yarn ci",
 		"test": "jest"

--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -20,6 +20,7 @@
 		"directory": "packages/liferay-npm-bundler-preset-liferay-dev"
 	},
 	"scripts": {
+		"postpublish": "echo '***'; echo 'NOTE: Remember to update and publish liferay-npm-scripts'; echo '***'",
 		"postversion": "node ../liferay-js-publish/bin/liferay-js-publish.js",
 		"preversion": "cd ../.. && yarn ci",
 		"test": "echo 'No tests currently defined for liferay-npm-bundler-preset-liferay-dev'"


### PR DESCRIPTION
Any time we update the reporter or the preset we have to update the scripts as well, because the latter depends on the first two.

Just insert a little, low-tech reminder to do so.

That wouldn't have stopped me from making the mistake that a just made though: we'll need something more for that:

1. Made changes to preset and scripts.
2. Published scripts v10.0.0.
3. Realized error, published preset v2.0.0.
4. Updated scripts dependency on preset.
5. Published scripts v10.0.1.

We'll need a bit more logic and automation to catch/prevent that kind of mistake.