### PR TITLE
chore(scripts): clean up straggling (but inconsequential) .babelrc references

### DIFF
--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -117,7 +117,7 @@ If you just set dependencies to be `['my-new-dependency']`, it will override the
 
 ### Other Config
 
-If you need more flexibility over babel or the bundler. You can still add a `.babelrc` or `.npmbundlerrc` which will be merged with the default settings this tool provides. [Default Babel Config](./src/config/babel.json), [Default Bundler Config](./src/config/npm-bundler.json)
+If you need more flexibility over Babel or the bundler. You can still add a `.babelrc.js` or `.npmbundlerrc` which will be merged with the default settings this tool provides. [Default Babel Config](./src/config/babel.json), [Default Bundler Config](./src/config/npm-bundler.json)
 
 Want to use a different `NODE_ENV`? Try doing something like
 

--- a/packages/liferay-npm-scripts/src/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/src/utils/deepMerge.js
@@ -186,7 +186,7 @@ function babelMerge(key) {
 				throw new Error(
 					'babelMerge(): ' +
 						'Cannot merge without two mergeable objects: ' +
-						'please check that the .babelrc file is well-formed'
+						'please check that the .babelrc.js file is well-formed'
 				);
 			}
 		};

--- a/packages/liferay-npm-scripts/test/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/test/utils/deepMerge.js
@@ -288,8 +288,8 @@ describe('deepMerge()', () => {
 			});
 		});
 
-		it("doesn't break when a stale .babelrc file is left on disk", () => {
-			// This is the original project-local .babelrc config.
+		it("doesn't break when a stale .babelrc.js file is left on disk", () => {
+			// This is the original project-local .babelrc.js config.
 			const project = {
 				presets: ['@babel/preset-react']
 			};


### PR DESCRIPTION
These are places where we still talk about ".babelrc" even though we have switched to using ".babelrc.js" files now; none of them should have any meaningful impact on runtime behavior:

- Text in an error message.
- Text in an `it` test description.
- A code comment.

If you `git grep babelrc` you will still find some additional references, but these can stay as they are:

- `runBabel()` still creates temporary .babelrc files, but these always go in a temporary directory (via `withTempFile()`).
- Our storybook wrapper creates .babelrc files too, but always in a temporary directory.
- The bundler preset still has ".babelrc" keys in it, which don't refer to filenames but rather to Babel config in the abstract sense; see: https://github.com/liferay/liferay-js-toolkit/wiki/.npmbundlerrc-file-reference