### PR TITLE
feat(scripts)!: enforce use of canonical config file names

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/check.js
+++ b/packages/liferay-npm-scripts/src/scripts/check.js
@@ -5,11 +5,13 @@
  */
 
 const spawnMultiple = require('../utils/spawnMultiple');
+const preflight = require('./check/preflight');
 const format = require('./format');
 const lint = require('./lint');
 
 function check() {
 	spawnMultiple(
+		() => preflight(),
 		() => format({check: true}),
 		() => lint()
 	);

--- a/packages/liferay-npm-scripts/src/scripts/check/preflight.js
+++ b/packages/liferay-npm-scripts/src/scripts/check/preflight.js
@@ -1,0 +1,69 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const path = require('path');
+
+const getPaths = require('../../utils/getPaths');
+const log = require('../../utils/log');
+const {SpawnError} = require('../../utils/spawnSync');
+
+const BABEL_CONFIG_FILE_NAME = '.babelrc.js';
+
+const ESLINT_CONFIG_FILE_NAME = '.eslintrc.js';
+
+const PRETTIER_CONFIG_FILE_NAME = '.prettierrc.js';
+
+/* eslint-disable sort-keys */
+
+const DISALLOWED_CONFIG_FILE_NAMES = {
+	// https://babeljs.io/docs/en/config-files/
+	'.babelrc': BABEL_CONFIG_FILE_NAME,
+	'.babelrc.cjs': BABEL_CONFIG_FILE_NAME,
+	'.babelrc.json': BABEL_CONFIG_FILE_NAME,
+	'.babelrc.mjs': BABEL_CONFIG_FILE_NAME,
+	'babel.config.cjs': BABEL_CONFIG_FILE_NAME,
+	'babel.config.js': BABEL_CONFIG_FILE_NAME,
+	'babel.config.json': BABEL_CONFIG_FILE_NAME,
+	'babel.config.mjs': BABEL_CONFIG_FILE_NAME,
+
+	// https://eslint.org/docs/user-guide/configuring
+	'.eslintrc': ESLINT_CONFIG_FILE_NAME,
+	'.eslintrc.cjs': ESLINT_CONFIG_FILE_NAME,
+	'.eslintrc.json': ESLINT_CONFIG_FILE_NAME,
+	'.eslintrc.yaml': ESLINT_CONFIG_FILE_NAME,
+	'.eslintrc.yml': ESLINT_CONFIG_FILE_NAME,
+
+	// https://prettier.io/docs/en/configuration.html
+	'.prettierrc': PRETTIER_CONFIG_FILE_NAME,
+	'.prettierrc.json': PRETTIER_CONFIG_FILE_NAME,
+	'.prettierrc.toml': PRETTIER_CONFIG_FILE_NAME,
+	'.prettierrc.yaml': PRETTIER_CONFIG_FILE_NAME,
+	'.prettierrc.yml': PRETTIER_CONFIG_FILE_NAME,
+	'prettier.config.js': PRETTIER_CONFIG_FILE_NAME
+};
+
+/* eslint-enable sort-keys */
+
+function preflight() {
+	const disallowedConfigs = getPaths(
+		Object.keys(DISALLOWED_CONFIG_FILE_NAMES),
+		[]
+	);
+
+	if (disallowedConfigs.length) {
+		log('Preflight check failed:');
+
+		disallowedConfigs.forEach(file => {
+			const suggested = DISALLOWED_CONFIG_FILE_NAMES[path.basename(file)];
+
+			log(`${file}: BAD - use ${suggested} instead`);
+		});
+
+		throw new SpawnError();
+	}
+}
+
+module.exports = preflight;

--- a/packages/liferay-npm-scripts/src/utils/filterGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/filterGlobs.js
@@ -19,9 +19,11 @@ function filterGlobs(globs, ...extensions) {
 		}
 	});
 
