### PR TITLE
feat(scripts)!: check desired filename format

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/check/preflight.js
+++ b/packages/liferay-npm-scripts/src/scripts/check/preflight.js
@@ -6,6 +6,7 @@
 
 const path = require('path');
 
+const getMergedConfig = require('../../utils/getMergedConfig');
 const getPaths = require('../../utils/getPaths');
 const log = require('../../utils/log');
 const {SpawnError} = require('../../utils/spawnSync');
@@ -47,6 +48,11 @@ const DISALLOWED_CONFIG_FILE_NAMES = {
 
 /* eslint-enable sort-keys */
 
+// TODO: Actual rules still to be decided in:
+// https://github.com/liferay/liferay-frontend-guidelines/issues/78
+const SCSS_FILENAME_DESCRIPTION = 'lower-case kebab-case';
+const SCSS_REGEXP = /\/_?([a-z0-9]+-)*[a-z0-9]+\.scss$/;
+
 function preflight() {
 	const errors = [...checkConfigFileNames(), ...checkSourceFileNames()];
 
@@ -83,7 +89,17 @@ function checkConfigFileNames() {
  * Returns a (possibly empty) array of error messages.
  */
 function checkSourceFileNames() {
-	return [];
+	const globs = getMergedConfig('npmscripts', 'check');
+
+	const sourceFiles = getPaths(globs, ['.scss']);
+
+	return sourceFiles
+		.filter(file => {
+			return !SCSS_REGEXP.test(file);
+		})
+		.map(file => {
+			return `${file}: BAD - name should be ${SCSS_FILENAME_DESCRIPTION}`;
+		});
 }
 
 module.exports = preflight;

--- a/packages/liferay-npm-scripts/src/scripts/check/preflight.js
+++ b/packages/liferay-npm-scripts/src/scripts/check/preflight.js
@@ -48,22 +48,42 @@ const DISALLOWED_CONFIG_FILE_NAMES = {
 /* eslint-enable sort-keys */
 
 function preflight() {
+	const errors = [...checkConfigFileNames(), ...checkSourceFileNames()];
+
+	if (errors.length) {
+		log('Preflight check failed:');
+
+		log(...errors);
+
+		throw new SpawnError();
+	}
+}
+
+/**
+ * Checks that config files use standard names.
+ *
+ * Returns a (possibly empty) array of error messages.
+ */
+function checkConfigFileNames() {
 	const disallowedConfigs = getPaths(
 		Object.keys(DISALLOWED_CONFIG_FILE_NAMES),
 		[]
 	);
 
-	if (disallowedConfigs.length) {
-		log('Preflight check failed:');
+	return disallowedConfigs.map(file => {
+		const suggested = DISALLOWED_CONFIG_FILE_NAMES[path.basename(file)];
 
-		disallowedConfigs.forEach(file => {
-			const suggested = DISALLOWED_CONFIG_FILE_NAMES[path.basename(file)];
+		return `${file}: BAD - use ${suggested} instead`;
+	});
+}
 
-			log(`${file}: BAD - use ${suggested} instead`);
-		});
-
-		throw new SpawnError();
-	}
+/**
+ * Checks that source files followed standard naming patterns.
+ *
+ * Returns a (possibly empty) array of error messages.
+ */
+function checkSourceFileNames() {
+	return [];
 }
 
 module.exports = preflight;


### PR DESCRIPTION
Draft only because this is just a proof-of-concept at this point because we haven't actually decided on the rules that we want to enforce.

---

Note that I am just doing this for SCSS files at this point because we might even want to pursue the alternative of baking this directly into our ESLint rules for our JS files.

FWIW, a quick survey of existing names in liferay-portal shows:

- 68 files using uppercase (ie. CamelCase) names: https://gist.github.com/wincent/6d62f155c01dee91c9dd5f0f6a533d8c
- 104 files using kebab-case names: https://gist.github.com/wincent/c7d39715cba6f794f558b71538bdc12a
- 758 files using neither of the above (generally, that means 0 or more underscores): https://gist.github.com/wincent/df6e2f276d91bb34a89cb17c7cd8ee99

Test plan: run in liferay-portal; each `getPaths` call takes about 4 seconds on my machine even though that means scanning the entire repo -- we could memoize that or make it "smarter" in CI (ie. by using the changed paths detection to short-circuit traversal instead of doing it at the end as a filtering step).

Related: https://github.com/liferay/liferay-frontend-guidelines/issues/78