### PR TITLE
feat(scripts): expose "prettier" subcommand

### DIFF
--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -82,7 +82,7 @@ One way to run prettier from Vim is with [the vim-prettier plugin](https://githu
 let g:prettier#exec_cmd_path = "~/bin/prettier.sh"
 ```
 
-Once you have configured the script to know where your liferay-portal checkout is by setting the `$PORTAL` variable, you can use the `:Prettier` command and others provided by the vim-prettier plugin in Vim, and it will use your script instead of the upstream version of Prettier. The script tries first to find the `liferay-npm-scripts` version, then `prettier`, and ultimately will fall back to `npx prettier` as a last resort. When working outside of the `$PORTAL` directory, it doesn't try to use the version provided by `liferay-npm-scripts`.
+Now you can use the `:Prettier` command and others provided by the vim-prettier plugin in Vim, and it will use your script instead of the upstream version of Prettier. The script tries first to find the `liferay-npm-scripts` version, then `prettier`, and ultimately will fall back to `npx prettier` as a last resort. When working outside of a liferay-portal clone, it doesn't try to use the version provided by `liferay-npm-scripts`.
 
 If you don't want to install vim-prettier, you can of course run the script directly using the `!` command:
 

--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -102,6 +102,14 @@ And you can always call directly into `liferay-npm-scripts` if you prefer:
 !path/to/liferay-npm-scripts prettier --write %
 ```
 
+#### Visual Studio Code
+
+A popular choice for running prettier from VSCode is the "[Prettier - Code Formatter](https://github.com/prettier/prettier-vscode)" extension.
+
+You can take [this sample wrapper module](./contrib/prettier/prettier.js) and configure the extension to use it instead of the standard `prettier` one. Just say you had the script at `~/bin/prettier.js`, in the UI you would go to `Preferences` → `Settings` → `User` → `Extensions` → `Prettier` → `Prettier Path` and set it to `~/bin/prettier.js`. Alternatively, if you prefer to manipulate the VSCode `settings.json` file directly, you would set `prettier.prettierPath` to `~/bin/prettier.js`.
+
+The wrapper script attempts to detect when you are working in a liferay-portal checkout and uses the customized Prettier formatting in that case; otherwise, it falls back to the standard behavior.
+
 ### test
 
 ```sh

--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -96,7 +96,7 @@ Or, if the script is in your path:
 !prettier.sh --write %
 ```
 
-And you can of course always call directly into liferay-npm-scripts if you prefer:
+And you can always call directly into `liferay-npm-scripts` if you prefer:
 
 ```
 !path/to/liferay-npm-scripts prettier --write %

--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -36,7 +36,9 @@ Do you need to use `liferay-npm-bridge-generator`? Just add a `.npmbridgerc` fil
 liferay-npm-scripts check
 ```
 
-Check calls `prettier` with the `--check` flag for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L25-L32).
+`check` runs ESLint to catch semantic problems (equivalent to running `eslint` without the `--fix` option) and Prettier to catch formatting issues (equivalent to running `prettier` with the `--check` flag) for the globs specified in your `npmscripts.config.js` configuration (or, in the absence of explicit configuration, in [the default preset](./src/presets/standard/index.js#L25-L32)).
+
+This is the task that runs in liferay-portal projects when you run `yarn checkFormat`.
 
 ### fix
 
@@ -44,7 +46,31 @@ Check calls `prettier` with the `--check` flag for the globs specified in your `
 liferay-npm-scripts fix
 ```
 
-Fix calls `prettier` with the `--write` flag for the globs specified in your `npmscripts.config.js` configuration. Or default preset seen [here](./src/presets/standard/index.js#L17-L24).
+`fix` runs ESLint and fixes autofixable issues (equivalent to passing the `--fix` option) and runs Prettier to enforce formatting (equivalent to calling `prettier` with the `--write` flag) for the globs specified in your `npmscripts.config.js` configuration (or, in the absence of explicit configuration, in [the default preset](./src/presets/standard/index.js#L17-L24)).
+
+This is the task that runs in liferay-portal projects when you run `yarn format` (or `gradlew formatSource -a`, or `ant format-source`).
+
+### prettier
+
+```sh
+liferay-npm-scripts prettier
+```
+
+When liferay-npm-scripts uses Prettier, it additionally applies some tweaks in a post-processing step to match liferay-portal coding conventions. Normally, you will want to run `liferay-npm-scripts check` or `liferay-npm-scripts fix` as described above rather than interacting with the `prettier` executable directly.
+
+However, in order to facilitate integration with editors and editor plugins, this subcommand exposes the augmented version of `prettier`, providing this "Prettier plus post-processing" functionality, using an interface that is similar to that of the `prettier` executable. Example usage:
+
+```sh
+liferay-npm-scripts prettier --write src/someFileToFormat.js
+```
+
+Supported flags:
+
+-   `--stdin-filepath=FILEPATH`
+-   `--stdin`
+-   `--write`
+
+All other `prettier` flags are ignored.
 
 ### test
 

--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -84,6 +84,24 @@ let g:prettier#exec_cmd_path = "~/bin/prettier.sh"
 
 Once you have configured the script to know where your liferay-portal checkout is by setting the `$PORTAL` variable, you can use the `:Prettier` command and others provided by the vim-prettier plugin in Vim, and it will use your script instead of the upstream version of Prettier. The script tries first to find the `liferay-npm-scripts` version, then `prettier`, and ultimately will fall back to `npx prettier` as a last resort. When working outside of the `$PORTAL` directory, it doesn't try to use the version provided by `liferay-npm-scripts`.
 
+If you don't want to install vim-prettier, you can of course run the script directly using the `!` command:
+
+```
+!~/bin/prettier.sh --write %
+```
+
+Or, if the script is in your path:
+
+```
+!prettier.sh --write %
+```
+
+And you can of course always call directly into liferay-npm-scripts if you prefer:
+
+```
+!path/to/liferay-npm-scripts prettier --write %
+```
+
 ### test
 
 ```sh

--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -61,7 +61,7 @@ When liferay-npm-scripts uses Prettier, it additionally applies some tweaks in a
 However, in order to facilitate integration with editors and editor plugins, this subcommand exposes the augmented version of `prettier`, providing this "Prettier plus post-processing" functionality, using an interface that is similar to that of the `prettier` executable. Example usage:
 
 ```sh
-liferay-npm-scripts prettier --write src/someFileToFormat.js
+liferay-npm-scripts prettier --write src/someFileToFormat.js 'test/**/*.js'
 ```
 
 Supported flags:

--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -72,6 +72,18 @@ Supported flags:
 
 All other `prettier` flags are ignored.
 
+#### Editor integrations
+
+##### Vim
+
+One way to run prettier from Vim is with [the vim-prettier plugin](https://github.com/prettier/vim-prettier). It comes with a setting, `g:prettier#exec_cmd_path`, that you can use to configure a custom `prettier` executable. For example, you could take [this sample shell script](./contrib/prettier/prettier.sh) and copy it somewhere such as `~/bin/`, then add a line like this to your `~/.vim/vimrc`:
+
+```
+let g:prettier#exec_cmd_path = "~/bin/prettier.sh"
+```
+
+Once you have configured the script to know where your liferay-portal checkout is by setting the `$PORTAL` variable, you can use the `:Prettier` command and others provided by the vim-prettier plugin in Vim, and it will use your script instead of the upstream version of Prettier. The script tries first to find the `liferay-npm-scripts` version, then `prettier`, and ultimately will fall back to `npx prettier` as a last resort. When working outside of the `$PORTAL` directory, it doesn't try to use the version provided by `liferay-npm-scripts`.
+
 ### test
 
 ```sh

--- a/packages/liferay-npm-scripts/contrib/prettier/prettier.js
+++ b/packages/liferay-npm-scripts/contrib/prettier/prettier.js
@@ -984,7 +984,7 @@ module.exports = {
 
 /**
  * Returns the root directory if `filepath` is inside a liferay-portal
- * checkout, otherwise return null.
+ * checkout, otherwise returns null.
  */
 function getPortalRoot(filepath) {
 	// Walk up until we find portal-web (in the root).

--- a/packages/liferay-npm-scripts/contrib/prettier/prettier.js
+++ b/packages/liferay-npm-scripts/contrib/prettier/prettier.js
@@ -1,0 +1,1080 @@
+/**
+ * © 2020 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Sample script that you can drop into your path to expose the
+ * "liferay-npm-scripts prettier" subcommand to VSCode
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+let outputChannel;
+
+// Keep this debug function around because debugging VSCode extensions is a
+// pain.
+//
+// eslint-disable-next-line no-unused-vars
+const debug = line => {
+	try {
+		if (!outputChannel) {
+			const {window} = require('vscode');
+
+			outputChannel = window.createOutputChannel('greg');
+		}
+
+		outputChannel.appendLine(line);
+	} catch (_error) {
+		// All hope is lost.
+	}
+};
+
+// Remember last-used prettier instance so that it can be used as a fallback.
+let prettier;
+
+/**
+ * Exports properties required by the prettier-vscode plugin.
+ *
+ * See: https://github.com/prettier/prettier-vscode/blob/cd1b3aa1f40f9fb5/src/ModuleResolver.ts#L122-L127
+ */
+module.exports = {
+	format(source, options = {}) {
+		const prettier = prepare(options.filepath);
+
+		if (prettier) {
+			return prettier.format(source, options);
+		} else {
+			// Last-resort fallback.
+			return source;
+		}
+	},
+
+	getFileInfo(filepath, options = {}) {
+		const prettier = prepare(filepath);
+
+		if (prettier) {
+			return prettier.getFileInfo(filepath, options);
+		} else {
+			return Promise.resolve({
+				ignored: false,
+				inferredParser: 'babel'
+			});
+		}
+	},
+
+	getSupportInfo(version) {
+		const prettier = prepare();
+
+		if (prettier) {
+			return prettier.getSupportInfo(version);
+		} else {
+			// Fallback snapshot from current version of Prettier (1.19.1).
+			/* eslint-disable sort-keys */
+			return {
+				languages: [
+					{
+						name: 'JavaScript',
+						type: 'programming',
+						tmScope: 'source.js',
+						aceMode: 'javascript',
+						codemirrorMode: 'javascript',
+						codemirrorMimeType: 'text/javascript',
+						color: '#f1e05a',
+						aliases: ['js', 'node'],
+						extensions: [
+							'.js',
+							'._js',
+							'.bones',
+							'.es',
+							'.es6',
+							'.frag',
+							'.gs',
+							'.jake',
+							'.jsb',
+							'.jscad',
+							'.jsfl',
+							'.jsm',
+							'.jss',
+							'.mjs',
+							'.njs',
+							'.pac',
+							'.sjs',
+							'.ssjs',
+							'.xsjs',
+							'.xsjslib'
+						],
+						filenames: ['Jakefile'],
+						interpreters: [
+							'chakra',
+							'd8',
+							'js',
+							'node',
+							'rhino',
+							'v8',
+							'v8-shell',
+							'nodejs'
+						],
+						linguistLanguageId: 183,
+						since: '0.0.0',
+						parsers: ['babel', 'flow'],
+						vscodeLanguageIds: ['javascript', 'mongo']
+					},
+					{
+						name: 'Flow',
+						type: 'programming',
+						tmScope: 'source.js',
+						aceMode: 'javascript',
+						codemirrorMode: 'javascript',
+						codemirrorMimeType: 'text/javascript',
+						color: '#f1e05a',
+						aliases: [],
+						extensions: ['.js.flow'],
+						filenames: [],
+						interpreters: [
+							'chakra',
+							'd8',
+							'js',
+							'node',
+							'rhino',
+							'v8',
+							'v8-shell'
+						],
+						linguistLanguageId: 183,
+						since: '0.0.0',
+						parsers: ['babel', 'flow'],
+						vscodeLanguageIds: ['javascript']
+					},
+					{
+						name: 'JSX',
+						type: 'programming',
+						group: 'JavaScript',
+						extensions: ['.jsx'],
+						tmScope: 'source.js.jsx',
+						aceMode: 'javascript',
+						codemirrorMode: 'jsx',
+						codemirrorMimeType: 'text/jsx',
+						linguistLanguageId: 178,
+						since: '0.0.0',
+						parsers: ['babel', 'flow'],
+						vscodeLanguageIds: ['javascriptreact']
+					},
+					{
+						name: 'TypeScript',
+						type: 'programming',
+						color: '#2b7489',
+						aliases: ['ts'],
+						interpreters: ['deno', 'ts-node'],
+						extensions: ['.ts'],
+						tmScope: 'source.ts',
+						aceMode: 'typescript',
+						codemirrorMode: 'javascript',
+						codemirrorMimeType: 'application/typescript',
+						linguistLanguageId: 378,
+						since: '1.4.0',
+						parsers: ['typescript'],
+						vscodeLanguageIds: ['typescript']
+					},
+					{
+						name: 'TSX',
+						type: 'programming',
+						group: 'TypeScript',
+						extensions: ['.tsx'],
+						tmScope: 'source.tsx',
+						aceMode: 'javascript',
+						codemirrorMode: 'jsx',
+						codemirrorMimeType: 'text/jsx',
+						linguistLanguageId: 94901924,
+						since: '1.4.0',
+						parsers: ['typescript'],
+						vscodeLanguageIds: ['typescriptreact']
+					},
+					{
+						name: 'JSON.stringify',
+						type: 'data',
+						tmScope: 'source.json',
+						aceMode: 'json',
+						codemirrorMode: 'javascript',
+						codemirrorMimeType: 'application/json',
+						searchable: false,
+						extensions: [],
+						filenames: [
+							'package.json',
+							'package-lock.json',
+							'composer.json'
+						],
+						linguistLanguageId: 174,
+						since: '1.13.0',
+						parsers: ['json-stringify'],
+						vscodeLanguageIds: ['json']
+					},
+					{
+						name: 'JSON',
+						type: 'data',
+						tmScope: 'source.json',
+						aceMode: 'json',
+						codemirrorMode: 'javascript',
+						codemirrorMimeType: 'application/json',
+						searchable: false,
+						extensions: [
+							'.json',
+							'.avsc',
+							'.geojson',
+							'.gltf',
+							'.har',
+							'.ice',
+							'.JSON-tmLanguage',
+							'.jsonl',
+							'.mcmeta',
+							'.tfstate',
+							'.tfstate.backup',
+							'.topojson',
+							'.webapp',
+							'.webmanifest',
+							'.yy',
+							'.yyp'
+						],
+						filenames: [
+							'.arcconfig',
+							'.htmlhintrc',
+							'.tern-config',
+							'.tern-project',
+							'.watchmanconfig',
+							'composer.lock',
+							'mcmod.info',
+							'.prettierrc'
+						],
+						linguistLanguageId: 174,
+						since: '1.5.0',
+						parsers: ['json'],
+						vscodeLanguageIds: ['json']
+					},
+					{
+						name: 'JSON with Comments',
+						type: 'data',
+						group: 'JSON',
+						tmScope: 'source.js',
+						aceMode: 'javascript',
+						codemirrorMode: 'javascript',
+						codemirrorMimeType: 'text/javascript',
+						aliases: ['jsonc'],
+						extensions: [
+							'.sublime-build',
+							'.sublime-commands',
+							'.sublime-completions',
+							'.sublime-keymap',
+							'.sublime-macro',
+							'.sublime-menu',
+							'.sublime-mousemap',
+							'.sublime-project',
+							'.sublime-settings',
+							'.sublime-theme',
+							'.sublime-workspace',
+							'.sublime_metrics',
+							'.sublime_session'
+						],
+						filenames: [
+							'.babelrc',
+							'.eslintrc.json',
+							'.jscsrc',
+							'.jshintrc',
+							'.jslintrc',
+							'jsconfig.json',
+							'language-configuration.json',
+							'tsconfig.json',
+							'.eslintrc'
+						],
+						linguistLanguageId: 423,
+						since: '1.5.0',
+						parsers: ['json'],
+						vscodeLanguageIds: ['jsonc']
+					},
+					{
+						name: 'JSON5',
+						type: 'data',
+						extensions: ['.json5'],
+						tmScope: 'source.js',
+						aceMode: 'javascript',
+						codemirrorMode: 'javascript',
+						codemirrorMimeType: 'application/json',
+						linguistLanguageId: 175,
+						since: '1.13.0',
+						parsers: ['json5'],
+						vscodeLanguageIds: ['json5']
+					},
+					{
+						name: 'CSS',
+						type: 'markup',
+						tmScope: 'source.css',
+						aceMode: 'css',
+						codemirrorMode: 'css',
+						codemirrorMimeType: 'text/css',
+						color: '#563d7c',
+						extensions: ['.css'],
+						linguistLanguageId: 50,
+						since: '1.4.0',
+						parsers: ['css'],
+						vscodeLanguageIds: ['css']
+					},
+					{
+						name: 'PostCSS',
+						type: 'markup',
+						tmScope: 'source.postcss',
+						group: 'CSS',
+						extensions: ['.pcss', '.postcss'],
+						aceMode: 'text',
+						linguistLanguageId: 262764437,
+						since: '1.4.0',
+						parsers: ['css'],
+						vscodeLanguageIds: ['postcss']
+					},
+					{
+						name: 'Less',
+						type: 'markup',
+						group: 'CSS',
+						extensions: ['.less'],
+						tmScope: 'source.css.less',
+						aceMode: 'less',
+						codemirrorMode: 'css',
+						codemirrorMimeType: 'text/css',
+						linguistLanguageId: 198,
+						since: '1.4.0',
+						parsers: ['less'],
+						vscodeLanguageIds: ['less']
+					},
+					{
+						name: 'SCSS',
+						type: 'markup',
+						tmScope: 'source.css.scss',
+						group: 'CSS',
+						aceMode: 'scss',
+						codemirrorMode: 'css',
+						codemirrorMimeType: 'text/x-scss',
+						extensions: ['.scss'],
+						linguistLanguageId: 329,
+						since: '1.4.0',
+						parsers: ['scss'],
+						vscodeLanguageIds: ['scss']
+					},
+					{
+						name: 'GraphQL',
+						type: 'data',
+						extensions: ['.graphql', '.gql', '.graphqls'],
+						tmScope: 'source.graphql',
+						aceMode: 'text',
+						linguistLanguageId: 139,
+						since: '1.5.0',
+						parsers: ['graphql'],
+						vscodeLanguageIds: ['graphql']
+					},
+					{
+						name: 'Markdown',
+						type: 'prose',
+						aliases: ['pandoc'],
+						aceMode: 'markdown',
+						codemirrorMode: 'gfm',
+						codemirrorMimeType: 'text/x-gfm',
+						wrap: true,
+						extensions: [
+							'.md',
+							'.markdown',
+							'.mdown',
+							'.mdwn',
+							'.mkd',
+							'.mkdn',
+							'.mkdown',
+							'.ronn',
+							'.workbook'
+						],
+						filenames: ['contents.lr', 'README'],
+						tmScope: 'source.gfm',
+						linguistLanguageId: 222,
+						since: '1.8.0',
+						parsers: ['markdown'],
+						vscodeLanguageIds: ['markdown']
+					},
+					{
+						name: 'MDX',
+						type: 'prose',
+						aliases: ['pandoc'],
+						aceMode: 'markdown',
+						codemirrorMode: 'gfm',
+						codemirrorMimeType: 'text/x-gfm',
+						wrap: true,
+						extensions: ['.mdx'],
+						filenames: [],
+						tmScope: 'source.gfm',
+						linguistLanguageId: 222,
+						since: '1.15.0',
+						parsers: ['mdx'],
+						vscodeLanguageIds: ['mdx']
+					},
+					{
+						name: 'Angular',
+						type: 'markup',
+						tmScope: 'text.html.basic',
+						aceMode: 'html',
+						codemirrorMode: 'htmlmixed',
+						codemirrorMimeType: 'text/html',
+						color: '#e34c26',
+						aliases: ['xhtml'],
+						extensions: ['.component.html'],
+						linguistLanguageId: 146,
+						since: '1.15.0',
+						parsers: ['angular'],
+						vscodeLanguageIds: ['html'],
+						filenames: []
+					},
+					{
+						name: 'HTML',
+						type: 'markup',
+						tmScope: 'text.html.basic',
+						aceMode: 'html',
+						codemirrorMode: 'htmlmixed',
+						codemirrorMimeType: 'text/html',
+						color: '#e34c26',
+						aliases: ['xhtml'],
+						extensions: [
+							'.html',
+							'.htm',
+							'.html.hl',
+							'.inc',
+							'.st',
+							'.xht',
+							'.xhtml',
+							'.mjml'
+						],
+						linguistLanguageId: 146,
+						since: '1.15.0',
+						parsers: ['html'],
+						vscodeLanguageIds: ['html']
+					},
+					{
+						name: 'Lightning Web Components',
+						type: 'markup',
+						tmScope: 'text.html.basic',
+						aceMode: 'html',
+						codemirrorMode: 'htmlmixed',
+						codemirrorMimeType: 'text/html',
+						color: '#e34c26',
+						aliases: ['xhtml'],
+						extensions: [],
+						linguistLanguageId: 146,
+						since: '1.17.0',
+						parsers: ['lwc'],
+						vscodeLanguageIds: ['html'],
+						filenames: []
+					},
+					{
+						name: 'Vue',
+						type: 'markup',
+						color: '#2c3e50',
+						extensions: ['.vue'],
+						tmScope: 'text.html.vue',
+						aceMode: 'html',
+						linguistLanguageId: 391,
+						since: '1.10.0',
+						parsers: ['vue'],
+						vscodeLanguageIds: ['vue']
+					},
+					{
+						name: 'YAML',
+						type: 'data',
+						tmScope: 'source.yaml',
+						aliases: ['yml'],
+						extensions: [
+							'.yml',
+							'.mir',
+							'.reek',
+							'.rviz',
+							'.sublime-syntax',
+							'.syntax',
+							'.yaml',
+							'.yaml-tmlanguage',
+							'.yml.mysql'
+						],
+						filenames: [
+							'.clang-format',
+							'.clang-tidy',
+							'.gemrc',
+							'glide.lock'
+						],
+						aceMode: 'yaml',
+						codemirrorMode: 'yaml',
+						codemirrorMimeType: 'text/x-yaml',
+						linguistLanguageId: 407,
+						since: '1.14.0',
+						parsers: ['yaml'],
+						vscodeLanguageIds: ['yaml']
+					}
+				],
+				options: [
+					{
+						name: 'arrowParens',
+						since: '1.9.0',
+						category: 'JavaScript',
+						type: 'choice',
+						default: 'avoid',
+						description:
+							'Include parentheses around a sole arrow function parameter.',
+						choices: [
+							{
+								value: 'avoid',
+								description:
+									'Omit parens when possible. Example: `x => x`'
+							},
+							{
+								value: 'always',
+								description:
+									'Always include parens. Example: `(x) => x`'
+							}
+						],
+						pluginDefaults: {}
+					},
+					{
+						name: 'bracketSpacing',
+						since: '0.0.0',
+						category: 'Common',
+						type: 'boolean',
+						default: true,
+						description: 'Print spaces between brackets.',
+						oppositeDescription:
+							'Do not print spaces between brackets.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'cursorOffset',
+						since: '1.4.0',
+						category: 'Special',
+						type: 'int',
+						default: -1,
+						range: {
+							start: -1,
+							end: null,
+							step: 1
+						},
+						description:
+							'Print (to stderr) where a cursor at the given position would move to after formatting.\nThis option cannot be used with --range-start and --range-end.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'endOfLine',
+						since: '1.15.0',
+						category: 'Global',
+						type: 'choice',
+						default: 'auto',
+						description: 'Which end of line characters to apply.',
+						choices: [
+							{
+								value: 'auto',
+								description:
+									"Maintain existing\n(mixed values within one file are normalised by looking at what's used after the first line)"
+							},
+							{
+								value: 'lf',
+								description:
+									'Line Feed only (\\n), common on Linux and macOS as well as inside git repos'
+							},
+							{
+								value: 'crlf',
+								description:
+									'Carriage Return + Line Feed characters (\\r\\n), common on Windows'
+							},
+							{
+								value: 'cr',
+								description:
+									'Carriage Return character only (\\r), used very rarely'
+							}
+						],
+						pluginDefaults: {}
+					},
+					{
+						name: 'filepath',
+						since: '1.4.0',
+						category: 'Special',
+						type: 'path',
+						description:
+							'Specify the input filepath. This will be used to do parser inference.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'htmlWhitespaceSensitivity',
+						since: '1.15.0',
+						category: 'HTML',
+						type: 'choice',
+						default: 'css',
+						description: 'How to handle whitespaces in HTML.',
+						choices: [
+							{
+								value: 'css',
+								description:
+									'Respect the default value of CSS display property.'
+							},
+							{
+								value: 'strict',
+								description:
+									'Whitespaces are considered sensitive.'
+							},
+							{
+								value: 'ignore',
+								description:
+									'Whitespaces are considered insensitive.'
+							}
+						],
+						pluginDefaults: {}
+					},
+					{
+						name: 'insertPragma',
+						since: '1.8.0',
+						category: 'Special',
+						type: 'boolean',
+						default: false,
+						description:
+							"Insert @format pragma into file's first docblock comment.",
+						pluginDefaults: {}
+					},
+					{
+						name: 'jsxBracketSameLine',
+						since: '0.17.0',
+						category: 'JavaScript',
+						type: 'boolean',
+						default: false,
+						description:
+							'Put > on the last line instead of at a new line.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'jsxSingleQuote',
+						since: '1.15.0',
+						category: 'JavaScript',
+						type: 'boolean',
+						default: false,
+						description: 'Use single quotes in JSX.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'parser',
+						since: '0.0.10',
+						category: 'Global',
+						type: 'choice',
+						description: 'Which parser to use.',
+						choices: [
+							{
+								value: 'flow',
+								description: 'Flow'
+							},
+							{
+								value: 'babel',
+								since: '1.16.0',
+								description: 'JavaScript'
+							},
+							{
+								value: 'babel-flow',
+								since: '1.16.0',
+								description: 'Flow'
+							},
+							{
+								value: 'typescript',
+								since: '1.4.0',
+								description: 'TypeScript'
+							},
+							{
+								value: 'css',
+								since: '1.7.1',
+								description: 'CSS'
+							},
+							{
+								value: 'less',
+								since: '1.7.1',
+								description: 'Less'
+							},
+							{
+								value: 'scss',
+								since: '1.7.1',
+								description: 'SCSS'
+							},
+							{
+								value: 'json',
+								since: '1.5.0',
+								description: 'JSON'
+							},
+							{
+								value: 'json5',
+								since: '1.13.0',
+								description: 'JSON5'
+							},
+							{
+								value: 'json-stringify',
+								since: '1.13.0',
+								description: 'JSON.stringify'
+							},
+							{
+								value: 'graphql',
+								since: '1.5.0',
+								description: 'GraphQL'
+							},
+							{
+								value: 'markdown',
+								since: '1.8.0',
+								description: 'Markdown'
+							},
+							{
+								value: 'mdx',
+								since: '1.15.0',
+								description: 'MDX'
+							},
+							{
+								value: 'vue',
+								since: '1.10.0',
+								description: 'Vue'
+							},
+							{
+								value: 'yaml',
+								since: '1.14.0',
+								description: 'YAML'
+							},
+							{
+								value: 'html',
+								since: '1.15.0',
+								description: 'HTML'
+							},
+							{
+								value: 'angular',
+								since: '1.15.0',
+								description: 'Angular'
+							},
+							{
+								value: 'lwc',
+								since: '1.17.0',
+								description: 'Lightning Web Components'
+							}
+						],
+						pluginDefaults: {}
+					},
+					{
+						name: 'pluginSearchDirs',
+						since: '1.13.0',
+						type: 'path',
+						array: true,
+						default: [],
+						category: 'Global',
+						description:
+							'Custom directory that contains prettier plugins in node_modules subdirectory.\nOverrides default behavior when plugins are searched relatively to the location of Prettier.\nMultiple values are accepted.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'plugins',
+						since: '1.10.0',
+						type: 'path',
+						array: true,
+						default: [],
+						category: 'Global',
+						description:
+							'Add a plugin. Multiple plugins can be passed as separate `--plugin`s.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'printWidth',
+						since: '0.0.0',
+						category: 'Global',
+						type: 'int',
+						default: 80,
+						description:
+							'The line length where Prettier will try wrap.',
+						range: {
+							start: 0,
+							end: null,
+							step: 1
+						},
+						pluginDefaults: {}
+					},
+					{
+						name: 'proseWrap',
+						since: '1.8.2',
+						category: 'Common',
+						type: 'choice',
+						default: 'preserve',
+						description: 'How to wrap prose.',
+						choices: [
+							{
+								since: '1.9.0',
+								value: 'always',
+								description:
+									'Wrap prose if it exceeds the print width.'
+							},
+							{
+								since: '1.9.0',
+								value: 'never',
+								description: 'Do not wrap prose.'
+							},
+							{
+								since: '1.9.0',
+								value: 'preserve',
+								description: 'Wrap prose as-is.'
+							}
+						],
+						pluginDefaults: {}
+					},
+					{
+						name: 'quoteProps',
+						since: '1.17.0',
+						category: 'JavaScript',
+						type: 'choice',
+						default: 'as-needed',
+						description:
+							'Change when properties in objects are quoted.',
+						choices: [
+							{
+								value: 'as-needed',
+								description:
+									'Only add quotes around object properties where required.'
+							},
+							{
+								value: 'consistent',
+								description:
+									'If at least one property in an object requires quotes, quote all properties.'
+							},
+							{
+								value: 'preserve',
+								description:
+									'Respect the input use of quotes in object properties.'
+							}
+						],
+						pluginDefaults: {}
+					},
+					{
+						name: 'rangeEnd',
+						since: '1.4.0',
+						category: 'Special',
+						type: 'int',
+						default: null,
+						range: {
+							start: 0,
+							end: null,
+							step: 1
+						},
+						description:
+							'Format code ending at a given character offset (exclusive).\nThe range will extend forwards to the end of the selected statement.\nThis option cannot be used with --cursor-offset.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'rangeStart',
+						since: '1.4.0',
+						category: 'Special',
+						type: 'int',
+						default: 0,
+						range: {
+							start: 0,
+							end: null,
+							step: 1
+						},
+						description:
+							'Format code starting at a given character offset.\nThe range will extend backwards to the start of the first line containing the selected statement.\nThis option cannot be used with --cursor-offset.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'requirePragma',
+						since: '1.7.0',
+						category: 'Special',
+						type: 'boolean',
+						default: false,
+						description:
+							"Require either '@prettier' or '@format' to be present in the file's first docblock comment\nin order for it to be formatted.",
+						pluginDefaults: {}
+					},
+					{
+						name: 'semi',
+						since: '1.0.0',
+						category: 'JavaScript',
+						type: 'boolean',
+						default: true,
+						description: 'Print semicolons.',
+						oppositeDescription:
+							'Do not print semicolons, except at the beginning of lines which may need them.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'singleQuote',
+						since: '0.0.0',
+						category: 'Common',
+						type: 'boolean',
+						default: false,
+						description:
+							'Use single quotes instead of double quotes.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'tabWidth',
+						type: 'int',
+						category: 'Global',
+						default: 2,
+						description: 'Number of spaces per indentation level.',
+						range: {
+							start: 0,
+							end: null,
+							step: 1
+						},
+						pluginDefaults: {}
+					},
+					{
+						name: 'trailingComma',
+						since: '0.0.0',
+						category: 'JavaScript',
+						type: 'choice',
+						default: 'none',
+						description:
+							'Print trailing commas wherever possible when multi-line.',
+						choices: [
+							{
+								value: 'none',
+								description: 'No trailing commas.'
+							},
+							{
+								value: 'es5',
+								description:
+									'Trailing commas where valid in ES5 (objects, arrays, etc.)'
+							},
+							{
+								value: 'all',
+								description:
+									'Trailing commas wherever possible (including function arguments).'
+							}
+						],
+						pluginDefaults: {}
+					},
+					{
+						name: 'useTabs',
+						since: '1.0.0',
+						category: 'Global',
+						type: 'boolean',
+						default: false,
+						description: 'Indent with tabs instead of spaces.',
+						pluginDefaults: {}
+					},
+					{
+						name: 'vueIndentScriptAndStyle',
+						since: '1.19.0',
+						category: 'HTML',
+						type: 'boolean',
+						default: false,
+						description:
+							'Indent script and style tags in Vue files.',
+						pluginDefaults: {}
+					}
+				]
+			};
+			/* eslint-enable sort-keys */
+		}
+	},
+
+	resolveConfig(filepath, options = {}) {
+		const prettier = prepare(filepath);
+
+		if (prettier) {
+			return prettier.resolveConfig(filepath, options);
+		} else {
+			return Promise.resolve(null);
+		}
+	},
+
+	version: '1.19.1'
+};
+
+const PORTAL_WEB = 'portal-web';
+
+/**
+ * Returns the root directory if `filepath` is inside a liferay-portal
+ * checkout, otherwise return null.
+ */
+function getPortalRoot(filepath) {
+	// Walk up until we find portal-web (in the root).
+	let current = filepath;
+
+	while (true) {
+		const parent = path.dirname(current);
+
+		const candidate = path.join(parent, PORTAL_WEB);
+
+		if (fs.existsSync(candidate)) {
+			current = candidate;
+
+			break;
+		} else {
+			if (parent === current) {
+				// Can't go any higher.
+				return null;
+			}
+
+			current = parent;
+		}
+	}
+
+	// Confirm that this really is liferay-portal by looking down.
+	if (fs.existsSync(path.join(current, 'docroot/WEB-INF/liferay-web.xml'))) {
+		return path.dirname(current);
+	} else {
+		return null;
+	}
+}
+
+/**
+ * Hack because current working directory will usually be "/" in
+ * the context of a VSCode extension, which means that our require
+ * statements won't work: liferay-portal's node_modules folder is
+ * obviously not at "/", and the extension's is generally hidden
+ * somewhere under "~/.vscode/extensions".
+ */
+function prepare(filepath) {
+	if (!filepath) {
+		return prettier;
+	}
+
+	const cwd = process.cwd();
+
+	let dir = '.';
+
+	let file = 'prettier';
+
+	const root = getPortalRoot(filepath);
+
+	if (root) {
+		const modules = path.join(root, 'modules/node_modules');
+
+		const scripts = path.join(modules, 'liferay-npm-scripts');
+
+		const wrapper = path.join(scripts, 'src/scripts/prettier.js');
+
+		const fallback = path.join(modules, 'prettier/bin-prettier.js');
+
+		if (fs.existsSync(wrapper)) {
+			dir = scripts;
+			file = wrapper;
+		} else if (fs.existsSync(fallback)) {
+			dir = modules;
+			file = fallback;
+		}
+	} else {
+		const extension = require('vscode').extensions.getExtension(
+			'esbenp.prettier-vscode'
+		);
+
+		if (extension) {
+			dir = path.join(extension.extensionPath);
+			file = path.join(dir, 'node_modules/prettier');
+		}
+	}
+	try {
+		process.chdir(dir);
+
+		// eslint-disable-next-line liferay/no-dynamic-require
+		prettier = require(file);
+	} catch (_error) {
+		// All hope is lost.
+	} finally {
+		process.chdir(cwd);
+	}
+
+	return prettier;
+}

--- a/packages/liferay-npm-scripts/contrib/prettier/prettier.js
+++ b/packages/liferay-npm-scripts/contrib/prettier/prettier.js
@@ -982,8 +982,6 @@ module.exports = {
 	version: '1.19.1'
 };
 
-const PORTAL_WEB = 'portal-web';
-
 /**
  * Returns the root directory if `filepath` is inside a liferay-portal
  * checkout, otherwise return null.
@@ -995,7 +993,7 @@ function getPortalRoot(filepath) {
 	while (true) {
 		const parent = path.dirname(current);
 
-		const candidate = path.join(parent, PORTAL_WEB);
+		const candidate = path.join(parent, 'portal-web');
 
 		if (fs.existsSync(candidate)) {
 			current = candidate;

--- a/packages/liferay-npm-scripts/contrib/prettier/prettier.sh
+++ b/packages/liferay-npm-scripts/contrib/prettier/prettier.sh
@@ -5,9 +5,20 @@
 # "liferay-npm-scripts prettier" subcommand to plugins.
 #
 
-PORTAL=~/code/portal/liferay-portal
+# Auto-detect liferay-portal checkout.
+while [[ $PWD != '/' ]]; do
+	if [ -d portal-web ]; then
+		if [ -e portal-web/docroot/WEB-INF/liferay-web.xml ]; then
+			PORTAL="$PWD"
+		fi
 
-if [ "${PWD##$PORTAL}" != "${PWD}" ]; then
+		break
+	else
+		cd ..
+	fi
+done
+
+if [ -n "$PORTAL" ]; then
   LIFERAY_NPM_SCRIPTS="$PORTAL/modules/node_modules/liferay-npm-scripts/bin/liferay-npm-scripts.js"
   LIFERAY_PRETTIER="$PORTAL/modules/node_modules/prettier/bin-prettier.js"
 else

--- a/packages/liferay-npm-scripts/contrib/prettier/prettier.sh
+++ b/packages/liferay-npm-scripts/contrib/prettier/prettier.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+#
+# Sample script that you can drop into your path to expose the
+# "liferay-npm-scripts prettier" subcommand to plugins.
+#
+
+PORTAL=~/code/portal/liferay-portal
+
+if [ "${PWD##$PORTAL}" != "${PWD}" ]; then
+  LIFERAY_NPM_SCRIPTS="$PORTAL/modules/node_modules/liferay-npm-scripts/bin/liferay-npm-scripts.js"
+  LIFERAY_PRETTIER="$PORTAL/modules/node_modules/prettier/bin-prettier.js"
+else
+  LIFERAY_NPM_SCRIPTS=""
+  LIFERAY_PRETTIER=""
+fi
+
+if [ -x "$LIFERAY_NPM_SCRIPTS" ]; then
+  "$LIFERAY_NPM_SCRIPTS" prettier "$@"
+elif [ -x "$LIFERAY_PRETTIER" ]; then
+  "$LIFERAY_PRETTIER" "$@"
+elif command -v prettier > /dev/null; then
+  prettier "$@"
+elif command -v npx > /dev/null; then
+  npx --quiet prettier "$@"
+else
+  echo "error: No prettier or npx executable found"
+  exit 1
+fi

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -26,6 +26,10 @@ module.exports = async function() {
 			await require('./scripts/fix')();
 		},
 
+		prettier() {
+			require('./scripts/prettier')(...ARGS_ARRAY.slice(1));
+		},
+
 		storybook() {
 			require('./scripts/storybook')();
 		},

--- a/packages/liferay-npm-scripts/src/scripts/prettier.js
+++ b/packages/liferay-npm-scripts/src/scripts/prettier.js
@@ -53,7 +53,7 @@ module.exports = function(...args) {
 		'--end-of-line=': ignore,
 		'--file-info=': ignore,
 		'--find-config-path=': ignore,
-		'--help': ignore,
+		'--help': help,
 		'--html-whitespace-sensitivity=': ignore,
 		'--ignore-path=': ignore,
 		'--insert-pragma': ignore,
@@ -93,7 +93,7 @@ module.exports = function(...args) {
 		'--with-node-modules': ignore,
 		'--write': set('write', true),
 		'-c': unsupported,
-		'-h': ignore,
+		'-h': help,
 		'-l': unsupported,
 		'-v': version
 	};
@@ -192,6 +192,18 @@ module.exports = function(...args) {
 
 function exit() {
 	process.exit(0);
+}
+
+function help() {
+	write(
+		'Usage: prettier [options] [file/glob ...]\n' +
+			'\n' +
+			'  --stdin                  Force reading input from stdin.\n' +
+			'  --stdin-filepath <path>  Path to the file to pretend that stdin comes from.\n' +
+			'  --write                  Edit files in-place. (Beware!)\n'
+	);
+
+	exit();
 }
 
 function isGlob(pattern) {

--- a/packages/liferay-npm-scripts/src/scripts/prettier.js
+++ b/packages/liferay-npm-scripts/src/scripts/prettier.js
@@ -1,0 +1,213 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const fs = require('fs');
+const prettier = require('prettier');
+
+const isJSP = require('../jsp/isJSP');
+const {format} = require('../prettier');
+const formatJSP = require('../jsp/formatJSP');
+const getMergedConfig = require('../utils/getMergedConfig');
+const getPaths = require('../utils/getPaths');
+
+const EXTENSIONS = ['.js', '.jsp', '.jspf', '.scss'];
+
+const IGNORE_FILE = '.prettierignore';
+
+/**
+ * Exposes a version of our augumented Prettier suitable for use within editors
+ * and editor plugins.
+ */
+module.exports = function(...args) {
+	let i;
+
+	let files = [];
+
+	const ignore = () => {};
+
+	const options = {};
+
+	const set = function(key, value) {
+		if (arguments.length === 2) {
+			return () => {
+				options[key] = value;
+			};
+		} else {
+			return value => {
+				options[key] = value;
+			};
+		}
+	};
+
+	const unsupported = () => {
+		throw new Error(`Unsupported option ${args[i]}`);
+	};
+
+	const OPTS = {
+		'-c': unsupported,
+		'--check': unsupported,
+		'-l': unsupported,
+		'--list-different': unsupported,
+		'--write': set('write', true),
+		'--arrow-parens=': ignore,
+		'--no-bracket-spacing': ignore,
+		'--end-of-line=': ignore,
+		'--html-whitespace-sensitivity=': ignore,
+		'--jsx-bracket-same-line': ignore,
+		'--jsx-single-quote': ignore,
+		'--parser=': ignore,
+		'--print-width=': ignore,
+		'--prose-wrap=': ignore,
+		'--quote-props=': ignore,
+		'--no-semi': ignore,
+		'--single-quote': ignore,
+		'--tab-width=': ignore,
+		'--trailing-comma=': ignore,
+		'--use-tabs': ignore,
+		'--vue-indent-script-and-style': ignore,
+		'--config=': ignore,
+		'--no-config': ignore,
+		'--config-precedence=': ignore,
+		'--no-editorconfig': ignore,
+		'--find-config-path=': ignore,
+		'--ignore-path=': ignore,
+		'--plugin=': ignore,
+		'--plugin-search-dir=': ignore,
+		'--with-node-modules': ignore,
+		'--cursor-offset=': ignore,
+		'--range-end=': ignore,
+		'--range-start': ignore,
+		'--no-color': ignore,
+		'--file-info=': ignore,
+		'-h': ignore,
+		'--help': ignore,
+		'--insert-pragma': ignore,
+		'--loglevel=': ignore,
+		'--require-pragma': ignore,
+		'--stdin': set('stdin', true),
+		'--stdin-filepath=': set('stdinFilepath'),
+		'--support-info': () => {
+			const info = prettier.getSupportInfo();
+
+			write(JSON.stringify(info, null, 2));
+
+			exit();
+		},
+		'-v': version,
+		'--version': version
+	};
+
+	for (i = 0; i < args.length; i++) {
+		const arg = args[i];
+
+		let handler;
+
+		Object.entries(OPTS).find(([option, callback]) => {
+			if (option.endsWith('=')) {
+				if (arg === option.slice(0, -1)) {
+					// eg. "--some-opt value"
+					value = args[++i];
+
+					handler = callback.bind(null, value);
+				} else if (arg.startsWith(option)) {
+					// eg. "--some-opt=value"
+					value = arg.slice(option.length);
+
+					handler = callback.bind(null, value);
+				}
+			} else if (arg === option) {
+				// eg. "--flag"
+				handler = callback;
+			}
+
+			return handler;
+		});
+
+		if (handler) {
+			handler();
+		} else if (arg.startsWith('-')) {
+			// Unknown option, just ignore it.
+		} else if (isGlob(arg)) {
+			getPaths([arg], [], IGNORE_FILE).forEach(filepath => {
+				files.push({
+					contents: null,
+					filepath
+				});
+			});
+		} else {
+			files.push({
+				contents: null,
+				filepath: arg
+			});
+		}
+	}
+
+	const config = getMergedConfig('prettier');
+
+	if (options.stdin) {
+		// When `--stdin` is in effect, Prettier ignores file arguments
+		// and the `--write` option, requires --stdin-filepath, and
+		// prints the output to stdout.
+		if (!options.stdinFilepath) {
+			throw new Error(`No --stdin-filepath provided`);
+		}
+
+		options.write = false;
+
+		files = [
+			{
+				contents: fs.readFileSync(0, 'utf8'),
+				filepath: options.stdinFilepath
+			}
+		];
+	}
+
+	if (!files.length) {
+		throw new Error('No matching files');
+	}
+
+	files.forEach(({contents, filepath}) => {
+		contents =
+			contents === null ? fs.readFileSync(filepath, 'utf8') : contents;
+
+		const prettierOptions = {
+			...config,
+			filepath
+		};
+
+		if (isJSP(filepath)) {
+			contents = formatJSP(contents, prettierOptions);
+		} else {
+			contents = format(contents, prettierOptions);
+		}
+
+		if (options.write) {
+			fs.writeFileSync(filepath, contents);
+		} else {
+			write(contents);
+		}
+	});
+};
+
+function exit() {
+	process.exit(0);
+}
+
+function isGlob(pattern) {
+	return pattern.startsWith('!') || pattern.includes('*');
+}
+
+function version() {
+	write(prettier.version);
+
+	exit();
+}
+
+function write(message) {
+	const newline = message.endsWith('\n' ? '' : '\n');
+
+	process.stdout.write(message + newline);
+}

--- a/packages/liferay-npm-scripts/src/scripts/prettier.js
+++ b/packages/liferay-npm-scripts/src/scripts/prettier.js
@@ -19,7 +19,7 @@ const IGNORE_FILE = '.prettierignore';
  * Exposes a version of our augumented Prettier suitable for use within editors
  * and editor plugins.
  */
-module.exports = function(...args) {
+function main(...args) {
 	let i;
 
 	let files = [];
@@ -188,7 +188,28 @@ module.exports = function(...args) {
 			write(contents);
 		}
 	});
-};
+}
+
+/**
+ * Properties required by the prettier-vscode plugin.
+ *
+ * See: https://github.com/prettier/prettier-vscode/blob/cd1b3aa1f40f9fb5/src/ModuleResolver.ts#L122-L127
+ */
+Object.assign(main, {
+	format(source, options = {}) {
+		const config = getMergedConfig('prettier');
+
+		return format(source, {...config, filepath: options.filepath});
+	},
+
+	getFileInfo: prettier.getFileInfo,
+
+	getSupportInfo: prettier.getSupportInfo,
+
+	resolveConfig: () => Promise.resolve(null),
+
+	version: prettier.version
+});
 
 function exit() {
 	process.exit(0);
@@ -221,3 +242,5 @@ function write(message) {
 
 	process.stdout.write(message + newline);
 }
+
+module.exports = main;

--- a/packages/liferay-npm-scripts/src/scripts/prettier.js
+++ b/packages/liferay-npm-scripts/src/scripts/prettier.js
@@ -7,13 +7,11 @@
 const fs = require('fs');
 const prettier = require('prettier');
 
+const formatJSP = require('../jsp/formatJSP');
 const isJSP = require('../jsp/isJSP');
 const {format} = require('../prettier');
-const formatJSP = require('../jsp/formatJSP');
 const getMergedConfig = require('../utils/getMergedConfig');
 const getPaths = require('../utils/getPaths');
-
-const EXTENSIONS = ['.js', '.jsp', '.jspf', '.scss'];
 
 const IGNORE_FILE = '.prettierignore';
 
@@ -47,46 +45,37 @@ module.exports = function(...args) {
 	};
 
 	const OPTS = {
-		'-c': unsupported,
-		'--check': unsupported,
-		'-l': unsupported,
-		'--list-different': unsupported,
-		'--write': set('write', true),
 		'--arrow-parens=': ignore,
-		'--no-bracket-spacing': ignore,
+		'--check': unsupported,
+		'--config=': ignore,
+		'--config-precedence=': ignore,
+		'--cursor-offset=': ignore,
 		'--end-of-line=': ignore,
+		'--file-info=': ignore,
+		'--find-config-path=': ignore,
+		'--help': ignore,
 		'--html-whitespace-sensitivity=': ignore,
+		'--ignore-path=': ignore,
+		'--insert-pragma': ignore,
 		'--jsx-bracket-same-line': ignore,
 		'--jsx-single-quote': ignore,
+		'--list-different': unsupported,
+		'--loglevel=': ignore,
+		'--no-bracket-spacing': ignore,
+		'--no-color': ignore,
+		'--no-config': ignore,
+		'--no-editorconfig': ignore,
+		'--no-semi': ignore,
 		'--parser=': ignore,
+		'--plugin=': ignore,
+		'--plugin-search-dir=': ignore,
 		'--print-width=': ignore,
 		'--prose-wrap=': ignore,
 		'--quote-props=': ignore,
-		'--no-semi': ignore,
-		'--single-quote': ignore,
-		'--tab-width=': ignore,
-		'--trailing-comma=': ignore,
-		'--use-tabs': ignore,
-		'--vue-indent-script-and-style': ignore,
-		'--config=': ignore,
-		'--no-config': ignore,
-		'--config-precedence=': ignore,
-		'--no-editorconfig': ignore,
-		'--find-config-path=': ignore,
-		'--ignore-path=': ignore,
-		'--plugin=': ignore,
-		'--plugin-search-dir=': ignore,
-		'--with-node-modules': ignore,
-		'--cursor-offset=': ignore,
 		'--range-end=': ignore,
 		'--range-start': ignore,
-		'--no-color': ignore,
-		'--file-info=': ignore,
-		'-h': ignore,
-		'--help': ignore,
-		'--insert-pragma': ignore,
-		'--loglevel=': ignore,
 		'--require-pragma': ignore,
+		'--single-quote': ignore,
 		'--stdin': set('stdin', true),
 		'--stdin-filepath=': set('stdinFilepath'),
 		'--support-info': () => {
@@ -96,8 +85,17 @@ module.exports = function(...args) {
 
 			exit();
 		},
+		'--tab-width=': ignore,
+		'--trailing-comma=': ignore,
+		'--use-tabs': ignore,
+		'--version': version,
+		'--vue-indent-script-and-style': ignore,
+		'--with-node-modules': ignore,
+		'--write': set('write', true),
+		'-c': unsupported,
+		'-h': ignore,
+		'-l': unsupported,
 		'-v': version,
-		'--version': version
 	};
 
 	for (i = 0; i < args.length; i++) {
@@ -109,12 +107,12 @@ module.exports = function(...args) {
 			if (option.endsWith('=')) {
 				if (arg === option.slice(0, -1)) {
 					// eg. "--some-opt value"
-					value = args[++i];
+					const value = args[++i];
 
 					handler = callback.bind(null, value);
 				} else if (arg.startsWith(option)) {
 					// eg. "--some-opt=value"
-					value = arg.slice(option.length);
+					const value = arg.slice(option.length);
 
 					handler = callback.bind(null, value);
 				}
@@ -207,7 +205,7 @@ function version() {
 }
 
 function write(message) {
-	const newline = message.endsWith('\n' ? '' : '\n');
+	const newline = message.endsWith('\n') ? '' : '\n';
 
 	process.stdout.write(message + newline);
 }

--- a/packages/liferay-npm-scripts/src/scripts/prettier.js
+++ b/packages/liferay-npm-scripts/src/scripts/prettier.js
@@ -95,7 +95,7 @@ module.exports = function(...args) {
 		'-c': unsupported,
 		'-h': ignore,
 		'-l': unsupported,
-		'-v': version,
+		'-v': version
 	};
 
 	for (i = 0; i < args.length; i++) {


### PR DESCRIPTION
As explained in the README, the intent here is to facilitate editor integration with our customized spin on Prettier. The idea is that instead of using the `prettier` executable, you can use `liferay-npm-scripts prettier` as a more-or-less drop-in replacement.

Next steps will involve showing how to actually use this in some editors, like Vim and VSCode.