### PR TITLE
refactor(scripts): remove DDM special-casing from Jest module mapper

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -83,22 +83,11 @@ function getJestModuleNameMapper() {
 							const dirname = path.dirname(relative);
 							const basename = path.basename(project);
 
-							if (fs.statSync(file).isDirectory()) {
-								// Special-case, for now, for projects like
-								// some under "dynamic-data-mapping/*", that
-								// have a "main" property of "./".
-								mappings[
-									`^${basename}/(.*)`
-								] = `<rootDir>${relative}/$1`;
-							} else {
-								mappings[
-									`^${basename}$`
-								] = `<rootDir>${relative}`;
+							mappings[`^${basename}$`] = `<rootDir>${relative}`;
 
-								mappings[
-									`^${basename}/(.*)`
-								] = `<rootDir>${dirname}/$1`;
-							}
+							mappings[
+								`^${basename}/(.*)`
+							] = `<rootDir>${dirname}/$1`;
 						}
 					}
 				}


### PR DESCRIPTION
I'll be making the requisite changes in liferay-portal to make this workaround no longer necessary (see [LPS-98114](https://issues.liferay.com/browse/LPS-98114)).

Once that is done, all package.json files in liferay-portal will have a "main" that points at an actual file (not a directory), or they won't have a "main" at all.

Closes: https://github.com/liferay/liferay-npm-tools/issues/162