### PR TITLE
feat(scripts): update preset to latest (v2.1.0)

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -46,7 +46,7 @@
 		"liferay-lang-key-dev-loader": "^1.0.3",
 		"liferay-npm-bridge-generator": "2.13.3",
 		"liferay-npm-bundler": "2.13.3",
-		"liferay-npm-bundler-preset-liferay-dev": "2.0.1",
+		"liferay-npm-bundler-preset-liferay-dev": "2.1.0",
 		"liferay-theme-tasks": "9.4.0",
 		"metal-tools-soy": "4.3.2",
 		"minimist": "^1.2.0",


### PR DESCRIPTION
Labeling this as a feature because the new version of the preset makes new Clay modules available.

Note that I'm sending this against "master" but we have to cut a maintenance release that is basically "master" minus the changes to the build output directory (d539eca etc). I'll prepare that after this and will see which way looks less hideous; either some revert commits on master or another branch.