### PR TITLE
feat: prevent accidental use of top-level `yarn version`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"format:check": "prettier --list-different '**/*.js' '**/*.json' '**/*.md'",
 		"lint": "eslint '.*.js' '**/*.js'",
 		"lint:fix": "eslint --fix '.*.js' '**/*.js'",
+		"preversion": "echo Cannot version top-level private package; false",
 		"test": "jest"
 	},
 	"workspaces": [


### PR DESCRIPTION
So that if you accidentally do `yarn version --major` at the top level, we'll fail fast instead of bumping the version number and creating a useless commit and tag.