### PR TITLE
feat(scripts): teach Jest to deal with new liferay-npm-bundler loaders

### DIFF
--- a/packages/liferay-npm-scripts/src/config/jest.config.js
+++ b/packages/liferay-npm-scripts/src/config/jest.config.js
@@ -17,6 +17,8 @@ module.exports = {
 	testURL: 'http://localhost',
 	transform: {
 		/* eslint-disable sort-keys */
+		'\\.css$': path.join(__dirname, '..', 'jest', 'transformStyles.js'),
+		'\\.scss$': path.join(__dirname, '..', 'jest', 'transformSass.js'),
 		'\\.soy$': path.join(__dirname, '..', 'jest', 'transformSoy.js'),
 		'.+': path.join(__dirname, '..', 'jest', 'transformBabel.js')
 		/* eslint-enable sort-keys */

--- a/packages/liferay-npm-scripts/src/jest/transformSass.js
+++ b/packages/liferay-npm-scripts/src/jest/transformSass.js
@@ -1,0 +1,17 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * This transform allows Jest to test components that make use of `import`
+ * statements to load SCSS files. Outside of tests, these get transformed by the
+ * liferay-npm-bundler into JS modules. In the Jest context, the bundler is not
+ * involved, so we turn those imports into side-effectless no-ops.
+ */
+module.exports = {
+	process(_src, _file) {
+		return '';
+	}
+};

--- a/packages/liferay-npm-scripts/src/jest/transformStyles.js
+++ b/packages/liferay-npm-scripts/src/jest/transformStyles.js
@@ -1,0 +1,17 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * This transform allows Jest to test components that make use of `import`
+ * statements to load CSS files. Outside of tests, these get transformed by the
+ * liferay-npm-bundler into JS modules. In the Jest context, the bundler is not
+ * involved, so we turn those imports into side-effectless no-ops.
+ */
+module.exports = {
+	process(_src, _file) {
+		return '';
+	}
+};


### PR DESCRIPTION
As explained in the inline comments, these transforms allow Jest to work with components that contain SCSS and CSS imports:

     import './MyComponents.scss';

Given such an import Jest will otherwise try to read the file and treat it as JS, which obviously won't work. We use the transform here to turn such "modules" into harmless no-ops.