### PR TITLE
feat(scripts): support "export namespace from" in Babel

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -17,6 +17,7 @@
 	"dependencies": {
 		"@babel/cli": "^7.2.3",
 		"@babel/plugin-proposal-class-properties": "7.4.4",
+		"@babel/plugin-proposal-export-namespace-from": "7.5.2",
 		"@babel/plugin-proposal-object-rest-spread": "7.4.4",
 		"@babel/preset-env": "^7.4.2",
 		"@babel/preset-react": "7.0.0",

--- a/packages/liferay-npm-scripts/src/config/babel.json
+++ b/packages/liferay-npm-scripts/src/config/babel.json
@@ -2,6 +2,7 @@
 	"presets": ["@babel/preset-env"],
 	"plugins": [
 		"@babel/proposal-class-properties",
+		"@babel/plugin-proposal-export-namespace-from",
 		"@babel/proposal-object-rest-spread"
 	],
 	"overrides": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,6 +315,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-decorators" "^7.2.0"
 
+"@babel/plugin-proposal-export-namespace-from@7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.5.2.tgz#ccd5ed05b06d700688ff1db01a9dd27155e0d2a0"
+  integrity sha512-TKUdOL07anjZEbR1iSxb5WFh810KyObdd29XLFLGo1IDsSuGrjH3ouWSbAxHNmrVKzr9X71UYl2dQ7oGGcRp0g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-export-namespace-from" "^7.2.0"
+
 "@babel/plugin-proposal-json-strings@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
@@ -374,6 +382,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz#69c159ffaf4998122161ad8ebc5e6d1f55df8612"
   integrity sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-export-namespace-from@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.2.0.tgz#8d257838c6b3b779db52c0224443459bd27fb039"
+  integrity sha512-1zGA3UNch6A+A11nIzBVEaE3DDJbjfB+eLIcf0GGOh/BJr/8NxL3546MGhV/r0RhH4xADFIEso39TKCfEMlsGA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
This enables the `@babel/plugin-proposal-export-namespace-from` plugin:

https://babeljs.io/docs/en/next/babel-plugin-proposal-export-namespace-from.html

Which allows Babel to process:

    export * as X from './x';

This is proposal is at Stage 4:

https://github.com/tc39/proposal-export-ns-from

and got merged into ECMA-262 already:

https://github.com/tc39/ecma262/pull/1174

Without this, we can write the above example as:

    import * as X from './x';
    export {X};

which is ok, but obviously not as nice. Example commit where I'm employing exactly that workaround:

https://github.com/wincent/liferay-portal/pull/67/commits/f41f93d433b35e210b64731dd4bc6a21cb195234