### PR TITLE
feat(scripts)!: update eslint-config-liferay v11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "6.1.0",
-		"eslint-config-liferay": "9.0.0",
+		"eslint-config-liferay": "11.1.1",
 		"prettier": "1.18.2"
 	},
 	"jest": {

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -415,7 +415,7 @@ function formatDate(date) {
 	return `${year}-${month}-${day}`;
 }
 
-async function generate({from, to, date, remote, version}) {
+async function generate({date, from, remote, to, version}) {
 	const changes = await getChanges(from, to);
 
 	const header = `## ${linkToVersion(version, remote)} (${formatDate(date)})`;

--- a/packages/liferay-jest-junit-reporter/src/index.js
+++ b/packages/liferay-jest-junit-reporter/src/index.js
@@ -6,10 +6,10 @@
 
 'use strict';
 
-const xml = require('xml');
 const fs = require('fs');
 const path = require('path');
 const stripAnsi = require('strip-ansi');
+const xml = require('xml');
 
 const NEW_LINE = '\n';
 

--- a/packages/liferay-jest-junit-reporter/test/index.js
+++ b/packages/liferay-jest-junit-reporter/test/index.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-jest.mock('fs');
-
-const reporter = require('../src');
-const fs = require('fs');
-
 const failedTestReport = {
 	numFailedTests: 1,
 	numTotalTests: 1,
@@ -53,7 +48,18 @@ const passedTestReport = {
 };
 
 describe('liferay-jest-junit-reporter', () => {
+	let fs;
+	let reporter;
+
 	beforeEach(() => {
+		jest.resetModules();
+
+		jest.mock('fs');
+
+		fs = require('fs');
+
+		reporter = require('../src');
+
 		// Prevent user-specific context from appearing in snapshots.
 		jest.spyOn(process, 'cwd').mockImplementation(
 			() =>
@@ -76,7 +82,7 @@ describe('liferay-jest-junit-reporter', () => {
 	it('writes a file for a failing test', () => {
 		reporter(failedTestReport);
 
-		const xmlWritten = fs.writeFileSync.mock.calls[1][1];
+		const xmlWritten = fs.writeFileSync.mock.calls[0][1];
 
 		expect(xmlWritten).toMatchSnapshot();
 	});

--- a/packages/liferay-js-insights/index.js
+++ b/packages/liferay-js-insights/index.js
@@ -8,10 +8,11 @@ const parser = require('@babel/parser');
 const findUp = require('find-up');
 const fs = require('fs');
 const globby = require('globby');
-const argv = require('minimist')(process.argv.slice(2));
+const minimist = require('minimist');
 const path = require('path');
 const util = require('util');
 
+const argv = minimist(process.argv.slice(2));
 const readFile = util.promisify(fs.readFile);
 
 const INSIGHTS = {

--- a/packages/liferay-js-insights/insights/dependencies.js
+++ b/packages/liferay-js-insights/insights/dependencies.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const traverse = require('@babel/traverse').default;
+const {default: traverse} = require('@babel/traverse');
 
 const SOURCE_GROUPS = [
 	{

--- a/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
+++ b/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const {SpawnError} = require('../src/utils/spawnSync');
 const log = require('../src/utils/log');
+const {SpawnError} = require('../src/utils/spawnSync');
 
 try {
 	require('../src/index')();

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -38,7 +38,7 @@
 		"css-loader": "^3.0.0",
 		"deepmerge": "^4.0.0",
 		"eslint": "6.1.0",
-		"eslint-config-liferay": "9.0.0",
+		"eslint-config-liferay": "11.1.1",
 		"http-proxy-middleware": "^0.19.1",
 		"jest": "^24.5.0",
 		"jest-fetch-mock": "^2.1.2",

--- a/packages/liferay-npm-scripts/src/format/Lexer.js
+++ b/packages/liferay-npm-scripts/src/format/Lexer.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const ReversibleMap = require('./ReversibleMap');
 const permute = require('../utils/permute');
+const ReversibleMap = require('./ReversibleMap');
 
 /**
  * Class for creating lexer instances.

--- a/packages/liferay-npm-scripts/src/format/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/format/formatJSP.js
@@ -5,9 +5,10 @@
  */
 
 const prettier = require('prettier');
+
 const getMergedConfig = require('../utils/getMergedConfig');
-const extractJS = require('./extractJS');
 const dedent = require('./dedent');
+const extractJS = require('./extractJS');
 const indent = require('./indent');
 const padLines = require('./padLines');
 const restoreTags = require('./restoreTags');

--- a/packages/liferay-npm-scripts/src/format/lex.js
+++ b/packages/liferay-npm-scripts/src/format/lex.js
@@ -22,8 +22,8 @@ function lex(source, options = {}) {
 	const lexer = new Lexer(api => {
 		const {
 			a,
-			an,
 			allOf,
+			an,
 			consume,
 			fail,
 			match,

--- a/packages/liferay-npm-scripts/src/format/restoreTags.js
+++ b/packages/liferay-npm-scripts/src/format/restoreTags.js
@@ -10,7 +10,7 @@ const {IDENTIFIER} = require('./getPaddedReplacement');
 const indent = require('./indent');
 const {SCRIPTLET_CONTENT} = require('./substituteTags');
 const {CLOSE_TAG, OPEN_TAG} = require('./tagReplacements');
-const {isFiller, TAB_CHAR} = require('./toFiller');
+const {TAB_CHAR, isFiller} = require('./toFiller');
 /**
  * Takes a source string and reinserts tags that were previously extracted with
  * substituteTags().

--- a/packages/liferay-npm-scripts/src/format/stripIndents.js
+++ b/packages/liferay-npm-scripts/src/format/stripIndents.js
@@ -66,7 +66,7 @@ function stripIndents(source) {
 	const tokens = [...lexer.lex(source)];
 
 	for (let i = 0; i < tokens.length; i++) {
-		const {name, contents} = tokens[i];
+		const {contents, name} = tokens[i];
 
 		switch (name) {
 			case 'OPEN_TAG_REPLACEMENT':

--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const CWD = process.cwd();
-
 const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
@@ -15,7 +13,7 @@ const getMergedConfig = require('../utils/getMergedConfig');
 const moveToTemp = require('../utils/moveToTemp');
 const removeFromTemp = require('../utils/removeFromTemp');
 const setEnv = require('../utils/setEnv');
-const {buildSoy, cleanSoy, translateSoy, soyExists} = require('../utils/soy');
+const {buildSoy, cleanSoy, soyExists, translateSoy} = require('../utils/soy');
 const spawnSync = require('../utils/spawnSync');
 const validateConfig = require('../utils/validateConfig');
 const withBabelConfig = require('../utils/withBabelConfig');
@@ -23,6 +21,7 @@ const webpack = require('./webpack');
 
 const BUILD_CONFIG = getMergedConfig('npmscripts', 'build');
 const BUNDLER_CONFIG = getMergedConfig('bundler');
+const CWD = process.cwd();
 
 /**
  * Compiles JavaScript files by running `babel` with merged config(user +

--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -6,10 +6,11 @@
 
 const fs = require('fs');
 const prettier = require('prettier');
+
 const formatJSP = require('../format/formatJSP');
+const isJSP = require('../format/isJSP');
 const getMergedConfig = require('../utils/getMergedConfig');
 const getPaths = require('../utils/getPaths');
-const isJSP = require('../format/isJSP');
 const log = require('../utils/log');
 const {SpawnError} = require('../utils/spawnSync');
 

--- a/packages/liferay-npm-scripts/src/scripts/storybook.js
+++ b/packages/liferay-npm-scripts/src/scripts/storybook.js
@@ -48,7 +48,7 @@ function buildNodePath() {
  * @param {Array} files The list of files to copy.
  */
 function copyStorybookConfigFiles(buildPath, files) {
-	files.forEach(function(file) {
+	files.forEach(file => {
 		fs.copyFileSync(
 			path.join(STORYBOOK_CONFIG_DIR_PATH, file),
 			path.join(buildPath, file)

--- a/packages/liferay-npm-scripts/src/scripts/webpack.js
+++ b/packages/liferay-npm-scripts/src/scripts/webpack.js
@@ -5,6 +5,7 @@
  */
 
 const fs = require('fs');
+
 const spawnSync = require('../utils/spawnSync');
 const withBabelConfig = require('../utils/withBabelConfig');
 

--- a/packages/liferay-npm-scripts/src/storybook/config.js
+++ b/packages/liferay-npm-scripts/src/storybook/config.js
@@ -11,6 +11,8 @@ import {addDecorator, configure} from '@storybook/react';
 function loadStories() {
 	// Don't use path.join here or webpack will complain with:
 	// "Critical dependency: the request of a dependency is an expression"
+
+	// eslint-disable-next-line liferay/no-dynamic-require
 	require(process.env.STORYBOOK_CWD + '/test/stories/index.es.js');
 
 	addDecorator(withA11y);

--- a/packages/liferay-npm-scripts/src/storybook/index.js
+++ b/packages/liferay-npm-scripts/src/storybook/index.js
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import * as StorybookReact from '@storybook/react';
-import * as StorybookAddonKnobs from '@storybook/addon-knobs';
 import * as StorybookAddonActions from '@storybook/addon-actions';
+import * as StorybookAddonKnobs from '@storybook/addon-knobs';
+import * as StorybookReact from '@storybook/react';
 
 const STORYBOOK_CONSTANTS = {
 	SPRITEMAP_PATH:

--- a/packages/liferay-npm-scripts/src/storybook/middleware.js
+++ b/packages/liferay-npm-scripts/src/storybook/middleware.js
@@ -5,8 +5,8 @@
  */
 
 const fs = require('fs');
-const path = require('path');
 const proxy = require('http-proxy-middleware');
+const path = require('path');
 
 const STORYBOOK_CONFIG = JSON.parse(
 	fs.readFileSync(path.join(__dirname, 'storybook-config.json'), 'utf8')

--- a/packages/liferay-npm-scripts/src/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/src/utils/deepMerge.js
@@ -15,7 +15,7 @@ const clone = (value, options) => merge(emptyTarget(value), value, options);
 function combineMerge(target, source, options) {
 	const destination = target.slice();
 
-	source.forEach(function(e, i) {
+	source.forEach((e, i) => {
 		if (typeof destination[i] === 'undefined') {
 			const cloneRequested = options.clone !== false;
 			const shouldClone = cloneRequested && options.isMergeableObject(e);

--- a/packages/liferay-npm-scripts/src/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/expandGlobs.js
@@ -6,6 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
+
 const getRegExpForGlob = require('./getRegExpForGlob');
 
 const DEFAULT_OPTIONS = {
@@ -18,7 +19,7 @@ const DEFAULT_OPTIONS = {
  * of matching files, searching in the current dirctory.
  */
 function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
-	const {type, maxDepth} = {
+	const {maxDepth, type} = {
 		...DEFAULT_OPTIONS,
 		...options
 	};

--- a/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
+++ b/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
@@ -16,7 +16,7 @@ function generateSoyDependencies(dependencies) {
 	const cwd = process.cwd();
 
 	const stringDependencies = dependencies
-		.map(function(dependency) {
+		.map(dependency => {
 			let resolvedDependency = null;
 
 			try {

--- a/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
@@ -87,6 +87,7 @@ function getMergedConfig(type, property) {
 
 			// Check for preset before creating config
 			if (userConfig.preset) {
+				// eslint-disable-next-line liferay/no-dynamic-require
 				presetConfig = require(userConfig.preset);
 			}
 

--- a/packages/liferay-npm-scripts/src/utils/getUserConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getUserConfig.js
@@ -5,6 +5,7 @@
  */
 
 const cosmiconfig = require('cosmiconfig');
+
 const findRoot = require('./findRoot');
 
 /**

--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -9,8 +9,8 @@ const path = require('path');
 const rimraf = require('rimraf');
 
 const expandGlobs = require('./expandGlobs');
-const getMergedConfig = require('./getMergedConfig');
 const generateSoyDependencies = require('./generateSoyDependencies');
+const getMergedConfig = require('./getMergedConfig');
 const log = require('./log');
 const spawnSync = require('./spawnSync');
 

--- a/packages/liferay-npm-scripts/src/utils/withBabelConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/withBabelConfig.js
@@ -6,10 +6,10 @@
 
 const fs = require('fs');
 
-const getMergedConfig = require('./getMergedConfig');
 const SignalHandler = require('../utils/SignalHandler');
 const moveToTemp = require('../utils/moveToTemp');
 const removeFromTemp = require('../utils/removeFromTemp');
+const getMergedConfig = require('./getMergedConfig');
 
 const BABEL_CONFIG = getMergedConfig('babel');
 

--- a/packages/liferay-npm-scripts/test/format/Lexer.js
+++ b/packages/liferay-npm-scripts/test/format/Lexer.js
@@ -540,7 +540,7 @@ describe('Lexer()', () => {
 			let active = false;
 
 			const lexer = new Lexer(api => {
-				const {consume, match, never, repeat, when, oneOf, token} = api;
+				const {consume, match, never, oneOf, repeat, token, when} = api;
 
 				return () => {
 					// Reason we have to use "never" here is because "pass"

--- a/packages/liferay-npm-scripts/test/format/formatJSP.js
+++ b/packages/liferay-npm-scripts/test/format/formatJSP.js
@@ -5,6 +5,7 @@
  */
 
 const path = require('path');
+
 const formatJSP = require('../../src/format/formatJSP');
 const getFixture = require('../../support/getFixture');
 

--- a/packages/liferay-npm-scripts/test/format/lex.js
+++ b/packages/liferay-npm-scripts/test/format/lex.js
@@ -5,6 +5,7 @@
  */
 
 const path = require('path');
+
 const lex = require('../../src/format/lex');
 const getFixture = require('../../support/getFixture');
 

--- a/packages/liferay-npm-scripts/test/format/substituteTags.js
+++ b/packages/liferay-npm-scripts/test/format/substituteTags.js
@@ -5,6 +5,7 @@
  */
 
 const path = require('path');
+
 const substituteTags = require('../../src/format/substituteTags');
 const dedent = require('../../support/dedent');
 const getFixture = require('../../support/getFixture');

--- a/packages/liferay-npm-scripts/test/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/expandGlobs.js
@@ -7,6 +7,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+
 const expandGlobs = require('../../src/utils/expandGlobs');
 const preprocessGlob = require('../../src/utils/preprocessGlob');
 

--- a/packages/liferay-npm-scripts/test/utils/spawnMultiple.js
+++ b/packages/liferay-npm-scripts/test/utils/spawnMultiple.js
@@ -4,16 +4,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-jest.mock('../../src/utils/log');
-
-const spawnMultiple = require('../../src/utils/spawnMultiple');
-const {SpawnError} = require('../../src/utils/spawnSync');
-
 describe('spawnMultiple()', () => {
 	let log;
+	let spawnMultiple;
+	let SpawnError;
 
 	beforeEach(() => {
+		jest.mock('../../src/utils/log');
+
 		log = require('../../src/utils/log');
+		spawnMultiple = require('../../src/utils/spawnMultiple');
+		({SpawnError} = require('../../src/utils/spawnSync'));
 	});
 
 	it('succeeds when all jobs succeed', () => {

--- a/packages/liferay-npm-scripts/test/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/test/utils/spawnSync.js
@@ -5,6 +5,7 @@
  */
 
 const os = require('os');
+
 const spawnSync = require('../../src/utils/spawnSync');
 
 const {SpawnError} = spawnSync;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5617,10 +5617,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-9.0.0.tgz#47f217de6a0429081e8d3415f360c78e673c9bd6"
-  integrity sha512-QduJpNHli+nKgAEJv4MlM70mf3AgtAM5UtqvDS9WTLtGBQUSh80Gb+pFXueFXzfyvA3rEjxB490KJQTkj1gyPw==
+eslint-config-liferay@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-11.1.1.tgz#2e13c773a4da68824d12fbfaa22d706fab787750"
+  integrity sha512-0RdnXrCxYEulT+hqs4NHlX3Ycg+3tR7OE27NKHvND1s4owJgL9FB+84FNNImPtSp56qURRsi7U+0mpD2fzTbmw==
   dependencies:
     eslint-config-prettier "5.0.0"
     eslint-plugin-no-for-of-loops "^1.0.0"
@@ -5628,6 +5628,7 @@ eslint-config-liferay@9.0.0:
     eslint-plugin-notice "0.7.8"
     eslint-plugin-react "7.13.0"
     eslint-plugin-react-hooks "1.6.0"
+    eslint-plugin-sort-destructure-keys "1.3.3"
 
 eslint-config-prettier@5.0.0:
   version "5.0.0"
@@ -5672,6 +5673,13 @@ eslint-plugin-react@7.13.0:
     object.fromentries "^2.0.0"
     prop-types "^15.7.2"
     resolve "^1.10.1"
+
+eslint-plugin-sort-destructure-keys@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.3.3.tgz#f8396d1665d1eb70b0ace4972a70dcabadc8d29e"
+  integrity sha512-+ZI4IsCQe1Xfdxo4kTEtXwfHoOOvhV1u6nG7s8Ot1s6KSYlAlx0bnwXSsLgqGzROYkpSAy/a5JI9pPN3pJQXpw==
+  dependencies:
+    natural-compare-lite "^1.4.0"
 
 eslint-scope@3.7.1:
   version "3.7.1"
@@ -10391,6 +10399,11 @@ natives@^1.1.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
   integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
+
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q=
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
This adds a number of high-impact new lints:

- liferay/destructure-requires
- liferay/group-imports
- liferay/imports-first
- liferay/no-absolute-import
- liferay/no-duplicate-imports
- liferay/no-dynamic-require
- liferay/no-require-and-call
- liferay/sort-imports
- prefer-arrow-callback
- prefer-object-spread
- sort-destructure-keys/sort-destructure-keys

And new settings:

- `parserOptions.ecmaVersion` is now set to 2018 (previously was 2017).