### PR TITLE
chore(preset): update bundler dependencies to v2.18.1

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/package.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/package.json
@@ -4,14 +4,14 @@
 	"description": "Default configuration for liferay-npm-bundler inside liferay-portal.",
 	"main": "config.json",
 	"dependencies": {
-		"babel-preset-liferay-standard": "2.18.0",
-		"liferay-npm-bundler-loader-css-loader": "2.18.0",
-		"liferay-npm-bundler-plugin-exclude-imports": "2.18.0",
-		"liferay-npm-bundler-plugin-inject-imports-dependencies": "2.18.0",
-		"liferay-npm-bundler-plugin-inject-peer-dependencies": "2.18.0",
-		"liferay-npm-bundler-plugin-namespace-packages": "2.18.0",
-		"liferay-npm-bundler-plugin-replace-browser-modules": "2.18.0",
-		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.18.0"
+		"babel-preset-liferay-standard": "2.18.1",
+		"liferay-npm-bundler-loader-css-loader": "2.18.1",
+		"liferay-npm-bundler-plugin-exclude-imports": "2.18.1",
+		"liferay-npm-bundler-plugin-inject-imports-dependencies": "2.18.1",
+		"liferay-npm-bundler-plugin-inject-peer-dependencies": "2.18.1",
+		"liferay-npm-bundler-plugin-namespace-packages": "2.18.1",
+		"liferay-npm-bundler-plugin-replace-browser-modules": "2.18.1",
+		"liferay-npm-bundler-plugin-resolve-linked-dependencies": "2.18.1"
 	},
 	"homepage": "https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-npm-bundler-preset-liferay-dev",
 	"repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,6 +2819,14 @@ babel-plugin-add-module-metadata@2.18.0:
     liferay-npm-build-tools-common "2.18.0"
     read-json-sync "^2.0.1"
 
+babel-plugin-add-module-metadata@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.18.1.tgz#24309b683d3cca5485801989af7165fad5f1747a"
+  integrity sha512-uvLC4VinAuNIEFxYB6GWhLBV6G/QzN5lja9POB9yC9ZnFQ1Z6OEvj5eoGeZikeWl+QRjrNzUPPjcMr11l+0KWQ==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
+    read-json-sync "^2.0.1"
+
 babel-plugin-add-react-displayname@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
@@ -2830,6 +2838,13 @@ babel-plugin-alias-modules@2.18.0:
   integrity sha512-B5EmOlELAYU1N1ZRdU689JQYIyEwZSKWfayz7hJ3OFBoRWrSCM5RkQBi3pu2d0OBpZzyx7yfyd3KDX9FoCrUEg==
   dependencies:
     liferay-npm-build-tools-common "2.18.0"
+
+babel-plugin-alias-modules@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.18.1.tgz#f1884a293dcc52f08088b8c48e5bec1fd894f140"
+  integrity sha512-y0oBB/PfYZzuLKFcRnozSVd0ayFc6/cnSnVlGPPHvzwtusaql1cZe9LvZhpi150zgFje7uKBU/VnPho/MDd+lA==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
 
 babel-plugin-dynamic-import-node@^2.3.0:
   version "2.3.0"
@@ -2963,6 +2978,13 @@ babel-plugin-name-amd-modules@2.18.0:
   dependencies:
     liferay-npm-build-tools-common "2.18.0"
 
+babel-plugin-name-amd-modules@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.18.1.tgz#af0f14fba4cf5834eb305a8b19e0dcf0ca43e98a"
+  integrity sha512-HGu6LUoNOgdL/4AqVOgx2KTkuhufNG4UybddTCnYXDK/dxXzOZQ0UL2qsJKQGOIGIxPtiKg9vJYc9NjoS8EAaw==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
+
 babel-plugin-named-asset-import@^0.3.1:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.5.tgz#d3fa1a7f1f4babd4ed0785b75e2f926df0d70d0d"
@@ -2975,6 +2997,13 @@ babel-plugin-namespace-amd-define@2.18.0:
   dependencies:
     liferay-npm-build-tools-common "2.18.0"
 
