### PR TITLE
fix(scripts): tighten up Jest module name mapper generation

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -91,7 +91,9 @@ function getJestModuleNameMapper() {
 									`^${basename}/(.*)`
 								] = `<rootDir>${relative}/$1`;
 							} else {
-								mappings[`^${basename}$`] = `<rootDir>${relative}`;
+								mappings[
+									`^${basename}$`
+								] = `<rootDir>${relative}`;
 
 								mappings[
 									`^${basename}/(.*)`

--- a/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -26,11 +26,11 @@ const IGNORE_GLOBS = ['node_modules/**'];
  * For example, in order for "segments/segments-web" to `import
  * {something} from 'frontend-js-web'`, we need mappings like:
  *
- *    "frontend-js-web": "<rootDir>../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js"
+ *    "^frontend-js-web$": "<rootDir>../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js"
  *
  * and:
  *
- *    "frontend-js-web/(.*)": "<rootDir>../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/$1"
+ *    "^frontend-js-web/(.*)": "<rootDir>../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/$1"
  *
  * We create such mappings by:
  *
@@ -88,13 +88,13 @@ function getJestModuleNameMapper() {
 								// some under "dynamic-data-mapping/*", that
 								// have a "main" property of "./".
 								mappings[
-									`${basename}/(.*)`
+									`^${basename}/(.*)`
 								] = `<rootDir>${relative}/$1`;
 							} else {
-								mappings[basename] = `<rootDir>${relative}`;
+								mappings[`^${basename}$`] = `<rootDir>${relative}`;
 
 								mappings[
-									`${basename}/(.*)`
+									`^${basename}/(.*)`
 								] = `<rootDir>${dirname}/$1`;
 							}
 						}


### PR DESCRIPTION
Latent bug in here that I don't think has bitten us in practice, but while testing changes for [LPS-98114](https://issues.liferay.com/browse/LPS-98114), I noticed that I could change imports in the following ways without triggering expected errors:

    import {foo} from 'some-module';

    // Add a prefix:
    import {bar} from 'sssssssome-module';

    // Add a suffix:
    import {baz} from 'some-moduleeeee';

We need to use stricter matching. The Jest documentation itself points out this pitfall:

> Note: If you provide module name without boundaries `^$` it may cause hard to spot errors. E.g. `relay` will replace all modules which contain `relay` as a substring in its name: `relay`, `react-relay` and `graphql-relay` will all be pointed to your stub.

See: https://jestjs.io/docs/en/configuration#modulenamemapper-objectstring-string