### PR TITLE
chore: prepare liferay-npm-scripts/v24.1.0-beta.1

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "liferay-npm-scripts",
-	"version": "24.0.1",
+	"version": "24.1.0-beta.1",
 	"description": "Collection of NPM scripts used for Liferay portlets",
 	"main": "index.js",
 	"author": {


### PR DESCRIPTION
Just a draft PR for visibility. To fully test the release in liferay-portal, it's not enough to `yarn add` the local path; that mysteriously breaks the gradle build of an unrelated project — specifically, it causes `packageRunBuild.destinationDir` to be `null` in `frontend-editor/frontend-editor-ckeditor-web`, leading to this:

```
> Ambiguous method overloading for method java.io.File#<init>.
  Cannot resolve which method to invoke for [null, class java.lang.String] due to overlapping prototypes between:
        [class java.lang.String, class java.lang.String]
        [class java.io.File, class java.lang.String]
```

on [this line](https://github.com/liferay/liferay-portal/blob/3f4502ca3f108494b444c1d82598dbe5b8e34bda/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle#L55). 🤷‍♂ 