### PR TITLE
feat(scripts): run preflight checks during "fix" runs too

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/fix.js
+++ b/packages/liferay-npm-scripts/src/scripts/fix.js
@@ -5,11 +5,13 @@
  */
 
 const spawnMultiple = require('../utils/spawnMultiple');
+const preflight = require('./check/preflight');
 const format = require('./format');
 const lint = require('./lint');
 
 function fix() {
 	spawnMultiple(
+		() => preflight(),
 		() => lint({fix: true}),
 		() => format()
 	);


### PR DESCRIPTION
I initially only had the preflight running during the "check" script because it doesn't have any autofix capability and so is never going to fix anything.

But talking with Chema just now it became clear that there is another workflow which is to just blindly run "yarn format" and never "yarn checkFormat". As such, it is possible to send a PR with a problem that would have been caught by the preflight check, only to find out too late in CI (which does "checkFormat") that there is an issue.

Test plan: Copy this change over to liferay-portal, create a bogus config file, and run `yarn format`; see error.