+babel-plugin-namespace-amd-define@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.18.1.tgz#6d39dfa3b7d8c43816e4fc3e8cb0987e5d288a4e"
+  integrity sha512-4vO/eK2gp6dyT4l/wxK6oyfAXwc9irb7nmeiqQUPrKI9VUxHBEdgYchpKYClX7R5LJoqq3mvMPA0NvSCjdVCcg==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
+
 babel-plugin-namespace-modules@2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.18.0.tgz#18f77776c7589389aa909d171e94f319b1e646e7"
@@ -2982,12 +3011,26 @@ babel-plugin-namespace-modules@2.18.0:
   dependencies:
     liferay-npm-build-tools-common "2.18.0"
 
+babel-plugin-namespace-modules@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.18.1.tgz#d8f1d4f3e04c65853ff540a7411ba60e492bf9f2"
+  integrity sha512-R4xcAYC6M4LwOTIipTBrzQlBucF9EnrwUyKe6Blhc3hWnpt201eBYwK3qtoBdvKeMu76pgdaq2LWMqcCdaTe9Q==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
+
 babel-plugin-normalize-requires@2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.18.0.tgz#9fe8c8c564c358f930c73e74641dc65fb8c41958"
   integrity sha512-SVardnflwPqdpxIBFCz8WE5xa8OihrqOoaPvrsZGydUOGZLpR8OUOyWG3koizJgTJz2DqM1KiwFF+uTSOEe63Q==
   dependencies:
     liferay-npm-build-tools-common "2.18.0"
+
+babel-plugin-normalize-requires@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.18.1.tgz#a0ae87e8f82ddf913d5c5bbef852827b13fc99b8"
+  integrity sha512-0ZVYTByHKhE+piWts1uQg4ur5DPZn+8yQ1aTKbCoO7ibDbz3fPfVxvbQMk8TaLZgfY+ljvQXhHZYeJAKEvu3qw==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
 
 babel-plugin-react-docgen@^4.0.0:
   version "4.1.0"
@@ -3081,6 +3124,15 @@ babel-plugin-wrap-modules-amd@2.18.0:
     liferay-npm-build-tools-common "2.18.0"
     read-json-sync "^2.0.1"
 
+babel-plugin-wrap-modules-amd@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.18.1.tgz#98e6e6c76aae6e9e4a588e667f28af136b397784"
+  integrity sha512-3VGHHr7mUjn7jwgOVIVUpRWrtDz2/YMHoMQgU7gP2iG87TzRTgUmfiRtCSKMPjDKDJpkLUApJNXLR9G79dkSGA==
+  dependencies:
+    babel-template "^6.26.0"
+    liferay-npm-build-tools-common "2.18.1"
+    read-json-sync "^2.0.1"
+
 babel-preset-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz#192b521e2217fb1d1f67cf73f70c336650ad3cdc"
@@ -3103,6 +3155,21 @@ babel-preset-liferay-standard@2.18.0:
     babel-plugin-normalize-requires "2.18.0"
     babel-plugin-transform-node-env-inline "0.4.3"
     babel-plugin-wrap-modules-amd "2.18.0"
+
+babel-preset-liferay-standard@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.18.1.tgz#4547d544d42ef5a41ab52a73c9809e22aceab670"
+  integrity sha512-S92lyF5PFMzSPAy5IjuDciuFMybeUmq1fkbBS04ndDTXNI0eW5wmDl2JKVmExWnLlyB3zJSgrIFmO30vjwPKQA==
+  dependencies:
+    babel-plugin-add-module-metadata "2.18.1"
+    babel-plugin-alias-modules "2.18.1"
+    babel-plugin-minify-dead-code-elimination "0.5.1"
+    babel-plugin-name-amd-modules "2.18.1"
+    babel-plugin-namespace-amd-define "2.18.1"
+    babel-plugin-namespace-modules "2.18.1"
+    babel-plugin-normalize-requires "2.18.1"
+    babel-plugin-transform-node-env-inline "0.4.3"
+    babel-plugin-wrap-modules-amd "2.18.1"
 
 "babel-preset-minify@^0.5.0 || 0.6.0-alpha.5":
   version "0.5.1"
