### PR TITLE
feat(scripts): expand config detection to handle more types

### DIFF
--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -9,7 +9,9 @@ const CONFIG_FILES = [
 	'**/.eslintrc.js',
 	'**/.prettierrc.js',
 	'**/.stylelintrc.js',
+	'**/gulpfile.js',
 	'**/npmscripts.config.js',
+	'**/webpack.config.dev.js',
 	'**/webpack.config.js'
 ];
 


### PR DESCRIPTION
As described [here](https://github.com/liferay/liferay-npm-tools/pull/363#issuecomment-580724595).

If we grow the list in this way, it enables us to delete 8 of 32 `.eslintrc.js` config files in liferay-portal, and trim down 1 others.

The only thing I am not a huge fan of is having to list `webpack.config.dev.js` separately from `webpack.config.js`; but I think that might be preferable to using a more complicated glob like `**/webpack.config*.js` -- these are the only webpack config files we have the repo in any case and I don't think we'll ever have much more than these:

- `modules/apps/frontend-js/frontend-js-web/webpack.config.js`
- `modules/apps/frontend-js/frontend-js-web/webpack.config.dev.js`
- `modules/apps/analytics/analytics-client-js/webpack.config.js`