### PR TITLE
feat(scripts)!: make Babel use preset-react by default (#303)

### DIFF
--- a/packages/liferay-npm-scripts/src/config/babel.json
+++ b/packages/liferay-npm-scripts/src/config/babel.json
@@ -4,7 +4,7 @@
 			"plugins": ["transform-react-remove-prop-types"]
 		}
 	},
-	"presets": ["@babel/preset-env"],
+	"presets": ["@babel/preset-env", "@babel/preset-react"],
 	"plugins": [
 		"@babel/proposal-class-properties",
 		"@babel/proposal-export-namespace-from",

--- a/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
@@ -29,6 +29,13 @@ function pluck(config, property) {
 	return config[property];
 }
 
+function isObject(maybeObject) {
+	return (
+		maybeObject &&
+		Object.prototype.toString.call(maybeObject) === '[object Object]'
+	);
+}
+
 /**
  * Returns a deep copy of `object`, with any instance of `property`
  * transformed using the `callback` (which should accept the value of
@@ -37,13 +44,18 @@ function pluck(config, property) {
 function filter(object, property, callback) {
 	if (Array.isArray(object)) {
 		return object.map(item => filter(item, property, callback));
-	} else {
+	} else if (isObject(object)) {
 		return Object.entries(object).reduce((acc, [key, value]) => {
 			return {
 				...acc,
-				[key]: key === property ? callback(value) : value
+				[key]:
+					key === property
+						? callback(value)
+						: filter(value, property, callback)
 			};
 		}, {});
+	} else {
+		return object;
 	}
 }
 

--- a/packages/liferay-npm-scripts/src/utils/runBabel.js
+++ b/packages/liferay-npm-scripts/src/utils/runBabel.js
@@ -15,7 +15,12 @@ const BABEL_CONFIG = getMergedConfig('babel');
  */
 function runBabel(...args) {
 	withTempFile('.babelrc', JSON.stringify(BABEL_CONFIG), babelRcPath => {
-		spawnSync('babel', ['--config-file', babelRcPath, ...args]);
+		spawnSync('babel', [
+			'--no-babelrc',
+			'--config-file',
+			babelRcPath,
+			...args
+		]);
 	});
 }
 

--- a/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
@@ -24,4 +24,42 @@ describe('getMergedConfig()', () => {
 			);
 		});
 	});
+
+	describe('"babel" config', () => {
+		it('strips blacklisted presets', () => {
+			jest.resetModules();
+
+			jest.isolateModules(() => {
+				const getMergedConfig = require('../../src/utils/getMergedConfig');
+
+				jest.mock('../../src/utils/getUserConfig', () => {
+					// Example use case from dynamic-data-mapping-form-builder:
+					// blacklist the "react" preset in order to use the
+					// "incremental-dom" plug-in.
+					return jest.fn(() => ({
+						liferay: {
+							excludes: {
+								presets: ['@babel/preset-react']
+							}
+						},
+						plugins: [
+							[
+								'incremental-dom',
+								{
+									components: true,
+									namespaceAttributes: true,
+									prefix: 'IncrementalDOM',
+									runtime: 'iDOMHelpers'
+								}
+							]
+						]
+					}));
+				});
+
+				const config = getMergedConfig('babel');
+
+				expect(config.presets).toEqual(['@babel/preset-env']);
+			});
+		});
+	});
 });

--- a/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
@@ -52,6 +52,13 @@ describe('getMergedConfig()', () => {
 									runtime: 'iDOMHelpers'
 								}
 							]
+						],
+						// The following isn't real config, but it shows
+						// that we can filter down below the top level.
+						overrides: [
+							{
+								presets: ['fancy', '@babel/preset-react']
+							}
 						]
 					}));
 				});
@@ -59,6 +66,11 @@ describe('getMergedConfig()', () => {
 				const config = getMergedConfig('babel');
 
 				expect(config.presets).toEqual(['@babel/preset-env']);
+
+				expect(config.overrides[0].presets).toMatchObject([
+					['@babel/preset-env', expect.anything()],
+					'fancy'
+				]);
 			});
 		});
 	});

--- a/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
@@ -42,6 +42,15 @@ describe('getMergedConfig()', () => {
 								presets: ['@babel/preset-react']
 							}
 						},
+
+						// This bit isn't real config, but it shows that
+						// we can filter down below the top level:
+						overrides: [
+							{
+								presets: ['fancy', '@babel/preset-react']
+							}
+						],
+
 						plugins: [
 							[
 								'incremental-dom',
@@ -52,13 +61,6 @@ describe('getMergedConfig()', () => {
 									runtime: 'iDOMHelpers'
 								}
 							]
-						],
-						// The following isn't real config, but it shows
-						// that we can filter down below the top level.
-						overrides: [
-							{
-								presets: ['fancy', '@babel/preset-react']
-							}
 						]
 					}));
 				});


### PR DESCRIPTION
Note that this will require some corresponding changes in liferay-portal, namely, there are two projects which use the incremental-dom plugin:

- https://github.com/liferay/liferay-portal/blob/1f84f9713487704f173e6777781a20d7c38477f6/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.babelrc
- https://github.com/liferay/liferay-portal/blob/1f84f9713487704f173e6777781a20d7c38477f6/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/.babelrc

I don't think we can turn off the preset for those, but we can disable the individual plugins that the preset activates.

I believe all the rest should be fine, but will obviously have to test things.

Closes: https://github.com/liferay/liferay-npm-tools/issues/303