### PR TITLE
feat(scripts): catch banned dependencies in package.json file

### DIFF
--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -21,6 +21,9 @@ module.exports = {
 	},
 	check: [...JS_GLOBS, ...JSP_GLOBS, ...SCSS_GLOBS],
 	fix: [...JS_GLOBS, ...JSP_GLOBS, ...SCSS_GLOBS],
+	rules: {
+		'blacklisted-dependency-patterns': ['^liferay-npm-bundler-loader-.+']
+	},
 	storybook: {
 		languagePaths: ['src/main/resources/content/Language.properties'],
 		port: '9000',

--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -9,8 +9,16 @@ const liferay = require('./dependencies/liferay');
 const metal = require('./dependencies/metal');
 
 const JS_GLOBS = ['{src,test}/**/*.js'];
+const JSON_GLOBS = ['/*.json'];
 const JSP_GLOBS = ['src/**/*.{jsp,jspf}'];
 const SCSS_GLOBS = ['{src,test}/**/*.scss'];
+
+const CHECK_AND_FIX_GLOBS = [
+	...JS_GLOBS,
+	...JSON_GLOBS,
+	...JSP_GLOBS,
+	...SCSS_GLOBS
+];
 
 module.exports = {
 	build: {
@@ -19,8 +27,8 @@ module.exports = {
 		output: 'build/node/packageRunBuild/resources',
 		temp: 'build/npmscripts'
 	},
-	check: [...JS_GLOBS, ...JSP_GLOBS, ...SCSS_GLOBS],
-	fix: [...JS_GLOBS, ...JSP_GLOBS, ...SCSS_GLOBS],
+	check: CHECK_AND_FIX_GLOBS,
+	fix: CHECK_AND_FIX_GLOBS,
 	rules: {
 		'blacklisted-dependency-patterns': ['^liferay-npm-bundler-loader-.+']
 	},

--- a/packages/liferay-npm-scripts/src/scripts/check/preflight.js
+++ b/packages/liferay-npm-scripts/src/scripts/check/preflight.js
@@ -59,23 +59,43 @@ const DISALLOWED_CONFIG_FILE_NAMES = {
 const IGNORE_FILE = '.eslintignore';
 
 function preflight() {
+	const errors = [...checkConfigFileNames(), ...checkSourceFileNames()];
+
+	if (errors.length) {
+		log('Preflight check failed:');
+
+		log(...errors);
+
+		throw new SpawnError();
+	}
+}
+
+/**
+ * Checks that config files use standard names.
+ *
+ * Returns a (possibly empty) array of error messages.
+ */
+function checkConfigFileNames() {
 	const disallowedConfigs = getPaths(
 		Object.keys(DISALLOWED_CONFIG_FILE_NAMES),
 		[],
 		IGNORE_FILE
 	);
 
-	if (disallowedConfigs.length) {
-		log('Preflight check failed:');
+	return disallowedConfigs.map(file => {
+		const suggested = DISALLOWED_CONFIG_FILE_NAMES[path.basename(file)];
 
-		disallowedConfigs.forEach(file => {
-			const suggested = DISALLOWED_CONFIG_FILE_NAMES[path.basename(file)];
+		return `${file}: BAD - use ${suggested} instead`;
+	});
+}
 
-			log(`${file}: BAD - use ${suggested} instead`);
-		});
-
-		throw new SpawnError();
-	}
+/**
+ * Checks that source files followed standard naming patterns.
+ *
+ * Returns a (possibly empty) array of error messages.
+ */
+function checkSourceFileNames() {
+	return [];
 }
 
 module.exports = preflight;

--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -21,7 +21,7 @@ const DEFAULT_OPTIONS = {
 /**
  * File extensions that we want Prettier to process.
  */
-const EXTENSIONS = ['.js', '.jsp', '.jspf', '.scss'];
+const EXTENSIONS = ['.js', '.json', '.jsp', '.jspf', '.scss'];
 
 const IGNORE_FILE = '.prettierignore';
 


### PR DESCRIPTION
Please see the individual commit messages for details, but the gist of it is:

- We check against bad dependencies getting added to "package.json" files.
- We format the JSON with Prettier.

Beware: we can't merge this until the bundler issue [described over here](https://github.com/izaera/liferay-portal/pull/125) is fixed, because only then will we be able to remove the bad dependencies from the dynamic-data-mapping-form-field-type project.