### PR TITLE
chore(scripts)!: update eslint-config-liferay v18.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "6.8.0",
-		"eslint-config-liferay": "17.0.0",
+		"eslint-config-liferay": "18.0.0",
 		"prettier": "1.19.1"
 	},
 	"jest": {

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -42,7 +42,7 @@
 		"css-loader": "^3.0.0",
 		"deepmerge": "^4.0.0",
 		"eslint": "6.8.0",
-		"eslint-config-liferay": "17.0.0",
+		"eslint-config-liferay": "18.0.0",
 		"fs-extra": "^8.1.0",
 		"globby": "11.0.0",
 		"http-proxy-middleware": "0.20.0",

--- a/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
@@ -152,7 +152,7 @@ function getMergedConfig(type, property) {
 
 			// Use default config if no user config exists
 			if (Object.keys(userConfig).length === 0) {
-				userConfig = require('../config/npmscripts.config.js');
+				userConfig = require('../config/npmscripts.config');
 			}
 
 			// Check for preset before creating config

--- a/yarn.lock
+++ b/yarn.lock
@@ -5313,10 +5313,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@17.0.0:
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-17.0.0.tgz#3a642a7e59f195688c0722a879c311b103ecbbb3"
-  integrity sha512-jzYJM6VhzFofUvw7LWkya536qrCxGwdU9p/E62lC3Wnd8UOJLKLYybyPfUU90UCsP9LpyZVtjbD1d14E+IfaQA==
+eslint-config-liferay@18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-18.0.0.tgz#13c093ddec1b67c9c8b3899c282e1a843cdab859"
+  integrity sha512-plAxtxXkt19s4+b6r+I0NuiWKJDoZY7v1x9wrEa2mjVqMQeZ9YhiQ9fy48rnLAp8e/o7iW0yo9jlrXD32zFutw==
   dependencies:
     eslint-config-prettier "^6.5.0"
     eslint-plugin-no-for-of-loops "^1.0.0"


### PR DESCRIPTION
Release notes:

https://github.com/liferay/eslint-config-liferay/releases/tag/v18.0.0

Most notably, adds a new ["liferay/import-extensions" rule](https://github.com/liferay/eslint-config-liferay/blob/9274501be1f606de8cb62b8e28e1baa24c17d7af/plugins/eslint-plugin-liferay/docs/rules/import-extensions.md) that disallows (and autofixes) unnecessary ".js" extensions in imports.

Includes autofix for this error:

    packages/liferay-npm-scripts/src/utils/getMergedConfig.js
      155:26  error  unnecessary extension in import  liferay/import-extensions