### PR TITLE
fix(scripts): teach jest wrapper to find .babelrc.js files

### DIFF
--- a/packages/liferay-npm-scripts/src/jest/transformBabel.js
+++ b/packages/liferay-npm-scripts/src/jest/transformBabel.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const fs = require('fs');
+const getUserConfig = require('../utils/getUserConfig');
 
-const config = JSON.parse(fs.readFileSync('.babelrc', 'utf8'));
+const config = getUserConfig('babel');
 
 module.exports = require('babel-jest').createTransformer(config);

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -14,6 +14,8 @@ const spawnSync = require('../utils/spawnSync');
 
 const BABEL_CONFIG = getMergedConfig('babel');
 const JEST_CONFIG = getMergedConfig('jest');
+
+const CONFIG_FILE_NAME = '.babelrc.js';
 const PREFIX_BACKUP = 'TEMP-';
 
 /**
@@ -67,8 +69,8 @@ module.exports = function(arrArgs = []) {
 };
 
 function setBabelConfig() {
-	if (fs.existsSync('.babelrc')) {
-		fs.renameSync('.babelrc', PREFIX_BACKUP + '.babelrc');
+	if (fs.existsSync(CONFIG_FILE_NAME)) {
+		fs.renameSync(CONFIG_FILE_NAME, PREFIX_BACKUP + CONFIG_FILE_NAME);
 	}
 
 	if (fs.existsSync('package.json')) {
@@ -86,16 +88,19 @@ function setBabelConfig() {
 		}
 	}
 
-	fs.writeFileSync('.babelrc', JSON.stringify(BABEL_CONFIG));
+	fs.writeFileSync(
+		CONFIG_FILE_NAME,
+		`module.exports = ${JSON.stringify(BABEL_CONFIG, null, 2)};`
+	);
 }
 
 function removeBabelConfig() {
-	fs.unlinkSync('.babelrc');
+	fs.unlinkSync(CONFIG_FILE_NAME);
 
-	const filePath = PREFIX_BACKUP + '.babelrc';
+	const filePath = PREFIX_BACKUP + CONFIG_FILE_NAME;
 
 	if (fs.existsSync(filePath)) {
-		fs.renameSync(filePath, '.babelrc');
+		fs.renameSync(filePath, CONFIG_FILE_NAME);
 	}
 
 	if (fs.existsSync('package.json')) {


### PR DESCRIPTION
Noticed this in final testing of:

https://github.com/brianchandotcom/liferay-portal/pull/83438

Test runs were failing in two modules (the only ones with .babelrc.js files) with this message:

    Multiple configuration files found. Please remove one:
     - .babelrc
     - .babelrc.js

The problem is this code in the Jest wrapper that was writing a duplicate .babelrc file into the correspond directories. In this commit we teach it to use ".babelrc.js" instead.