### PR TITLE
feat(scripts): substitute goog.getMsg() calls in soy files (#277)

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -38,7 +38,6 @@
 		"deepmerge": "^4.0.0",
 		"eslint": "6.1.0",
 		"eslint-config-liferay": "9.0.0",
-		"glob": "^7.1.3",
 		"http-proxy-middleware": "^0.19.1",
 		"jest": "^24.5.0",
 		"jest-fetch-mock": "^2.1.2",

--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -14,7 +14,7 @@ const getMergedConfig = require('../utils/getMergedConfig');
 const moveToTemp = require('../utils/moveToTemp');
 const removeFromTemp = require('../utils/removeFromTemp');
 const setEnv = require('../utils/setEnv');
-const {buildSoy, cleanSoy, soyExists} = require('../utils/soy');
+const {buildSoy, cleanSoy, translateSoy, soyExists} = require('../utils/soy');
 const spawnSync = require('../utils/spawnSync');
 const validateConfig = require('../utils/validateConfig');
 const withBabelConfig = require('../utils/withBabelConfig');
@@ -99,6 +99,8 @@ module.exports = function() {
 	}
 
 	runBundler();
+
+	translateSoy(BUILD_CONFIG.output);
 
 	if (fs.existsSync(path.join(CWD, '.npmbridgerc'))) {
 		runBridge();

--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -56,7 +56,9 @@ function translateSoy(directory) {
 	files.forEach(file => {
 		const contents = fs.readFileSync(file, 'utf8');
 
-		const updated = contents.replace(EXTERNAL_MSG_REGEX, (match, p1, p2, p3) => {
+		const updated = contents.replace(
+			EXTERNAL_MSG_REGEX,
+			(match, p1, p2, p3) => {
 				let externalMsg = match.replace(
 					EXTERNAL_MSG_REGEX,
 					`var $1 = Liferay.Language.get('$2');`
@@ -69,7 +71,8 @@ function translateSoy(directory) {
 				}
 
 				return externalMsg;
-			})
+			}
+		);
 
 		if (contents !== updated) {
 			changedFiles++;
@@ -80,7 +83,9 @@ function translateSoy(directory) {
 	if (changedFiles) {
 		const objects = changedFiles === 1 ? 'file' : 'files';
 
-		log(`Updated goog.getMsg() -> Liferay.Language.get() in ${changedFiles} ${objects}`);
+		log(
+			`Updated goog.getMsg() -> Liferay.Language.get() in ${changedFiles} ${objects}`
+		);
 	}
 }
 
@@ -89,11 +94,11 @@ function translateSoy(directory) {
  */
 function soyExists() {
 	return !!expandGlobs([path.join(BUILD_CONFIG.input, '**/*.soy')]).length;
-};
+}
 
 module.exports = {
 	buildSoy,
 	cleanSoy,
 	soyExists,
-	translateSoy,
+	translateSoy
 };

--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -5,9 +5,9 @@
  */
 
 const fs = require('fs');
-const glob = require('glob');
 const path = require('path');
 
+const expandGlobs = require('./expandGlobs');
 const getMergedConfig = require('./getMergedConfig');
 const generateSoyDependencies = require('./generateSoyDependencies');
 const log = require('./log');
@@ -45,7 +45,7 @@ const EXTERNAL_MSG_REGEX = /var (MSG_EXTERNAL_\d+(?:\$\$\d+)?) = goog\.getMsg\(\
  * `--externalMsgFormat` option above.
  */
 function translateSoy(directory) {
-	const files = glob.sync(path.join(directory, '**/*.soy.js'));
+	const files = expandGlobs([path.join(directory, '**/*.soy.js')]);
 
 	if (!files.length) {
 		return;
@@ -88,7 +88,7 @@ function translateSoy(directory) {
  * Checks to see if there are any soy files
  */
 function soyExists() {
-	return !!glob.sync(path.join(BUILD_CONFIG.input, '**/*.soy')).length;
+	return !!expandGlobs([path.join(BUILD_CONFIG.input, '**/*.soy')]).length;
 };
 
 module.exports = {

--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -4,37 +4,96 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+const fs = require('fs');
 const glob = require('glob');
 const path = require('path');
 
 const getMergedConfig = require('./getMergedConfig');
 const generateSoyDependencies = require('./generateSoyDependencies');
+const log = require('./log');
 const spawnSync = require('./spawnSync');
 
 const BUILD_CONFIG = getMergedConfig('npmscripts', 'build');
 
 /**
- * Removes any generated soy.js files
- */
-exports.cleanSoy = function() {
-	spawnSync('rimraf', ['src/**/*.soy.js']);
-};
-
-/**
  * Compiles soy files by running `metalsoy` bin with specified soy dependencies
  */
-exports.buildSoy = function() {
+function buildSoy() {
 	spawnSync('metalsoy', [
 		'--soyDeps',
 		generateSoyDependencies(BUILD_CONFIG.dependencies),
 		'--externalMsgFormat',
 		"Liferay.Language.get('$2')"
 	]);
-};
+}
+
+/**
+ * Removes any generated soy.js files
+ */
+function cleanSoy() {
+	spawnSync('rimraf', ['src/**/*.soy.js']);
+}
+
+const EXTERNAL_MSG_REGEX = /var (MSG_EXTERNAL_\d+(?:\$\$\d+)?) = goog\.getMsg\(\s*'([\w,-{}$]+)'\s*(?:,\s*\{([\s\S]+?)\})?\);/g;
+
+/**
+ * Scans soy files in `directory` replacing calls to `goog.getMsg()`
+ * with calls to `Liferay.Language.get()`.
+ *
+ * This covers compiled soy that comes in via NPM modules (eg. Clay v2.0
+ * packages); in-tree soy is handled by `buildSoy()` and the
+ * `--externalMsgFormat` option above.
+ */
+function translateSoy(directory) {
+	const files = glob.sync(path.join(directory, '**/*.soy.js'));
+
+	if (!files.length) {
+		return;
+	}
+
+	let changedFiles = 0;
+
+	files.forEach(file => {
+		const contents = fs.readFileSync(file, 'utf8');
+
+		const updated = contents.replace(EXTERNAL_MSG_REGEX, (match, p1, p2, p3) => {
+				let externalMsg = match.replace(
+					EXTERNAL_MSG_REGEX,
+					`var $1 = Liferay.Language.get('$2');`
+				);
+
+				if (p3) {
+					externalMsg = externalMsg.replace(/\{\$[^}]+}/g, 'x');
+
+					externalMsg = externalMsg += `\n\t${p1} = ${p1}.replace(/{(\\d+)}/g, '\\x01$1\\x01');\n`;
+				}
+
+				return externalMsg;
+			})
+
+		if (contents !== updated) {
+			changedFiles++;
+			fs.writeFileSync(file, updated);
+		}
+	});
+
+	if (changedFiles) {
+		const objects = changedFiles === 1 ? 'file' : 'files';
+
+		log(`Updated goog.getMsg() -> Liferay.Language.get() in ${changedFiles} ${objects}`);
+	}
+}
 
 /**
  * Checks to see if there are any soy files
  */
-exports.soyExists = function() {
-	return !!glob.sync(path.join(BUILD_CONFIG.input, '/**/*.soy')).length;
+function soyExists() {
+	return !!glob.sync(path.join(BUILD_CONFIG.input, '**/*.soy')).length;
+};
+
+module.exports = {
+	buildSoy,
+	cleanSoy,
+	soyExists,
+	translateSoy,
 };

--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -91,6 +91,8 @@ function translateSoy(directory) {
 				 *          /{(\d+)}/g,
 				 *          '\x01$1\x01'
 				 *      );
+				 *
+				 * @see https://github.com/google/closure-templates/blob/514a6381287d732e41fcab660305ebf33920a42f/java/src/com/google/template/soy/incrementaldomsrc/AssistantForHtmlMsgs.java#L105-L139
 				 */
 				if (params) {
 					externalMsg = externalMsg.replace(/\{\$[^}]+}/g, 'x');


### PR DESCRIPTION
Test plan: copied this over to liferay-portal and ran a build in frontend-taglib-clay. Saw this output:

    $ liferay-npm-scripts build
    Using NODE_ENV: "production"
    Compiling soy
    Generated src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.soy.js
    Finished compiling soy
    Successfully compiled 2 files with Babel.
    Bundling took 1s
    Updated goog.getMsg() -> Liferay.Language.get() in 34 files
    ✨  Done in 5.69s.

In the output folder, you can see changes like this:

    var MSG_EXTERNAL_2532519427604455359 = Liferay.Language.get('select-items');

going to:

    var MSG_EXTERNAL_2532519427604455359 = goog.getMsg('select-items');

That sample from:

    frontend-taglib-clay$clay-management-toolbar@2.18.1/src/ClayManagementToolbar.soy.js

Closes: https://github.com/liferay/liferay-npm-tools/issues/277