### PR TITLE
refactor(scripts): use rimraf API directly (#284)

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -8,6 +8,7 @@ const CWD = process.cwd();
 
 const fs = require('fs');
 const path = require('path');
+const rimraf = require('rimraf');
 
 const SignalHandler = require('../utils/SignalHandler');
 const getMergedConfig = require('../utils/getMergedConfig');
@@ -99,7 +100,7 @@ function runBridge() {
 		const output = bridgeConfig[moduleKey].output;
 
 		if (output) {
-			spawnSync('rimraf', [`${output}/**/*.map`]);
+			rimraf.sync(`${output}/**/*.map`);
 		}
 	});
 }

--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -6,6 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const rimraf = require('rimraf');
 
 const expandGlobs = require('./expandGlobs');
 const getMergedConfig = require('./getMergedConfig');
@@ -31,7 +32,7 @@ function buildSoy() {
  * Removes any generated soy.js files
  */
 function cleanSoy() {
-	spawnSync('rimraf', ['src/**/*.soy.js']);
+	rimraf.sync('src/**/*.soy.js');
 }
 
 const EXTERNAL_MSG_REGEX = /var (MSG_EXTERNAL_\d+(?:\$\$\d+)?) = goog\.getMsg\(\s*'([\w,-{}$]+)'\s*(?:,\s*\{([\s\S]+?)\})?\);/g;


### PR DESCRIPTION
We can avoid the indirection of spawning a separate process with this small change.

Test plan: `yarn add` this to liferay-portal and do `yarn build` in a module that contains soy (eg. frontend-taglib-clay) and see that soy files are cleaned up from src directory after the build.

![ScreenFlow](https://user-images.githubusercontent.com/7074/66467497-d1ec0780-ea84-11e9-9fac-bddd01c1e4ad.gif)

Closes: https://github.com/liferay/liferay-npm-tools/issues/284