### PR TITLE
fix(scripts): use canonical plugin name format

### DIFF
--- a/packages/liferay-npm-scripts/src/config/babel.json
+++ b/packages/liferay-npm-scripts/src/config/babel.json
@@ -2,7 +2,7 @@
 	"presets": ["@babel/preset-env"],
 	"plugins": [
 		"@babel/proposal-class-properties",
-		"@babel/plugin-proposal-export-namespace-from",
+		"@babel/proposal-export-namespace-from",
 		"@babel/proposal-object-rest-spread"
 	],
 	"overrides": [


### PR DESCRIPTION
Otherwise we'll throw an error (because we added code to require canonically formatted names in order to avoid unintended duplicate plugins when we merge configs).

      Error: checkBabelName(): expected
      "@babel/proposal-export-namespace-from", got
      "@babel/plugin-proposal-export-namespace-from"