### PR TITLE
revert: "chore(scripts): send build output to "build" instead of "classes"

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -263,7 +263,7 @@
 		"semver": true,
 		"source-map": true
 	},
-	"output": "build/node/packageRunBuild/resources",
+	"output": "classes/META-INF/resources/",
 	"rules": [
 		{
 			"test": "\\.scss$",

--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "liferay-npm-bundler-preset-liferay-dev",
-	"version": "2.1.0",
+	"version": "3.0.0",
 	"description": "Default configuration for liferay-npm-bundler inside liferay-portal.",
 	"main": "config.json",
 	"dependencies": {

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -46,7 +46,7 @@
 		"liferay-lang-key-dev-loader": "^1.0.3",
 		"liferay-npm-bridge-generator": "2.13.3",
 		"liferay-npm-bundler": "2.13.3",
-		"liferay-npm-bundler-preset-liferay-dev": "2.1.0",
+		"liferay-npm-bundler-preset-liferay-dev": "3.0.0",
 		"liferay-theme-tasks": "9.4.0",
 		"metal-tools-soy": "4.3.2",
 		"minimist": "^1.2.0",

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "liferay-npm-scripts",
-	"version": "10.1.4",
+	"version": "11.0.0",
 	"description": "Collection of NPM scripts used for Liferay portlets",
 	"main": "index.js",
 	"author": {

--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -14,7 +14,7 @@ module.exports = {
 	build: {
 		dependencies: [...clay, ...liferay, ...metal],
 		input: 'src/main/resources/META-INF/resources',
-		output: 'build/node/packageRunBuild/resources'
+		output: 'classes/META-INF/resources'
 	},
 	check: [...JS_GLOBS, '{src,test}/**/*.scss'],
 	fix: [...JS_GLOBS, '{src,test}/**/*.scss'],


### PR DESCRIPTION
As explained [here](https://github.com/liferay/liferay-npm-tools/pull/290#issuecomment-540490277) we need to revert the commit that changes the build output location because we're not ready to update that in liferay-portal yet.

This reverts commit d539ecacf92a0674d1e2787a1bd6a3932e78922e.