### PR TITLE
fix(scripts): make soy.js correctly expand globs on Windows

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -45,7 +45,7 @@ const EXTERNAL_MSG_REGEX = /var (MSG_EXTERNAL_\d+(?:\$\$\d+)?) = goog\.getMsg\(\
  * `--externalMsgFormat` option above.
  */
 function translateSoy(directory) {
-	const files = expandGlobs([path.join(directory, '**/*.soy.js')]);
+	const files = expandGlobs([path.posix.join(directory, '**/*.soy.js')]);
 
 	if (!files.length) {
 		return;
@@ -123,7 +123,8 @@ function translateSoy(directory) {
  * Checks to see if there are any soy files
  */
 function soyExists() {
-	return !!expandGlobs([path.join(BUILD_CONFIG.input, '**/*.soy')]).length;
+	return !!expandGlobs([path.posix.join(BUILD_CONFIG.input, '**/*.soy')])
+		.length;
 }
 
 module.exports = {


### PR DESCRIPTION
Addresses the failure to translate soy files reported here:

https://github.com/petershin/liferay-portal/pull/724#issuecomment-537253992