### PR TITLE
feat(scripts): add "process" to the default list of globals

### DIFF
--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -25,6 +25,7 @@ module.exports = {
 		AUI: true,
 		CKEDITOR: true,
 		Liferay: true,
+		process: true,
 		submitForm: true,
 		svg4everybody: true,
 		themeDisplay: true


### PR DESCRIPTION
As explained in the related issue:

In the old days it wasn't actually safe to assume `process` was defined, because not all code passed through the bundler, which is the one that [sets up Babel](https://github.com/liferay/liferay-js-toolkit/wiki/How-to-use-liferay-npm-bundler#an-example) to use the [babel-plugin-transform-node-env-inline package](https://www.npmjs.com/package/babel-plugin-transform-node-env-inline).

But right now, pretty much everything *does* go through it, and we can afford to add `process: true` to our `globals` set-up in one place instead of sprinkling it around in various `.eslintrc.js` files.

The only exceptions I am aware of right now are our frontend-js-web Webpack bundle, which operates in `mode: 'production'` during the build and inspecting the build output I was able to confirm that `if (process.env.NODE_ENV === '...')` checks are getting correctly compiled away.

Marking this one as a "feature" because it will streamline the task of configuration in liferay-portal.

Closes: https://github.com/liferay/liferay-npm-tools/issues/369