@@ -9021,12 +9088,26 @@ liferay-npm-build-tools-common@2.18.0:
     read-json-sync "^2.0.1"
     resolve "^1.8.1"
 
-liferay-npm-bundler-loader-css-loader@2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.18.0.tgz#f589ca9bd354491f23e267a508494621dde23736"
-  integrity sha512-P1c7T1O/wbOuQDbCvRfK8LjVXEwxo4VWDtSZQ8l/1uOfZDZvBAyFXQcABJkPl2chJWvEE+BbymFognpd/NWJ/g==
+liferay-npm-build-tools-common@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.18.1.tgz#bf4b8967d3c0576af0294e33f4417a4196a9c22d"
+  integrity sha512-qgycjooxtT5OBjca2H/od5IS1UFyZDkhXL+9zt2t9+s8wRSLxxSb76ma/O+S2AR3NTBZWrG/mcIRfH7SW//Vew==
   dependencies:
-    liferay-npm-build-tools-common "2.18.0"
+    chalk "^2.4.2"
+    dot-prop "^5.0.1"
+    escape-string-regexp "^2.0.0"
+    liferay-npm-bundler-preset-standard "2.18.1"
+    merge "^1.2.1"
+    properties "^1.2.1"
+    read-json-sync "^2.0.1"
+    resolve "^1.8.1"
+
+liferay-npm-bundler-loader-css-loader@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.18.1.tgz#c149b5337732a743d29d6c77813391fd9e6381a0"
+  integrity sha512-cEZ/IcyIiNI7hRH+6Mv6Lb9BVC1TqxtYU6noVzjRp3UE/kTlwMX46iOmfMiVawXKXVogAu2CBa9iLaOTCCZrqw==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
     read-json-sync "^2.0.1"
 
 liferay-npm-bundler-plugin-exclude-imports@2.18.0:
@@ -9036,12 +9117,26 @@ liferay-npm-bundler-plugin-exclude-imports@2.18.0:
   dependencies:
     liferay-npm-build-tools-common "2.18.0"
 
+liferay-npm-bundler-plugin-exclude-imports@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.18.1.tgz#04c10963576b352d3b03273b465e71912beec2b2"
+  integrity sha512-G8jNXqKZnobn0UiZJt/1UEWZuutu5SnHSURS+T4ioJQjOW2rLCzbuorLJAz6L3Ez/xLAdAkYZ/HdlxGdfEq/QA==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
+
 liferay-npm-bundler-plugin-inject-imports-dependencies@2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.18.0.tgz#7c15c7d876907df49ea33b0a6addd822a113697d"
   integrity sha512-TVj6sxDEoGTCFQaNcFRIUYfTh0zMKbRfm+ZPrjU0GKLevvrtvtGXf9w7lFIge8YdKGCoV7Sa539k3YdVIx8qFQ==
   dependencies:
     liferay-npm-build-tools-common "2.18.0"
+
+liferay-npm-bundler-plugin-inject-imports-dependencies@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.18.1.tgz#8e1a5a1e6bf752eaca6a259f22e43e316726d471"
+  integrity sha512-50A+HKetsRO817ueVqlwnOgRJm0d5PEDlOiEwOUzhMtQCdfD5uDqRvl8MGbNkcCUdN9+pc7Roj0u7/04TjWfSw==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
 
 liferay-npm-bundler-plugin-inject-peer-dependencies@2.18.0:
   version "2.18.0"
@@ -9053,12 +9148,29 @@ liferay-npm-bundler-plugin-inject-peer-dependencies@2.18.0:
     read-json-sync "^2.0.1"
     resolve "^1.8.1"
 
+liferay-npm-bundler-plugin-inject-peer-dependencies@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.18.1.tgz#10ba53bf53b5b5856783d247e361ff9b0ef7a58b"
+  integrity sha512-WJyIZ5dZcEHurm+q9y3CONtU6Ih6dzYT2HU2ExpF9gvVYGI74KZQ6m9BTYgJ75lx3LdBsTA8d23Tx5U87/5T+g==
+  dependencies:
+    globby "^10.0.1"
+    liferay-npm-build-tools-common "2.18.1"
+    read-json-sync "^2.0.1"
+    resolve "^1.8.1"
+
 liferay-npm-bundler-plugin-namespace-packages@2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.18.0.tgz#30fd9fea4dc17407b949fc8ecb81fe69afb5b36e"
   integrity sha512-DUhkQQinIJmSN29UUs1jr0BPlirwNvKLtqShaUX8R9zOLytKVbFiwtNY2m79mcmd0fnfoPm/xT9JcRm5KL2M2A==
   dependencies:
     liferay-npm-build-tools-common "2.18.0"
