### PR TITLE
feat(scripts): make preflight checks respect .eslintignore (#354)

### DIFF
--- a/packages/liferay-npm-scripts/src/scripts/check/preflight.js
+++ b/packages/liferay-npm-scripts/src/scripts/check/preflight.js
@@ -56,10 +56,13 @@ const DISALLOWED_CONFIG_FILE_NAMES = {
 
 /* eslint-enable sort-keys */
 
+const IGNORE_FILE = '.eslintignore';
+
 function preflight() {
 	const disallowedConfigs = getPaths(
 		Object.keys(DISALLOWED_CONFIG_FILE_NAMES),
-		[]
+		[],
+		IGNORE_FILE
 	);
 
 	if (disallowedConfigs.length) {


### PR DESCRIPTION
In https://github.com/wincent/liferay-portal/commit/f7704c187c75117402a8d479ea8c76dcc368b824 we renamed all `.babelrc` files to `.babelrc.js`, and it seems that it [requires some additional changes](https://github.com/lawrence-lee/liferay-portal/pull/146)) (at least those, maybe more) to make the project-templates tasks keep working.

Now, the files under `modules/sdk` are [actually ignored by our `.eslintignore`](https://github.com/liferay/liferay-portal/blob/650fcb63d396ef746999d8c1097b181aec31cc51/modules/.eslintignore#L42) but our preflight checks don't actually use ESLint, and at the time I saw no harm in letting them run over the entire repo — but as you can see above, that assessment was off and the change was not harmless after all.

So, I think it would be reasonable to use the `.eslintignore` file as a cue to skip the preflight checks under `modules/sdk` (and anywhere else that is ignored). It is a *bit* weird to use the contents of a file with "eslint" in the name to control the behavior of code that isn't actually running ESLint, but it probably beats complectifying our other config file (eg. `npmscripts.config.js`) with yet another configuration option, or implementing our own `.npmscriptsignore` or anything like that.

Test plan: In liferay-portal, with ".babelrc" files under "modules/sdk" and elsewhere, see that it doesn't complain about "modules/sdk" when I run checkFormat, but it does in the other places.

Closes: https://github.com/liferay/liferay-npm-tools/issues/354