### PR TITLE
fix(scripts): make soy resolver overrides work with ".soy" as well

### DIFF
--- a/packages/liferay-npm-scripts/src/config/jest.config.js
+++ b/packages/liferay-npm-scripts/src/config/jest.config.js
@@ -23,5 +23,6 @@ module.exports = {
 		'\\.soy$': path.join(__dirname, '..', 'jest', 'transformSoy.js'),
 		'.+': path.join(__dirname, '..', 'jest', 'transformBabel.js')
 		/* eslint-enable sort-keys */
-	}
+	},
+	transformIgnorePatterns: ['/node_modules/', '<rootDir>/.*\\.soy$']
 };

--- a/packages/liferay-npm-scripts/src/jest/resolver.js
+++ b/packages/liferay-npm-scripts/src/jest/resolver.js
@@ -18,10 +18,16 @@ module.exports = function(request, options) {
 	const {basedir, defaultResolver} = options;
 
 	// Redirect imports to .soy.js files from input to output directory
-	if (basedir.startsWith(CWD) && request.endsWith('.soy.js')) {
-		const dir = basedir.replace(INPUT, OUTPUT);
+	if (basedir.startsWith(CWD)) {
+		if (/\.soy(?:\.js)?$/.test(request)) {
+			const dir = basedir.replace(INPUT, OUTPUT);
 
-		return path.join(dir, request);
+			return path.join(
+				dir,
+				path.dirname(request),
+				path.basename(request, '.js') + '.js'
+			);
+		}
 	}
 
 	// Fallback to default resolver


### PR DESCRIPTION
We have a mix of these two import styles in liferay-portal:

    import templates from './Thing.soy';
    import templates from './Other.soy.js';

- ".soy": about 93 hits (via `git grep "import.+\.soy'" -- '*.js'`)
- ".soy.js": about 65 hits (via `git grep "import.+\.soy\.js'" -- '*.js'`)

As such, the resolver hack that we had in place for ".soy.js" files was brittle.

In this commit, I make it work for both. If the requested file ends in either extension and passes our `basedir` (ie. own project) check, then we rewrite it, and normalize the extension to always be ".soy.js".

On the source side, I am preparing a commit to liferay-portal that makes us use ".soy" everywhere; in general we don't want an explicit ".js" extension in any `import` statement, because it is inconsistent.

I'll follow that up with a lint to ensure that we're don't let any of these creep back in.

Note also that I had to set up `transformIgnorePatterns` because once we have rewritten own-project references, we want to make sure that we require the files that we actually built (with `buildSoy`) rather than falling through to our `transformSoy` stub).