### PR TITLE
fix(scripts): teach ESLint that .baberc.js is a Node module

### DIFF
--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -5,6 +5,7 @@
  */
 
 const CONFIG_FILES = [
+	'**/.babelrc.js',
 	'**/.eslintrc.js',
 	'**/.prettierrc.js',
 	'**/npmscripts.config.js'


### PR DESCRIPTION
Otherwise we will get two false positives in liferay-portal when we port the remaining .babelrc files to .babelrc.js:

    modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/.babelrc.js
      15:1  error  'module' is not defined.  no-undef

    modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/.babelrc.js
      15:1  error  'module' is not defined.  no-undef

    ✖ 2 problems (2 errors, 0 warnings)