### PR TITLE
fix(scripts): don't use color or report results if successful (#317)

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -167,10 +167,11 @@ function formatter(results) {
 	let errors = 0;
 	let fixableErrorCount = 0;
 	let fixableWarningCount = 0;
+	let output = '';
 	let warnings = 0;
 
 	results.forEach(result => {
-		log(color.UNDERLINE + result.filePath + color.RESET);
+		output += color.UNDERLINE + result.filePath + color.RESET + '\n';
 
 		result.messages.forEach(
 			({column, fix, line, message, ruleId, severity}) => {
@@ -195,42 +196,46 @@ function formatter(results) {
 
 				const label = ruleId || 'syntax-error';
 
-				log(`  ${line}:${column}  ${type}  ${message}  ${label}`);
+				output += `  ${line}:${column}  ${type}  ${message}  ${label}\n`;
 			}
 		);
 
-		log('');
+		output += '\n';
 	});
 
 	const total = errors + warnings;
 
-	const summary = [
-		color.BOLD,
-		color.RED,
-		HEAVY_MULTIPLICATION_X,
-		' ',
-		pluralize('problem', total),
-		' ',
-		`(${pluralize('error', errors)}, `,
-		`${pluralize('warning', warnings)})`,
-		color.RESET
-	];
-
-	if (fixableErrorCount || fixableWarningCount) {
-		summary.push(
-			'\n',
+	if (total) {
+		const summary = [
 			color.BOLD,
-			color.RED,
-			'  ',
-			pluralize('error', fixableErrorCount),
-			' and ',
-			pluralize('warning', fixableWarningCount),
-			' potentially fixable with the `--fix` option.',
+			errors ? color.RED : color.YELLOW,
+			HEAVY_MULTIPLICATION_X,
+			' ',
+			pluralize('problem', total),
+			' ',
+			`(${pluralize('error', errors)}, `,
+			`${pluralize('warning', warnings)})`,
 			color.RESET
-		);
+		];
+
+		if (fixableErrorCount || fixableWarningCount) {
+			summary.push(
+				'\n',
+				color.BOLD,
+				errors ? color.RED : color.YELLOW,
+				'  ',
+				pluralize('error', fixableErrorCount),
+				' and ',
+				pluralize('warning', fixableWarningCount),
+				' potentially fixable with the `--fix` option.',
+				color.RESET
+			);
+		}
+
+		output += summary.join('');
 	}
 
-	return summary.join('');
+	return output;
 }
 
 /**

--- a/packages/liferay-npm-scripts/test/scripts/lint.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint.js
@@ -132,8 +132,10 @@ describe('scripts/lint.js', () => {
 
 				expect(logged).toContain('/fancy/test.js');
 
-				expect(logged).toContain(
-					'20:10  error  Avoid explosions.  no-boom'
+				// `isTTY` varies in different CI environments, so we use a
+				// regex here to match in a color-agnostic way.
+				expect(logged).toMatch(
+					/20:10 {2}.*error.* {2}Avoid explosions. {2}no-boom/
 				);
 
 				expect(logged).toContain(


### PR DESCRIPTION
Only report if there are errors or warnings, and do so in red for errors and yellow if there are only warnings. This matches the ESLint behavior.

Closes: https://github.com/liferay/liferay-npm-tools/issues/317