### PR TITLE
fix(scripts): treat webpack.config.js as a config file

### DIFF
--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -9,7 +9,8 @@ const CONFIG_FILES = [
 	'**/.eslintrc.js',
 	'**/.prettierrc.js',
 	'**/.stylelintrc.js',
-	'**/npmscripts.config.js'
+	'**/npmscripts.config.js',
+	'**/webpack.config.js'
 ];
 
 module.exports = {


### PR DESCRIPTION
Originally included in [the beta release](https://github.com/liferay/liferay-npm-tools/pull/361) I did yesterday, but forget to sent it to master as well, so here it goes.

---

So that we don't have to write custom ESLint exclusions just so that we
can use symbols like `require` in the config files. Will silence output
like:

    modules/apps/analytics/analytics-client-js/webpack.config.js
      15:17  error  'require' is not defined.  no-undef
      16:24  error  '__dirname' is not defined.  no-undef
      19:1  error  'module' is not defined.  no-undef