### PR TITLE
feat(preset): set up style-loader

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -269,6 +269,10 @@
 	"output": "build/node/packageRunBuild/resources",
 	"rules": [
 		{
+			"test": "\\.css$",
+			"use": ["style-loader"]
+		},
+		{
 			"test": "\\.scss$",
 			"exclude": "node_modules",
 			"use": [

--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -6,6 +6,7 @@
 	"dependencies": {
 		"babel-preset-liferay-standard": "2.17.0",
 		"liferay-npm-bundler-loader-css-loader": "2.17.0",
+		"liferay-npm-bundler-loader-style-loader": "2.17.0",
 		"liferay-npm-bundler-plugin-exclude-imports": "2.17.0",
 		"liferay-npm-bundler-plugin-inject-imports-dependencies": "2.17.0",
 		"liferay-npm-bundler-plugin-inject-peer-dependencies": "2.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9028,6 +9028,13 @@ liferay-npm-bundler-loader-css-loader@2.17.0:
   dependencies:
     liferay-npm-build-tools-common "2.17.0"
 
+liferay-npm-bundler-loader-style-loader@2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-style-loader/-/liferay-npm-bundler-loader-style-loader-2.17.0.tgz#6e2f309d133b2cb208358f872024eb2237de1819"
+  integrity sha512-zKODY1xY/hr4YvGfc/5LlFntSq+zCx9sdj1UfL+NGtY5NS92VvS3Y4x7/3bxspXoXuDCxfGq2prOkfme+SwuDw==
+  dependencies:
+    liferay-npm-build-tools-common "2.17.0"
+
 liferay-npm-bundler-plugin-exclude-imports@2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.17.0.tgz#48d6fa5cca0707bb8dd7fab939ced6cabdf17062"


### PR DESCRIPTION
People are [using this in liferay-portal](https://github.com/brianchandotcom/liferay-portal/commit/dfb71a9dce4924f11912396f9cc1d4849874a8bd
) but we don't want people sneaking in `devDependencies` by declaring them in `dependencies`, so let's make it "official".

About the version number: that liferay-portal commit was using quite a stale version of the loaders, presumably because there was a long delay between it being written and finally being merged. This is another reason why we'd prefer to control the version numbers centrally (via this preset). Note that I'm using 2.17.0 (and not the latest, 2.17.1) just to keep this change small. There was only one small change in 2.17.1, and it doesn't seem relevant to liferay-portal (it was done for the benefit of the liferay-js-themes-toolkit):

https://github.com/liferay/liferay-js-toolkit/commit/a09456d598dac80ef0c9152b04b16c99e3425d69