### PR TITLE
feat(preset): add frontend-js-components-web to the preset

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -20,6 +20,9 @@
 	},
 	"config": {
 		"imports": {
+			"frontend-js-components-web": {
+				"/": ">=1.0.0"
+			},
 			"frontend-js-metal-web": {
 				"core-js": ">=2.6.5",
 				"incremental-dom": ">=0.5.1",


### PR DESCRIPTION
This is a new module where we will be putting React components that don't belong in Clay itself, but which are used in multiple places throughout liferay-portal.

We not putting them in frontend-js-web to avoid bloat there, nor in frontend-js-react-web because that's just plumbing for using React in liferay-portal. You could think of these as being analogous or related to the Clay "Satellites" defined in Lexicon.