### PR TITLE
chore: remove unnecessary line from .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
-node_modules
 copyright.js


### PR DESCRIPTION
Because Prettier ignores node_modules by default:

> Prettier CLI will ignore files located in `node_modules` directory. To opt-out from this behavior use `--with-node-modules` flag.

https://prettier.io/docs/en/cli.html