+
+liferay-npm-bundler-plugin-namespace-packages@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.18.1.tgz#17fe56bead4f6199546a51ac20ac09856d77c5ea"
+  integrity sha512-pgbfpAXmy9Jpcr+m02lLTEqFDkzk33FThaVBVHXk3llS+l7JJhUV0ghyTTJutt6ve/q/DNEsb7Eg6WhcZ2GzWg==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
 
 liferay-npm-bundler-plugin-replace-browser-modules@2.18.0:
   version "2.18.0"
@@ -9069,12 +9181,30 @@ liferay-npm-bundler-plugin-replace-browser-modules@2.18.0:
     fs-extra "^8.1.0"
     liferay-npm-build-tools-common "2.18.0"
 
+liferay-npm-bundler-plugin-replace-browser-modules@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.18.1.tgz#d543719286548a3c6f31910e39419fc81811f86d"
+  integrity sha512-LGa12lVOLJgQO0IR5mUVsbwJZrrCb2ti0LuX6h52Ie/F5/IKbKiYTP4LWfegCJKG0bUuUPo4p5mYq9qcdA+6GA==
+  dependencies:
+    dot-prop "^5.0.1"
+    fs-extra "^8.1.0"
+    liferay-npm-build-tools-common "2.18.1"
+
 liferay-npm-bundler-plugin-resolve-linked-dependencies@2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.18.0.tgz#77c24e15d8b54ccdd7a35f7446e717728f71543d"
   integrity sha512-z+VrTuZ9z6Di769VdsPvFOxlAbx/ZLJVoZ4WLpysAbgltKPgmI5fowxTVcYPqLt07qsJ6hm8Q4vQ66eah52OWA==
   dependencies:
     liferay-npm-build-tools-common "2.18.0"
+    read-json-sync "^2.0.1"
+    semver "^6.3.0"
+
+liferay-npm-bundler-plugin-resolve-linked-dependencies@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.18.1.tgz#ae7fcad99857f004076b1afc7151f2863501082d"
+  integrity sha512-nuhJm/wQi4dqQjaMr3q6WP2P+0uuqoVyaAAS7DGCzvBf4wAVh5bzsQsCo6MM050FzFlD/8evQotPRrUDN7J1lg==
+  dependencies:
+    liferay-npm-build-tools-common "2.18.1"
     read-json-sync "^2.0.1"
     semver "^6.3.0"
 
@@ -9090,6 +9220,19 @@ liferay-npm-bundler-preset-standard@2.18.0:
     liferay-npm-bundler-plugin-namespace-packages "2.18.0"
     liferay-npm-bundler-plugin-replace-browser-modules "2.18.0"
     liferay-npm-bundler-plugin-resolve-linked-dependencies "2.18.0"
+
+liferay-npm-bundler-preset-standard@2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.18.1.tgz#20949f7a5cca83664867402195b0ebe6f8c0e383"
+  integrity sha512-XxrhThPdAvVd4102WGik+ACVs5zf9JgaDXy196wkWGtWB5r28Vr309atmEcD4Zj4mpStWbveVaPN/18wE2M/AA==
+  dependencies:
+    babel-preset-liferay-standard "2.18.1"
+    liferay-npm-bundler-plugin-exclude-imports "2.18.1"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.18.1"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.18.1"
+    liferay-npm-bundler-plugin-namespace-packages "2.18.1"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.18.1"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.18.1"
 
 liferay-npm-bundler@2.18.0:
   version "2.18.0"


### PR DESCRIPTION
Just a routine update, like https://github.com/liferay/liferay-npm-tools/pull/374 — as noted there, the duplication in the lockfile is expected and temporary.