-	return globs.filter(glob => {
-		return extensions.some(extension => glob.endsWith(extension));
-	});
+	return extensions.length
+		? globs.filter(glob => {
+				return extensions.some(extension => glob.endsWith(extension));
+		  })
+		: globs;
 }
 
 module.exports = filterGlobs;

--- a/packages/liferay-npm-scripts/src/utils/getPaths.js
+++ b/packages/liferay-npm-scripts/src/utils/getPaths.js
@@ -24,7 +24,7 @@ const readIgnoreFile = require('../utils/readIgnoreFile');
 function getPaths(globs, extensions, ignoreFile) {
 	const root = findRoot();
 
-	ignoreFile = path.join(root || '.', ignoreFile);
+	ignoreFile = ignoreFile ? path.join(root || '.', ignoreFile) : '';
 
 	const ignores = fs.existsSync(ignoreFile) ? readIgnoreFile(ignoreFile) : [];
 

--- a/packages/liferay-npm-scripts/test/utils/filterGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/filterGlobs.js
@@ -25,6 +25,10 @@ describe('filterGlobs()', () => {
 		expect(filterGlobs(globs, '.doc')).toEqual([]);
 	});
 
+	it('returns everything when not given an extensions', () => {
+		expect(filterGlobs(globs)).toEqual(globs);
+	});
+
 	it('complains given an invalid extension', () => {
 		expect(() => filterGlobs(globs, 'js')).toThrow(
 			/expected extension "js"/

--- a/packages/liferay-npm-scripts/test/utils/filterGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/filterGlobs.js
@@ -25,7 +25,7 @@ describe('filterGlobs()', () => {
 		expect(filterGlobs(globs, '.doc')).toEqual([]);
 	});
 
-	it('returns everything when not given an extensions', () => {
+	it('returns everything when not given any extensions', () => {
 		expect(filterGlobs(globs)).toEqual(globs);
 	});
 


### PR DESCRIPTION
We want developers to only use `.babelrc.js`, `.eslintrc.js` (and technically, `.prettierrc.js` too, although there should be exactly one of those in liferay-portal) so that we can format and lint those files, to make sure we get the full benefit of rules like this one:

https://github.com/liferay/eslint-config-liferay/blob/master/plugins/eslint-plugin-liferay-portal/docs/rules/no-explicit-extend.md

To that effect, this commit adds an additional "preflight" step to our "check" script, which means that we now have 3 phases:

1. Preflight checks (currently, these just check for disallowed config file names, but this would be a logical spot to put additional checks in the future).
2. Formatting checks (ie. Prettier).
3. Lint checks (ie. ESLint).

I initially considered baking the check for config files into the other steps (ie. the Prettier step could check for bad Prettier config files, and the lint step could check for bad ESLint config files), but that would have involved scanning the repo multiple times and I figure it is better to do one scan (which takes a few seconds) up front. It also ends up being cleaner because we don't have to juggle multiple error conditions and produce clear output for them; eg:

- Config is bad but tool succeeded.
- Config is good but tool failed.
- Config is bad and tool failed.
- Config is good and tool succeeded.

So, we just run three steps (preflight, format, lint) and the logic ends up being very simple.

In any case, we don't have much choice anyway. If we didn't do this, where would we put the enforcement of the use of ".babelrc.js" files? We would need to add a separate step for that anyway. As a bonus, this gives us an obvious extension point for any other non-ESLint checks that we might want to run in the future.

Test plan: Running this in liferay-portal gives output like this in the presence of errors:

    $ liferay-npm-scripts check
    Preflight check failed:
    src/.eslintrc: BAD - use .eslintrc.js instead
    src/.prettierrc: BAD - use .prettierrc.js instead

    Prettier checked 11 files

    1 of 3 jobs failed
    error Command failed with exit code 1.

And in a clean run:

    $ liferay-npm-scripts check
    Prettier checked 11 files

    ✨  Done in 1.70s.

Closes: https://github.com/liferay/liferay-npm-tools/issues/339