### PR TITLE
feat(scripts)!: enforce trailing commas in JS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,19 +9,19 @@ module.exports = {
 	env: {
 		browser: true,
 		jest: true,
-		node: true
+		node: true,
 	},
 	extends: 'liferay',
 	parserOptions: {
-		ecmaVersion: 2018
+		ecmaVersion: 2018,
 	},
 	rules: {
 		'no-for-of-loops/no-for-of-loops': 'off',
 		'notice/notice': [
 			'error',
 			{
-				templateFile: path.join(__dirname, 'copyright.js')
-			}
-		]
-	}
+				templateFile: path.join(__dirname, 'copyright.js'),
+			},
+		],
+	},
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
 	"bracketSpacing": false,
 	"singleQuote": true,
 	"tabWidth": 4,
+	"trailingComma": "es5",
 	"useTabs": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-	"bracketSpacing": false,
-	"singleQuote": true,
-	"tabWidth": 4,
-	"trailingComma": "es5",
-	"useTabs": true
-}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+module.exports = {
+	bracketSpacing: false,
+	singleQuote: true,
+	tabWidth: 4,
+	trailingComma: 'es5',
+	useTabs: true,
+};

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -233,7 +233,7 @@ function printBanner(message) {
 		['(_)   ', ' ', '   ` '],
 		['  |   ', '*', '   | '],
 		['  |___', '_', '___| '],
-		['  (_)_', '_', '____)']
+		['  (_)_', '_', '____)'],
 	];
 
 	let banner = '';
@@ -337,7 +337,7 @@ function parseArgs(args) {
 	const options = {
 		outfile: './CHANGELOG.md',
 		to: 'HEAD',
-		updateTags: true
+		updateTags: true,
 	};
 
 	let match;
@@ -477,7 +477,7 @@ async function main(_node, _script, ...args) {
 		from,
 		remote,
 		to,
-		version
+		version,
 	});
 
 	let written = 0;
@@ -497,7 +497,7 @@ async function main(_node, _script, ...args) {
 				from: previousVersion,
 				remote,
 				to: from,
-				version: from
+				version: from,
 			});
 			contents += '\n' + chunk;
 
@@ -517,7 +517,7 @@ async function main(_node, _script, ...args) {
 		if (previousContents.indexOf(`[${version}]`) !== -1) {
 			const message = [
 				`${outfile} already contains a reference to ${version}.`,
-				'Did you mean to regenerate using the --regenerate switch?'
+				'Did you mean to regenerate using the --regenerate switch?',
 			];
 			if (options.force) {
 				warn(...message);

--- a/packages/liferay-jest-junit-reporter/src/index.js
+++ b/packages/liferay-jest-junit-reporter/src/index.js
@@ -32,8 +32,8 @@ module.exports = report => {
 			skipped: 0,
 			tests: report.numTotalTests,
 			time: 0,
-			timestamp: report.startTime
-		}
+			timestamp: report.startTime,
+		},
 	};
 
 	const testResults = report.testResults
@@ -43,7 +43,7 @@ module.exports = report => {
 					? results.concat(
 							suite.testResults.map(test => ({
 								...test,
-								testFilePath: suite.testFilePath
+								testFilePath: suite.testFilePath,
 							}))
 					  )
 					: results,
@@ -57,9 +57,9 @@ module.exports = report => {
 							path.dirname(testCase.testFilePath)
 						),
 						name: testCase.fullName,
-						time: testCase.duration / 1000
-					}
-				}
+						time: testCase.duration / 1000,
+					},
+				},
 			];
 
 			if (testCase.failureMessages && testCase.failureMessages.length) {
@@ -76,20 +76,20 @@ module.exports = report => {
 					failure: [
 						{
 							_attr: {
-								message: failureMessageArr[0][0]
-							}
+								message: failureMessageArr[0][0],
+							},
 						},
 						failureMessageArr
 							.map(failureMessage =>
 								failureMessage.join(NEW_LINE)
 							)
-							.join(NEW_LINE)
-					]
+							.join(NEW_LINE),
+					],
 				});
 			}
 
 			return {
-				testcase: results
+				testcase: results,
 			};
 		});
 

--- a/packages/liferay-jest-junit-reporter/test/index.js
+++ b/packages/liferay-jest-junit-reporter/test/index.js
@@ -23,13 +23,13 @@ const failedTestReport = {
 					duration: 46,
 					// copied from a failed jest test
 					failureMessages: [
-						'Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).toBe(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32mfalse\u001b[39m\nReceived: \u001b[31mtrue\u001b[39m\n    at Object.<anonymous> (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/metal/js/KeyValue/KeyValue.es.js:70:18)\n    at Object.asyncFn (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/jasmine_async.js:108:37)\n    at resolve (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/queue_runner.js:56:12)\n    at new Promise (<anonymous>)\n    at mapper (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/queue_runner.js:43:19)\n    at promise.then (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/queue_runner.js:87:41)\n    at <anonymous>\n    at process._tickCallback (internal/process/next_tick.js:182:7)'
+						'Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).toBe(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32mfalse\u001b[39m\nReceived: \u001b[31mtrue\u001b[39m\n    at Object.<anonymous> (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/metal/js/KeyValue/KeyValue.es.js:70:18)\n    at Object.asyncFn (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/jasmine_async.js:108:37)\n    at resolve (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/queue_runner.js:56:12)\n    at new Promise (<anonymous>)\n    at mapper (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/queue_runner.js:43:19)\n    at promise.then (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/queue_runner.js:87:41)\n    at <anonymous>\n    at process._tickCallback (internal/process/next_tick.js:182:7)',
 					],
-					fullName: 'Field DocumentLibrary should not be readOnly'
-				}
-			]
-		}
-	]
+					fullName: 'Field DocumentLibrary should not be readOnly',
+				},
+			],
+		},
+	],
 };
 
 const passedTestReport = {
@@ -45,11 +45,11 @@ const passedTestReport = {
 				{
 					duration: 46,
 					failureMessages: [],
-					fullName: 'Field DocumentLibrary should not be readOnly'
-				}
-			]
-		}
-	]
+					fullName: 'Field DocumentLibrary should not be readOnly',
+				},
+			],
+		},
+	],
 };
 
 describe('liferay-jest-junit-reporter', () => {

--- a/packages/liferay-js-insights/index.js
+++ b/packages/liferay-js-insights/index.js
@@ -16,7 +16,7 @@ const readFile = util.promisify(fs.readFile);
 
 const INSIGHTS = {
 	dependencies: require('./insights/dependencies'),
-	loc: require('./insights/loc')
+	loc: require('./insights/loc'),
 };
 
 let report;
@@ -35,7 +35,7 @@ if (argv.json) {
 async function parse(content) {
 	return parser.parse(content, {
 		plugins: ['classProperties', 'jsx'],
-		sourceType: 'module'
+		sourceType: 'module',
 	});
 }
 
@@ -54,7 +54,7 @@ async function getModuleMeta(modulePath) {
 	// Finds the root git folder
 	const gitRoot = await findUp('.git', {
 		cwd,
-		type: 'directory'
+		type: 'directory',
 	});
 
 	const url = `https://github.com/liferay/liferay-portal/blob/master/${path.relative(
@@ -65,7 +65,7 @@ async function getModuleMeta(modulePath) {
 	return {
 		app,
 		name,
-		url
+		url,
 	};
 }
 

--- a/packages/liferay-js-insights/insights/dependencies.js
+++ b/packages/liferay-js-insights/insights/dependencies.js
@@ -8,31 +8,31 @@ const {default: traverse} = require('@babel/traverse');
 const SOURCE_GROUPS = [
 	{
 		name: 'clay3',
-		test: source => source.startsWith('@clayui')
+		test: source => source.startsWith('@clayui'),
 	},
 	{
 		name: 'react',
 		test: source =>
 			source.startsWith('react') ||
 			source.startsWith('prop-types') ||
-			source.startsWith('classnames')
+			source.startsWith('classnames'),
 	},
 	{
 		name: 'js',
-		test: source => source.startsWith('frontend-js-web')
+		test: source => source.startsWith('frontend-js-web'),
 	},
 	{
 		name: 'metal',
-		test: source => source.startsWith('metal-') || source === 'metal'
+		test: source => source.startsWith('metal-') || source === 'metal',
 	},
 	{
 		name: 'clay2',
-		test: source => source.startsWith('clay-') || source === 'clay'
+		test: source => source.startsWith('clay-') || source === 'clay',
 	},
 	{
 		name: 'others',
-		test: source => true // eslint-disable-line
-	}
+		test: source => true, // eslint-disable-line
+	},
 ];
 
 /**
@@ -63,9 +63,9 @@ module.exports = async function({ast}) {
 				...dependencies[name],
 				node.specifiers
 					.filter(specifier => specifier.local.name)
-					.map(specifier => specifier.local.name)
+					.map(specifier => specifier.local.name),
 			].reduce((memo, it) => memo.concat(it), []); // Not using flatMap to support Node.js 10;;;
-		}
+		},
 	});
 
 	return dependencies;

--- a/packages/liferay-js-insights/insights/loc.js
+++ b/packages/liferay-js-insights/insights/loc.js
@@ -36,6 +36,6 @@ module.exports = async function({ast, content}) {
 		code,
 		comment,
 		total,
-		whitespace
+		whitespace,
 	};
 };

--- a/packages/liferay-js-insights/reporters/airtable.js
+++ b/packages/liferay-js-insights/reporters/airtable.js
@@ -11,7 +11,7 @@ const progress = new cliProgress.MultiBar(
 		clearOnComplete: false,
 		format:
 			'{output} | [{bar}] {percentage}% | ETA: {eta}s | {value}/{total}',
-		hideCursor: true
+		hideCursor: true,
 	},
 	cliProgress.Presets.shades_grey
 );
@@ -42,7 +42,7 @@ module.exports = async function(modulesInfo, config) {
 		airtableApiKey: process.env.LFR_DEPS_AIRTABLE_API_KEY,
 		airtableBaseKey: process.env.LFR_DEPS_AIRTABLE_BASE_KEY,
 		output: 'master',
-		...config
+		...config,
 	};
 
 	const base = new Airtable({apiKey: airtableApiKey}).base(airtableBaseKey);
@@ -58,14 +58,14 @@ module.exports = async function(modulesInfo, config) {
 					app: moduleInfo.meta.app,
 					module: moduleInfo.meta.name,
 					url: moduleInfo.meta.url,
-					...moduleInfo.dependencies
-				}
+					...moduleInfo.dependencies,
+				},
 			};
 		});
 
 		try {
 			await base(output).create(chunk, {
-				typecast: true
+				typecast: true,
 			});
 		} catch (err) {
 			console.error(err);

--- a/packages/liferay-js-insights/reporters/json.js
+++ b/packages/liferay-js-insights/reporters/json.js
@@ -13,7 +13,7 @@ const writeFile = util.promisify(fs.writeFile);
  */
 function prepareModule(dependencies) {
 	const simpleModule = {
-		dependencies: {}
+		dependencies: {},
 	};
 
 	Object.keys(dependencies)
@@ -37,7 +37,7 @@ module.exports = async function(modulesInfo, {output}) {
 		.reduce((acc, {dependencies, meta}) => {
 			const moduleData = {
 				name: meta.name,
-				...prepareModule(dependencies)
+				...prepareModule(dependencies),
 			};
 
 			acc[meta.app] = acc[meta.app] || {modules: []};

--- a/packages/liferay-js-insights/reporters/table.js
+++ b/packages/liferay-js-insights/reporters/table.js
@@ -6,7 +6,7 @@
 const Table = require('cli-table');
 
 const DEFAULT_CONFIG = {
-	output: 'meta.app,meta.name,dependencies.clay3,dependencies.react'
+	output: 'meta.app,meta.name,dependencies.clay3,dependencies.react',
 };
 
 /**
@@ -20,7 +20,7 @@ const idx = (p, o) => p.reduce((xs, x) => (xs && xs[x] ? xs[x] : null), o);
 module.exports = async function(modulesInfo, config) {
 	const {output} = {
 		...DEFAULT_CONFIG,
-		...config
+		...config,
 	};
 
 	const head = output.split(',');

--- a/packages/liferay-js-publish/src/index.js
+++ b/packages/liferay-js-publish/src/index.js
@@ -119,7 +119,7 @@ function confirm(prompt, answer = 'y', matcher = YES_REGEX) {
 	if (!readline) {
 		readline = createInterface({
 			input: process.stdin,
-			output: process.stdout
+			output: process.stdout,
 		});
 	}
 

--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -169,13 +169,13 @@ If you need to add additional configuration you can do so by creating a `npmscri
 
 ```js
 module.exports = {
-	preset: 'path/to/some/dependency'
+	preset: 'path/to/some/dependency',
 };
 
 // or npm package (this needs to also be specified in your package.json)
 
 module.exports = {
-	preset: 'my-cool-preset'
+	preset: 'my-cool-preset',
 };
 ```
 
@@ -187,8 +187,8 @@ const standardPreset = require('liferay-npm-scripts/src/presets/standard/index')
 module.exports = {
 	preset: 'liferay-npm-scripts/src/presets/standard/index',
 	build: {
-		dependencies: [...standardPreset.build.dependencies, 'asset-taglib']
-	}
+		dependencies: [...standardPreset.build.dependencies, 'asset-taglib'],
+	},
 };
 ```
 

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/webpack/sample/webpack.config.dev.js
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/webpack/sample/webpack.config.dev.js
@@ -7,6 +7,6 @@ module.exports = {
 	entry: './index.js',
 	output: {
 		filename: 'bundle.js',
-		path: __dirname
-	}
+		path: __dirname,
+	},
 };

--- a/packages/liferay-npm-scripts/contrib/prettier/prettier.js
+++ b/packages/liferay-npm-scripts/contrib/prettier/prettier.js
@@ -59,7 +59,7 @@ module.exports = {
 		} else {
 			return Promise.resolve({
 				ignored: false,
-				inferredParser: 'babel'
+				inferredParser: 'babel',
 			});
 		}
 	},
@@ -103,7 +103,7 @@ module.exports = {
 							'.sjs',
 							'.ssjs',
 							'.xsjs',
-							'.xsjslib'
+							'.xsjslib',
 						],
 						filenames: ['Jakefile'],
 						interpreters: [
@@ -114,12 +114,12 @@ module.exports = {
 							'rhino',
 							'v8',
 							'v8-shell',
-							'nodejs'
+							'nodejs',
 						],
 						linguistLanguageId: 183,
 						since: '0.0.0',
 						parsers: ['babel', 'flow'],
-						vscodeLanguageIds: ['javascript', 'mongo']
+						vscodeLanguageIds: ['javascript', 'mongo'],
 					},
 					{
 						name: 'Flow',
@@ -139,12 +139,12 @@ module.exports = {
 							'node',
 							'rhino',
 							'v8',
-							'v8-shell'
+							'v8-shell',
 						],
 						linguistLanguageId: 183,
 						since: '0.0.0',
 						parsers: ['babel', 'flow'],
-						vscodeLanguageIds: ['javascript']
+						vscodeLanguageIds: ['javascript'],
 					},
 					{
 						name: 'JSX',
@@ -158,7 +158,7 @@ module.exports = {
 						linguistLanguageId: 178,
 						since: '0.0.0',
 						parsers: ['babel', 'flow'],
-						vscodeLanguageIds: ['javascriptreact']
+						vscodeLanguageIds: ['javascriptreact'],
 					},
 					{
 						name: 'TypeScript',
@@ -174,7 +174,7 @@ module.exports = {
 						linguistLanguageId: 378,
 						since: '1.4.0',
 						parsers: ['typescript'],
-						vscodeLanguageIds: ['typescript']
+						vscodeLanguageIds: ['typescript'],
 					},
 					{
 						name: 'TSX',
@@ -188,7 +188,7 @@ module.exports = {
 						linguistLanguageId: 94901924,
 						since: '1.4.0',
 						parsers: ['typescript'],
-						vscodeLanguageIds: ['typescriptreact']
+						vscodeLanguageIds: ['typescriptreact'],
 					},
 					{
 						name: 'JSON.stringify',
@@ -202,12 +202,12 @@ module.exports = {
 						filenames: [
 							'package.json',
 							'package-lock.json',
-							'composer.json'
+							'composer.json',
 						],
 						linguistLanguageId: 174,
 						since: '1.13.0',
 						parsers: ['json-stringify'],
-						vscodeLanguageIds: ['json']
+						vscodeLanguageIds: ['json'],
 					},
 					{
 						name: 'JSON',
@@ -233,7 +233,7 @@ module.exports = {
 							'.webapp',
 							'.webmanifest',
 							'.yy',
-							'.yyp'
+							'.yyp',
 						],
 						filenames: [
 							'.arcconfig',
@@ -243,12 +243,12 @@ module.exports = {
 							'.watchmanconfig',
 							'composer.lock',
 							'mcmod.info',
-							'.prettierrc'
+							'.prettierrc',
 						],
 						linguistLanguageId: 174,
 						since: '1.5.0',
 						parsers: ['json'],
-						vscodeLanguageIds: ['json']
+						vscodeLanguageIds: ['json'],
 					},
 					{
 						name: 'JSON with Comments',
@@ -272,7 +272,7 @@ module.exports = {
 							'.sublime-theme',
 							'.sublime-workspace',
 							'.sublime_metrics',
-							'.sublime_session'
+							'.sublime_session',
 						],
 						filenames: [
 							'.babelrc',
@@ -283,12 +283,12 @@ module.exports = {
 							'jsconfig.json',
 							'language-configuration.json',
 							'tsconfig.json',
-							'.eslintrc'
+							'.eslintrc',
 						],
 						linguistLanguageId: 423,
 						since: '1.5.0',
 						parsers: ['json'],
-						vscodeLanguageIds: ['jsonc']
+						vscodeLanguageIds: ['jsonc'],
 					},
 					{
 						name: 'JSON5',
@@ -301,7 +301,7 @@ module.exports = {
 						linguistLanguageId: 175,
 						since: '1.13.0',
 						parsers: ['json5'],
-						vscodeLanguageIds: ['json5']
+						vscodeLanguageIds: ['json5'],
 					},
 					{
 						name: 'CSS',
@@ -315,7 +315,7 @@ module.exports = {
 						linguistLanguageId: 50,
 						since: '1.4.0',
 						parsers: ['css'],
-						vscodeLanguageIds: ['css']
+						vscodeLanguageIds: ['css'],
 					},
 					{
 						name: 'PostCSS',
@@ -327,7 +327,7 @@ module.exports = {
 						linguistLanguageId: 262764437,
 						since: '1.4.0',
 						parsers: ['css'],
-						vscodeLanguageIds: ['postcss']
+						vscodeLanguageIds: ['postcss'],
 					},
 					{
 						name: 'Less',
@@ -341,7 +341,7 @@ module.exports = {
 						linguistLanguageId: 198,
 						since: '1.4.0',
 						parsers: ['less'],
-						vscodeLanguageIds: ['less']
+						vscodeLanguageIds: ['less'],
 					},
 					{
 						name: 'SCSS',
@@ -355,7 +355,7 @@ module.exports = {
 						linguistLanguageId: 329,
 						since: '1.4.0',
 						parsers: ['scss'],
-						vscodeLanguageIds: ['scss']
+						vscodeLanguageIds: ['scss'],
 					},
 					{
 						name: 'GraphQL',
@@ -366,7 +366,7 @@ module.exports = {
 						linguistLanguageId: 139,
 						since: '1.5.0',
 						parsers: ['graphql'],
-						vscodeLanguageIds: ['graphql']
+						vscodeLanguageIds: ['graphql'],
 					},
 					{
 						name: 'Markdown',
@@ -385,14 +385,14 @@ module.exports = {
 							'.mkdn',
 							'.mkdown',
 							'.ronn',
-							'.workbook'
+							'.workbook',
 						],
 						filenames: ['contents.lr', 'README'],
 						tmScope: 'source.gfm',
 						linguistLanguageId: 222,
 						since: '1.8.0',
 						parsers: ['markdown'],
-						vscodeLanguageIds: ['markdown']
+						vscodeLanguageIds: ['markdown'],
 					},
 					{
 						name: 'MDX',
@@ -408,7 +408,7 @@ module.exports = {
 						linguistLanguageId: 222,
 						since: '1.15.0',
 						parsers: ['mdx'],
-						vscodeLanguageIds: ['mdx']
+						vscodeLanguageIds: ['mdx'],
 					},
 					{
 						name: 'Angular',
@@ -424,7 +424,7 @@ module.exports = {
 						since: '1.15.0',
 						parsers: ['angular'],
 						vscodeLanguageIds: ['html'],
-						filenames: []
+						filenames: [],
 					},
 					{
 						name: 'HTML',
@@ -443,12 +443,12 @@ module.exports = {
 							'.st',
 							'.xht',
 							'.xhtml',
-							'.mjml'
+							'.mjml',
 						],
 						linguistLanguageId: 146,
 						since: '1.15.0',
 						parsers: ['html'],
-						vscodeLanguageIds: ['html']
+						vscodeLanguageIds: ['html'],
 					},
 					{
 						name: 'Lightning Web Components',
@@ -464,7 +464,7 @@ module.exports = {
 						since: '1.17.0',
 						parsers: ['lwc'],
 						vscodeLanguageIds: ['html'],
-						filenames: []
+						filenames: [],
 					},
 					{
 						name: 'Vue',
@@ -476,7 +476,7 @@ module.exports = {
 						linguistLanguageId: 391,
 						since: '1.10.0',
 						parsers: ['vue'],
-						vscodeLanguageIds: ['vue']
+						vscodeLanguageIds: ['vue'],
 					},
 					{
 						name: 'YAML',
@@ -492,13 +492,13 @@ module.exports = {
 							'.syntax',
 							'.yaml',
 							'.yaml-tmlanguage',
-							'.yml.mysql'
+							'.yml.mysql',
 						],
 						filenames: [
 							'.clang-format',
 							'.clang-tidy',
 							'.gemrc',
-							'glide.lock'
+							'glide.lock',
 						],
 						aceMode: 'yaml',
 						codemirrorMode: 'yaml',
@@ -506,8 +506,8 @@ module.exports = {
 						linguistLanguageId: 407,
 						since: '1.14.0',
 						parsers: ['yaml'],
-						vscodeLanguageIds: ['yaml']
-					}
+						vscodeLanguageIds: ['yaml'],
+					},
 				],
 				options: [
 					{
@@ -522,15 +522,15 @@ module.exports = {
 							{
 								value: 'avoid',
 								description:
-									'Omit parens when possible. Example: `x => x`'
+									'Omit parens when possible. Example: `x => x`',
 							},
 							{
 								value: 'always',
 								description:
-									'Always include parens. Example: `(x) => x`'
-							}
+									'Always include parens. Example: `(x) => x`',
+							},
 						],
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'bracketSpacing',
@@ -541,7 +541,7 @@ module.exports = {
 						description: 'Print spaces between brackets.',
 						oppositeDescription:
 							'Do not print spaces between brackets.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'cursorOffset',
@@ -552,11 +552,11 @@ module.exports = {
 						range: {
 							start: -1,
 							end: null,
-							step: 1
+							step: 1,
 						},
 						description:
 							'Print (to stderr) where a cursor at the given position would move to after formatting.\nThis option cannot be used with --range-start and --range-end.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'endOfLine',
@@ -569,25 +569,25 @@ module.exports = {
 							{
 								value: 'auto',
 								description:
-									"Maintain existing\n(mixed values within one file are normalised by looking at what's used after the first line)"
+									"Maintain existing\n(mixed values within one file are normalised by looking at what's used after the first line)",
 							},
 							{
 								value: 'lf',
 								description:
-									'Line Feed only (\\n), common on Linux and macOS as well as inside git repos'
+									'Line Feed only (\\n), common on Linux and macOS as well as inside git repos',
 							},
 							{
 								value: 'crlf',
 								description:
-									'Carriage Return + Line Feed characters (\\r\\n), common on Windows'
+									'Carriage Return + Line Feed characters (\\r\\n), common on Windows',
 							},
 							{
 								value: 'cr',
 								description:
-									'Carriage Return character only (\\r), used very rarely'
-							}
+									'Carriage Return character only (\\r), used very rarely',
+							},
 						],
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'filepath',
@@ -596,7 +596,7 @@ module.exports = {
 						type: 'path',
 						description:
 							'Specify the input filepath. This will be used to do parser inference.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'htmlWhitespaceSensitivity',
@@ -609,20 +609,20 @@ module.exports = {
 							{
 								value: 'css',
 								description:
-									'Respect the default value of CSS display property.'
+									'Respect the default value of CSS display property.',
 							},
 							{
 								value: 'strict',
 								description:
-									'Whitespaces are considered sensitive.'
+									'Whitespaces are considered sensitive.',
 							},
 							{
 								value: 'ignore',
 								description:
-									'Whitespaces are considered insensitive.'
-							}
+									'Whitespaces are considered insensitive.',
+							},
 						],
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'insertPragma',
@@ -632,7 +632,7 @@ module.exports = {
 						default: false,
 						description:
 							"Insert @format pragma into file's first docblock comment.",
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'jsxBracketSameLine',
@@ -642,7 +642,7 @@ module.exports = {
 						default: false,
 						description:
 							'Put > on the last line instead of at a new line.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'jsxSingleQuote',
@@ -651,7 +651,7 @@ module.exports = {
 						type: 'boolean',
 						default: false,
 						description: 'Use single quotes in JSX.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'parser',
@@ -662,95 +662,95 @@ module.exports = {
 						choices: [
 							{
 								value: 'flow',
-								description: 'Flow'
+								description: 'Flow',
 							},
 							{
 								value: 'babel',
 								since: '1.16.0',
-								description: 'JavaScript'
+								description: 'JavaScript',
 							},
 							{
 								value: 'babel-flow',
 								since: '1.16.0',
-								description: 'Flow'
+								description: 'Flow',
 							},
 							{
 								value: 'typescript',
 								since: '1.4.0',
-								description: 'TypeScript'
+								description: 'TypeScript',
 							},
 							{
 								value: 'css',
 								since: '1.7.1',
-								description: 'CSS'
+								description: 'CSS',
 							},
 							{
 								value: 'less',
 								since: '1.7.1',
-								description: 'Less'
+								description: 'Less',
 							},
 							{
 								value: 'scss',
 								since: '1.7.1',
-								description: 'SCSS'
+								description: 'SCSS',
 							},
 							{
 								value: 'json',
 								since: '1.5.0',
-								description: 'JSON'
+								description: 'JSON',
 							},
 							{
 								value: 'json5',
 								since: '1.13.0',
-								description: 'JSON5'
+								description: 'JSON5',
 							},
 							{
 								value: 'json-stringify',
 								since: '1.13.0',
-								description: 'JSON.stringify'
+								description: 'JSON.stringify',
 							},
 							{
 								value: 'graphql',
 								since: '1.5.0',
-								description: 'GraphQL'
+								description: 'GraphQL',
 							},
 							{
 								value: 'markdown',
 								since: '1.8.0',
-								description: 'Markdown'
+								description: 'Markdown',
 							},
 							{
 								value: 'mdx',
 								since: '1.15.0',
-								description: 'MDX'
+								description: 'MDX',
 							},
 							{
 								value: 'vue',
 								since: '1.10.0',
-								description: 'Vue'
+								description: 'Vue',
 							},
 							{
 								value: 'yaml',
 								since: '1.14.0',
-								description: 'YAML'
+								description: 'YAML',
 							},
 							{
 								value: 'html',
 								since: '1.15.0',
-								description: 'HTML'
+								description: 'HTML',
 							},
 							{
 								value: 'angular',
 								since: '1.15.0',
-								description: 'Angular'
+								description: 'Angular',
 							},
 							{
 								value: 'lwc',
 								since: '1.17.0',
-								description: 'Lightning Web Components'
-							}
+								description: 'Lightning Web Components',
+							},
 						],
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'pluginSearchDirs',
@@ -761,7 +761,7 @@ module.exports = {
 						category: 'Global',
 						description:
 							'Custom directory that contains prettier plugins in node_modules subdirectory.\nOverrides default behavior when plugins are searched relatively to the location of Prettier.\nMultiple values are accepted.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'plugins',
@@ -772,7 +772,7 @@ module.exports = {
 						category: 'Global',
 						description:
 							'Add a plugin. Multiple plugins can be passed as separate `--plugin`s.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'printWidth',
@@ -785,9 +785,9 @@ module.exports = {
 						range: {
 							start: 0,
 							end: null,
-							step: 1
+							step: 1,
 						},
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'proseWrap',
@@ -801,20 +801,20 @@ module.exports = {
 								since: '1.9.0',
 								value: 'always',
 								description:
-									'Wrap prose if it exceeds the print width.'
+									'Wrap prose if it exceeds the print width.',
 							},
 							{
 								since: '1.9.0',
 								value: 'never',
-								description: 'Do not wrap prose.'
+								description: 'Do not wrap prose.',
 							},
 							{
 								since: '1.9.0',
 								value: 'preserve',
-								description: 'Wrap prose as-is.'
-							}
+								description: 'Wrap prose as-is.',
+							},
 						],
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'quoteProps',
@@ -828,20 +828,20 @@ module.exports = {
 							{
 								value: 'as-needed',
 								description:
-									'Only add quotes around object properties where required.'
+									'Only add quotes around object properties where required.',
 							},
 							{
 								value: 'consistent',
 								description:
-									'If at least one property in an object requires quotes, quote all properties.'
+									'If at least one property in an object requires quotes, quote all properties.',
 							},
 							{
 								value: 'preserve',
 								description:
-									'Respect the input use of quotes in object properties.'
-							}
+									'Respect the input use of quotes in object properties.',
+							},
 						],
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'rangeEnd',
@@ -852,11 +852,11 @@ module.exports = {
 						range: {
 							start: 0,
 							end: null,
-							step: 1
+							step: 1,
 						},
 						description:
 							'Format code ending at a given character offset (exclusive).\nThe range will extend forwards to the end of the selected statement.\nThis option cannot be used with --cursor-offset.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'rangeStart',
@@ -867,11 +867,11 @@ module.exports = {
 						range: {
 							start: 0,
 							end: null,
-							step: 1
+							step: 1,
 						},
 						description:
 							'Format code starting at a given character offset.\nThe range will extend backwards to the start of the first line containing the selected statement.\nThis option cannot be used with --cursor-offset.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'requirePragma',
@@ -881,7 +881,7 @@ module.exports = {
 						default: false,
 						description:
 							"Require either '@prettier' or '@format' to be present in the file's first docblock comment\nin order for it to be formatted.",
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'semi',
@@ -892,7 +892,7 @@ module.exports = {
 						description: 'Print semicolons.',
 						oppositeDescription:
 							'Do not print semicolons, except at the beginning of lines which may need them.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'singleQuote',
@@ -902,7 +902,7 @@ module.exports = {
 						default: false,
 						description:
 							'Use single quotes instead of double quotes.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'tabWidth',
@@ -913,9 +913,9 @@ module.exports = {
 						range: {
 							start: 0,
 							end: null,
-							step: 1
+							step: 1,
 						},
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'trailingComma',
@@ -928,20 +928,20 @@ module.exports = {
 						choices: [
 							{
 								value: 'none',
-								description: 'No trailing commas.'
+								description: 'No trailing commas.',
 							},
 							{
 								value: 'es5',
 								description:
-									'Trailing commas where valid in ES5 (objects, arrays, etc.)'
+									'Trailing commas where valid in ES5 (objects, arrays, etc.)',
 							},
 							{
 								value: 'all',
 								description:
-									'Trailing commas wherever possible (including function arguments).'
-							}
+									'Trailing commas wherever possible (including function arguments).',
+							},
 						],
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'useTabs',
@@ -950,7 +950,7 @@ module.exports = {
 						type: 'boolean',
 						default: false,
 						description: 'Indent with tabs instead of spaces.',
-						pluginDefaults: {}
+						pluginDefaults: {},
 					},
 					{
 						name: 'vueIndentScriptAndStyle',
@@ -960,9 +960,9 @@ module.exports = {
 						default: false,
 						description:
 							'Indent script and style tags in Vue files.',
-						pluginDefaults: {}
-					}
-				]
+						pluginDefaults: {},
+					},
+				],
 			};
 			/* eslint-enable sort-keys */
 		}
@@ -978,7 +978,7 @@ module.exports = {
 		}
 	},
 
-	version: '1.19.1'
+	version: '1.19.1',
 };
 
 /**

--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -11,13 +11,13 @@ const CONFIG_FILES = [
 	'**/gulpfile.js',
 	'**/npmscripts.config.js',
 	'**/webpack.config.dev.js',
-	'**/webpack.config.js'
+	'**/webpack.config.js',
 ];
 
 module.exports = {
 	env: {
 		browser: true,
-		es6: true
+		es6: true,
 	},
 	extends: [require.resolve('eslint-config-liferay/portal')],
 	globals: {
@@ -27,29 +27,29 @@ module.exports = {
 		process: true,
 		submitForm: true,
 		svg4everybody: true,
-		themeDisplay: true
+		themeDisplay: true,
 	},
 	overrides: [
 		{
 			env: {
-				node: true
+				node: true,
 			},
-			files: CONFIG_FILES
+			files: CONFIG_FILES,
 		},
 		{
 			env: {
 				jest: true,
-				node: true
+				node: true,
 			},
-			files: ['**/test/**/*.js']
-		}
+			files: ['**/test/**/*.js'],
+		},
 	],
 	parser: 'babel-eslint',
 	parserOptions: {
 		ecmaFeatures: {
-			jsx: true
+			jsx: true,
 		},
-		ecmaVersion: 2018
+		ecmaVersion: 2018,
 	},
-	root: true
+	root: true,
 };

--- a/packages/liferay-npm-scripts/src/config/jest.config.js
+++ b/packages/liferay-npm-scripts/src/config/jest.config.js
@@ -21,8 +21,8 @@ module.exports = {
 		'\\.css$': path.join(__dirname, '..', 'jest', 'transformStyles.js'),
 		'\\.scss$': path.join(__dirname, '..', 'jest', 'transformSass.js'),
 		'\\.soy$': path.join(__dirname, '..', 'jest', 'transformSoy.js'),
-		'.+': path.join(__dirname, '..', 'jest', 'transformBabel.js')
+		'.+': path.join(__dirname, '..', 'jest', 'transformBabel.js'),
 		/* eslint-enable sort-keys */
 	},
-	transformIgnorePatterns: ['/node_modules/', '<rootDir>/.*\\.soy$']
+	transformIgnorePatterns: ['/node_modules/', '<rootDir>/.*\\.soy$'],
 };

--- a/packages/liferay-npm-scripts/src/config/npmscripts.config.js
+++ b/packages/liferay-npm-scripts/src/config/npmscripts.config.js
@@ -6,5 +6,5 @@
 var path = require('path');
 
 module.exports = {
-	preset: path.join(__dirname, '../presets/standard/index')
+	preset: path.join(__dirname, '../presets/standard/index'),
 };

--- a/packages/liferay-npm-scripts/src/config/prettier.json
+++ b/packages/liferay-npm-scripts/src/config/prettier.json
@@ -4,6 +4,6 @@
 	"jsxSingleQuote": false,
 	"singleQuote": true,
 	"tabWidth": 4,
-	"trailingComma": "none",
+	"trailingComma": "es5",
 	"useTabs": true
 }

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -9,7 +9,7 @@ module.exports = async function() {
 	const ARGS_ARRAY = process.argv.slice(2);
 
 	const {
-		_: [type]
+		_: [type],
 	} = minimist(ARGS_ARRAY);
 
 	const PUBLIC_COMMANDS = {
@@ -43,7 +43,7 @@ module.exports = async function() {
 
 		webpack() {
 			require('./scripts/webpack')(...ARGS_ARRAY.slice(1));
-		}
+		},
 	};
 
 	const PRIVATE_COMMANDS = {
@@ -68,12 +68,12 @@ module.exports = async function() {
 		 */
 		'lint:quiet': async function lintQuiet() {
 			await require('./scripts/lint')({quiet: true});
-		}
+		},
 	};
 
 	const COMMANDS = {
 		...PUBLIC_COMMANDS,
-		...PRIVATE_COMMANDS
+		...PRIVATE_COMMANDS,
 	};
 
 	if (COMMANDS[type]) {

--- a/packages/liferay-npm-scripts/src/jest/mocks/Liferay.js
+++ b/packages/liferay-npm-scripts/src/jest/mocks/Liferay.js
@@ -62,7 +62,7 @@ const Session = {
 	/**
 	 * https://github.com/liferay/liferay-portal/blob/a4866af62eb89c69ee00d0e69dbe7ff092b50048/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js#L103
 	 */
-	set: jest.fn(() => Promise.resolve({}))
+	set: jest.fn(() => Promise.resolve({})),
 };
 
 /**

--- a/packages/liferay-npm-scripts/src/jest/mocks/Liferay.js
+++ b/packages/liferay-npm-scripts/src/jest/mocks/Liferay.js
@@ -30,7 +30,7 @@ const events = {
 	/**
 	 * https://yuilibrary.com/yui/docs/api/files/event-custom_js_event-target.js.html#l136
 	 */
-	once: jest.fn()
+	once: jest.fn(),
 };
 
 /**
@@ -47,7 +47,7 @@ const Language = {
 	/**
 	 * https://github.com/liferay/liferay-portal/blob/31073fb75fb0d3b309f9e0f921cb7a469aa2703d/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/language.js#L18
 	 */
-	get: jest.fn(key => key)
+	get: jest.fn(key => key),
 };
 
 /**
@@ -106,7 +106,7 @@ const ThemeDisplay = {
 	/**
 	 * https://github.com/liferay/liferay-portal/blob/31073fb75fb0d3b309f9e0f921cb7a469aa2703d/portal-web/docroot/html/common/themes/top_js.jspf#L247
 	 */
-	getPortalURL: jest.fn(() => 'http://localhost:8080')
+	getPortalURL: jest.fn(() => 'http://localhost:8080'),
 };
 
 /**
@@ -139,7 +139,7 @@ const Util = {
 	/**
 	 * https://github.com/liferay/liferay-portal/blob/31073fb75fb0d3b309f9e0f921cb7a469aa2703d/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js#L999
 	 */
-	sub: jest.fn()
+	sub: jest.fn(),
 };
 
 module.exports = {
@@ -148,5 +148,5 @@ module.exports = {
 	Session,
 	ThemeDisplay,
 	Util,
-	authToken
+	authToken,
 };

--- a/packages/liferay-npm-scripts/src/jest/transformSass.js
+++ b/packages/liferay-npm-scripts/src/jest/transformSass.js
@@ -12,5 +12,5 @@
 module.exports = {
 	process(_src, _file) {
 		return '';
-	}
+	},
 };

--- a/packages/liferay-npm-scripts/src/jest/transformSoy.js
+++ b/packages/liferay-npm-scripts/src/jest/transformSoy.js
@@ -27,5 +27,5 @@ module.exports = {
 
 			module.exports = templates;
 		`;
-	}
+	},
 };

--- a/packages/liferay-npm-scripts/src/jest/transformStyles.js
+++ b/packages/liferay-npm-scripts/src/jest/transformStyles.js
@@ -12,5 +12,5 @@
 module.exports = {
 	process(_src, _file) {
 		return '';
-	}
+	},
 };

--- a/packages/liferay-npm-scripts/src/jsp/Lexer.js
+++ b/packages/liferay-npm-scripts/src/jsp/Lexer.js
@@ -55,7 +55,7 @@ class Lexer {
 
 			exec(_string) {
 				return getMatchObject('');
-			}
+			},
 		};
 
 		/**
@@ -66,7 +66,7 @@ class Lexer {
 
 			exec(_string) {
 				return null;
-			}
+			},
 		};
 
 		/**
@@ -112,7 +112,7 @@ class Lexer {
 
 				to,
 
-				until
+				until,
 			};
 		}
 
@@ -153,7 +153,7 @@ class Lexer {
 					return matcher.exec(string);
 				},
 
-				name
+				name,
 			};
 		}
 
@@ -191,7 +191,7 @@ class Lexer {
 
 				to,
 
-				until
+				until,
 			};
 		}
 
@@ -215,7 +215,7 @@ class Lexer {
 							? JSON.stringify(stringOrRegExp)
 							: stringOrRegExp.toString())
 					);
-				}
+				},
 			});
 
 			matcher.exec = string => {
@@ -268,7 +268,7 @@ class Lexer {
 					}
 				},
 
-				name
+				name,
 			};
 		}
 
@@ -360,7 +360,7 @@ class Lexer {
 
 				to,
 
-				until
+				until,
 			};
 		}
 
@@ -401,7 +401,7 @@ class Lexer {
 					}
 				},
 
-				name
+				name,
 			};
 		}
 
@@ -460,7 +460,7 @@ class Lexer {
 
 				onMatch,
 
-				test
+				test,
 			};
 		}
 
@@ -517,7 +517,7 @@ class Lexer {
 					return null;
 				},
 
-				name
+				name,
 			};
 		}
 
@@ -568,7 +568,7 @@ class Lexer {
 					return getMatchObject(consumed);
 				},
 
-				name
+				name,
 			};
 		}
 
@@ -598,7 +598,7 @@ class Lexer {
 					}
 				},
 
-				name
+				name,
 			};
 		}
 
@@ -740,7 +740,7 @@ class Lexer {
 			return {
 				contents,
 				index: input.length - remaining.length - contents.length,
-				name
+				name,
 			};
 		};
 
@@ -760,7 +760,7 @@ class Lexer {
 
 			get remaining() {
 				return remaining;
-			}
+			},
 		};
 
 		/**
@@ -790,7 +790,7 @@ class Lexer {
 			repeat,
 			sequence,
 			token,
-			when
+			when,
 		};
 
 		const advance = this._callback(API);
@@ -852,13 +852,13 @@ class Lexer {
 						}
 
 						return tokens.get(counter + 1);
-					}
+					},
 				},
 				previous: {
 					// Non-enumerable so that tokens can be
 					// introspected without the clutter.
-					value: tokens.get(counter - 1)
-				}
+					value: tokens.get(counter - 1),
+				},
 			});
 		};
 

--- a/packages/liferay-npm-scripts/src/jsp/extractJS.js
+++ b/packages/liferay-npm-scripts/src/jsp/extractJS.js
@@ -47,7 +47,7 @@ const JS_TYPES = new Set([
 	'text/jscript',
 	'text/livescript',
 	'text/x-ecmascript',
-	'text/x-javascript'
+	'text/x-javascript',
 ]);
 
 /**
@@ -103,17 +103,19 @@ function extractJS(source) {
 							end: {
 								column: lastLine.length + 1,
 								line:
-									prefixLines.length + contentLines.length - 1
+									prefixLines.length +
+									contentLines.length -
+									1,
 							},
 							index: offset,
 							length: match.length,
 							start: {
 								column: lastPrefixLine.length + 1,
-								line: prefixLines.length
-							}
+								line: prefixLines.length,
+							},
 						},
 						scriptAttributes,
-						tagNamespace
+						tagNamespace,
 					});
 				}
 			}

--- a/packages/liferay-npm-scripts/src/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/formatJSP.js
@@ -15,12 +15,11 @@ const processJSP = require('./processJSP');
 function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 	const prettierOptions = {
 		...prettierConfig,
+		parser: 'babel',
 
 		// Because JS in JSP does not pass through Babel, and because IE will
 		// choke on trailing commas.
-		trailingComma: 'none',
-
-		parser: 'babel'
+		trailingComma: 'none'
 	};
 
 	return processJSP(source, {

--- a/packages/liferay-npm-scripts/src/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/formatJSP.js
@@ -19,13 +19,13 @@ function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 
 		// Because JS in JSP does not pass through Babel, and because IE will
 		// choke on trailing commas.
-		trailingComma: 'none'
+		trailingComma: 'none',
 	};
 
 	return processJSP(source, {
 		onFormat: input => {
 			return prettier.format(input, prettierOptions);
-		}
+		},
 	});
 }
 

--- a/packages/liferay-npm-scripts/src/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/formatJSP.js
@@ -15,6 +15,11 @@ const processJSP = require('./processJSP');
 function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 	const prettierOptions = {
 		...prettierConfig,
+
+		// Because JS in JSP does not pass through Babel, and because IE will
+		// choke on trailing commas.
+		trailingComma: 'none',
+
 		parser: 'babel'
 	};
 

--- a/packages/liferay-npm-scripts/src/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/formatJSP.js
@@ -16,10 +16,6 @@ function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 	const prettierOptions = {
 		...prettierConfig,
 		parser: 'babel',
-
-		// Because JS in JSP does not pass through Babel, and because IE will
-		// choke on trailing commas.
-		trailingComma: 'none',
 	};
 
 	return processJSP(source, {

--- a/packages/liferay-npm-scripts/src/jsp/lex.js
+++ b/packages/liferay-npm-scripts/src/jsp/lex.js
@@ -9,13 +9,13 @@
 const Lexer = require('./Lexer');
 
 const DEFAULT_OPTIONS = {
-	ELEnabled: true
+	ELEnabled: true,
 };
 
 function lex(source, options = {}) {
 	const {ELEnabled} = {
 		...DEFAULT_OPTIONS,
-		...options
+		...options,
 	};
 
 	const lexer = new Lexer(api => {
@@ -34,7 +34,7 @@ function lex(source, options = {}) {
 			repeat,
 			sequence,
 			token,
-			when
+			when,
 		} = api;
 
 		meta.set('ELEnabled', !!ELEnabled);
@@ -306,7 +306,7 @@ function lex(source, options = {}) {
 					'\\u3041-\\u3094',
 					'\\u30a1-\\u30fa',
 					'\\u3105-\\u312c',
-					'\\uac00-\\ud7a3'
+					'\\uac00-\\ud7a3',
 				].join('')}]`
 			)
 		).name('BASE_CHAR');
@@ -409,7 +409,7 @@ function lex(source, options = {}) {
 					'\\u20e1',
 					'\\u302a-\\u302f',
 					'\\u3099',
-					'\\u309a'
+					'\\u309a',
 				].join('')}]`
 			)
 			/* eslint-enable no-misleading-character-class */
@@ -432,7 +432,7 @@ function lex(source, options = {}) {
 					'\\u0d66-\\u0d6f',
 					'\\u0e50-\\u0e59',
 					'\\u0ed0-\\u0ed9',
-					'\\u0f20-\\u0f29'
+					'\\u0f20-\\u0f29',
 				].join('')}]`
 			)
 		).name('DIGIT');
@@ -450,7 +450,7 @@ function lex(source, options = {}) {
 					'\\u3005',
 					'\\u3031-\\u3035',
 					'\\u309d-\\u309e',
-					'\\u30fc-\\u30fe'
+					'\\u30fc-\\u30fe',
 				].join('')}]`
 			)
 		).name('EXTENDER');
@@ -541,7 +541,7 @@ function lex(source, options = {}) {
 			a('NAME').onMatch((match, meta) => {
 				meta.set('attribute:names', [
 					...meta.get('attribute:names'),
-					match[0]
+					match[0],
 				]);
 			}),
 			'EQ',
@@ -768,14 +768,14 @@ function lex(source, options = {}) {
 		[Symbol.iterator]: {
 			value() {
 				return lexer.lex(source);
-			}
+			},
 		},
 
 		tokens: {
 			get() {
 				return [...lexer.lex(source)];
-			}
-		}
+			},
+		},
 	});
 
 	return iterable;

--- a/packages/liferay-npm-scripts/src/jsp/lintJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/lintJSP.js
@@ -11,14 +11,14 @@ const linter = new Linter();
 
 const rules = {
 	'no-debugger': 'error',
-	'no-extra-boolean-cast': 'error'
+	'no-extra-boolean-cast': 'error',
 };
 
 const SEVERITY = {
 	/* eslint-disable sort-keys */
 	ERROR: 2,
 	WARNING: 1,
-	OFF: 0
+	OFF: 0,
 	/* eslint-enable sort-keys */
 };
 
@@ -81,12 +81,12 @@ function lintJSP(source, onReport, options = {}) {
 					fixableWarningCount,
 					messages,
 					source,
-					warningCount
+					warningCount,
 				});
 			}
 
 			return source;
-		}
+		},
 	});
 }
 

--- a/packages/liferay-npm-scripts/src/jsp/processJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/processJSP.js
@@ -63,7 +63,7 @@ function processJSP(source, {onFormat, onLint}) {
 
 		return {
 			...block,
-			contents: prefix + indented + suffix
+			contents: prefix + indented + suffix,
 		};
 	});
 

--- a/packages/liferay-npm-scripts/src/jsp/restoreTags.js
+++ b/packages/liferay-npm-scripts/src/jsp/restoreTags.js
@@ -40,7 +40,7 @@ function restoreTags(source, tags) {
 			IDENTIFIER_REPLACEMENT,
 			NEWLINE,
 			WHITESPACE,
-			ANYTHING
+			ANYTHING,
 			/* eslint-enable sort-keys */
 		});
 	});
@@ -175,7 +175,7 @@ function appendScriptlet(scriptlet, token, output) {
 		'-1': token.previous,
 		0: token,
 		1: token.next,
-		2: token.next && token.next.next
+		2: token.next && token.next.next,
 		/* eslint-enable sort-keys */
 	};
 

--- a/packages/liferay-npm-scripts/src/jsp/stripIndents.js
+++ b/packages/liferay-npm-scripts/src/jsp/stripIndents.js
@@ -54,7 +54,7 @@ function stripIndents(source) {
 			CLOSE_TAG_REPLACEMENT,
 			NEWLINE,
 			WHITESPACE,
-			ANYTHING
+			ANYTHING,
 			/* eslint-enable sort-keys */
 		});
 	});

--- a/packages/liferay-npm-scripts/src/jsp/substituteTags.js
+++ b/packages/liferay-npm-scripts/src/jsp/substituteTags.js
@@ -8,7 +8,7 @@ const lex = require('./lex');
 const {
 	getCloseTagReplacement,
 	getOpenTagReplacement,
-	getSelfClosingTagReplacement
+	getSelfClosingTagReplacement,
 } = require('./tagReplacements');
 const toFiller = require('./toFiller');
 

--- a/packages/liferay-npm-scripts/src/jsp/tagReplacements.js
+++ b/packages/liferay-npm-scripts/src/jsp/tagReplacements.js
@@ -141,5 +141,5 @@ module.exports = {
 
 	getCloseTagReplacement,
 	getOpenTagReplacement,
-	getSelfClosingTagReplacement
+	getSelfClosingTagReplacement,
 };

--- a/packages/liferay-npm-scripts/src/presets/standard/dependencies/clay.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/dependencies/clay.js
@@ -33,5 +33,5 @@ module.exports = [
 	'clay-select',
 	'clay-sticker',
 	'clay-table',
-	'clay-tooltip'
+	'clay-tooltip',
 ];

--- a/packages/liferay-npm-scripts/src/presets/standard/dependencies/liferay.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/dependencies/liferay.js
@@ -8,5 +8,5 @@ module.exports = [
 	'frontend-js-web',
 	'frontend-taglib-clay',
 	'frontend-taglib',
-	'hello-soy-web'
+	'hello-soy-web',
 ];

--- a/packages/liferay-npm-scripts/src/presets/standard/dependencies/metal.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/dependencies/metal.js
@@ -36,5 +36,5 @@ module.exports = [
 	'metal-toggler',
 	'metal-uri',
 	'metal-useragent',
-	'metal-web-component'
+	'metal-web-component',
 ];

--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -16,7 +16,7 @@ const CHECK_AND_FIX_GLOBS = [
 	...JS_GLOBS,
 	...JSON_GLOBS,
 	...JSP_GLOBS,
-	...SCSS_GLOBS
+	...SCSS_GLOBS,
 ];
 
 module.exports = {
@@ -24,16 +24,16 @@ module.exports = {
 		dependencies: [...clay, ...liferay, ...metal],
 		input: 'src/main/resources/META-INF/resources',
 		output: 'build/node/packageRunBuild/resources',
-		temp: 'build/npmscripts'
+		temp: 'build/npmscripts',
 	},
 	check: CHECK_AND_FIX_GLOBS,
 	fix: CHECK_AND_FIX_GLOBS,
 	rules: {
-		'blacklisted-dependency-patterns': ['^liferay-npm-bundler-loader-.+']
+		'blacklisted-dependency-patterns': ['^liferay-npm-bundler-loader-.+'],
 	},
 	storybook: {
 		languagePaths: ['src/main/resources/content/Language.properties'],
 		port: '9000',
-		portalURL: 'http://0.0.0.0:8080'
-	}
+		portalURL: 'http://0.0.0.0:8080',
+	},
 };

--- a/packages/liferay-npm-scripts/src/prettier/index.js
+++ b/packages/liferay-npm-scripts/src/prettier/index.js
@@ -49,12 +49,12 @@ const cli = new CLIEngine({
 	overrides: [],
 	parserOptions: {
 		...eslintConfig.parserOptions,
-		sourceType: 'module'
+		sourceType: 'module',
 	},
 	rules: {
-		'newline-before-block-statements': 'error'
+		'newline-before-block-statements': 'error',
 	},
-	useEslintrc: false
+	useEslintrc: false,
 });
 
 /**
@@ -88,7 +88,7 @@ function format(source, options) {
 			// Override "parser" value from `getConfigForFile()`, which
 			// is an absolute path; make it a name that matches the
 			// parser we defined with `defineParser()` above.
-			parser: 'babel-eslint'
+			parser: 'babel-eslint',
 		},
 
 		{allowInlineConfig: false, filename}
@@ -99,5 +99,5 @@ function format(source, options) {
 
 module.exports = {
 	check,
-	format
+	format,
 };

--- a/packages/liferay-npm-scripts/src/prettier/rules/newline-before-block-statements.js
+++ b/packages/liferay-npm-scripts/src/prettier/rules/newline-before-block-statements.js
@@ -34,7 +34,7 @@ module.exports = {
 						);
 					},
 					message: 'line break needed before node',
-					node
+					node,
 				});
 			}
 		}
@@ -90,7 +90,7 @@ module.exports = {
 				if (finalizer) {
 					check(handler || block);
 				}
-			}
+			},
 		};
-	}
+	},
 };

--- a/packages/liferay-npm-scripts/src/scripts/check/preflight.js
+++ b/packages/liferay-npm-scripts/src/scripts/check/preflight.js
@@ -52,7 +52,7 @@ const DISALLOWED_CONFIG_FILE_NAMES = {
 	'.stylelintrc.json': STYLELINT_CONFIG_FILE_NAME,
 	'.stylelintrc.yml': STYLELINT_CONFIG_FILE_NAME,
 	'.stylelintrc.yaml': STYLELINT_CONFIG_FILE_NAME,
-	'stylelint.config.js': STYLELINT_CONFIG_FILE_NAME
+	'stylelint.config.js': STYLELINT_CONFIG_FILE_NAME,
 };
 
 /* eslint-enable sort-keys */

--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -14,7 +14,7 @@ const log = require('../utils/log');
 const {SpawnError} = require('../utils/spawnSync');
 
 const DEFAULT_OPTIONS = {
-	check: false
+	check: false,
 };
 
 /**
@@ -30,7 +30,7 @@ const IGNORE_FILE = '.prettierignore';
 function format(options = {}) {
 	const {check} = {
 		...DEFAULT_OPTIONS,
-		...options
+		...options,
 	};
 
 	const globs = check
@@ -58,7 +58,7 @@ function format(options = {}) {
 
 			const prettierOptions = {
 				...config,
-				filepath
+				filepath,
 			};
 
 			let checkFormat;

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -18,7 +18,7 @@ const lintSCSS = require('./lint/stylelint/lintSCSS');
 
 const DEFAULT_OPTIONS = {
 	fix: false,
-	quiet: false
+	quiet: false,
 };
 
 /**
@@ -31,7 +31,7 @@ const DEFAULT_OPTIONS = {
 const EXTENSIONS = {
 	js: ['.js', '.ts', '.tsx'],
 	jsp: ['.jsp', '.jspf'],
-	scss: ['.scss']
+	scss: ['.scss'],
 };
 
 const IGNORE_FILE = '.eslintignore';
@@ -42,7 +42,7 @@ const IGNORE_FILE = '.eslintignore';
 async function lint(options = {}) {
 	const {fix, quiet} = {
 		...DEFAULT_OPTIONS,
-		...options
+		...options,
 	};
 
 	const globs = fix
@@ -77,12 +77,12 @@ async function lint(options = {}) {
 
 		// Avoid spurious warnings of the form, "File ignored by
 		// default. Use a negated ignore pattern ... to override"
-		ignorePattern: '!*'
+		ignorePattern: '!*',
 	});
 
 	const {default: jsPaths, jspPaths, scssPaths} = partitionArray(paths, {
 		jspPaths: isJSP,
-		scssPaths: isSCSS
+		scssPaths: isSCSS,
 	});
 
 	let report;
@@ -100,7 +100,7 @@ async function lint(options = {}) {
 
 	for (const [paths, linter] of [
 		[jspPaths, lintJSP],
-		[scssPaths, lintSCSS]
+		[scssPaths, lintSCSS],
 	]) {
 		for (const filePath of paths) {
 			// TODO: non-sync version to make use of I/O concurrency
@@ -112,7 +112,7 @@ async function lint(options = {}) {
 					result => {
 						report.results.push({
 							...result,
-							filePath: path.resolve(filePath)
+							filePath: path.resolve(filePath),
 						});
 					},
 					{filePath, fix, quiet}
@@ -142,7 +142,7 @@ async function lint(options = {}) {
 
 			return {
 				...result,
-				messages
+				messages,
 			};
 		})
 		.filter(Boolean);
@@ -162,7 +162,7 @@ function color(name) {
 				RED: '\x1b[31m',
 				RESET: '\x1b[0m',
 				UNDERLINE: '\x1b[4m',
-				YELLOW: '\x1b[33m'
+				YELLOW: '\x1b[33m',
 			}[name] || ''
 		);
 	} else {
@@ -237,7 +237,7 @@ function formatter(results) {
 			' ',
 			`(${pluralize('error', errors)}, `,
 			`${pluralize('warning', warnings)})`,
-			color.RESET
+			color.RESET,
 		];
 
 		if (fixableErrorCount || fixableWarningCount) {
@@ -268,7 +268,7 @@ function formatter(results) {
  */
 function partitionArray(array, predicates) {
 	const results = {
-		default: []
+		default: [],
 	};
 
 	Object.keys(predicates).forEach(key => {

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/lintSCSS.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/lintSCSS.js
@@ -46,7 +46,7 @@ async function lintSCSS(source, onReport, options = {}) {
 		// containing non-source metadata instead.
 		fix,
 
-		syntax: 'scss'
+		syntax: 'scss',
 	});
 
 	results.forEach(result => {
@@ -72,7 +72,7 @@ async function lintSCSS(source, onReport, options = {}) {
 							line,
 							message: text,
 							ruleId: rule,
-							severity: severity === 'error' ? 2 : 1
+							severity: severity === 'error' ? 2 : 1,
 						};
 					}
 				)
@@ -90,7 +90,7 @@ async function lintSCSS(source, onReport, options = {}) {
 			fixableWarningCount,
 			messages,
 			source,
-			warningCount
+			warningCount,
 		});
 	}
 

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-block-comments.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-block-comments.js
@@ -9,13 +9,13 @@ const ruleName = 'liferay/no-block-comments';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
 	expected:
-		'No block-based comments (/* ... */); use line-based (//) comment syntax instead'
+		'No block-based comments (/* ... */); use line-based (//) comment syntax instead',
 });
 
 module.exports = stylelint.createPlugin(ruleName, actual => {
 	return function(root, result) {
 		const validOptions = stylelint.utils.validateOptions(result, ruleName, {
-			actual
+			actual,
 		});
 
 		if (!validOptions) {
@@ -28,7 +28,7 @@ module.exports = stylelint.createPlugin(ruleName, actual => {
 					message: messages.expected,
 					node: comment,
 					result,
-					ruleName
+					ruleName,
 				});
 			}
 		});

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-import-extension.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-import-extension.js
@@ -8,7 +8,7 @@ const stylelint = require('stylelint');
 const ruleName = 'liferay/no-import-extension';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
-	extension: 'imports must omit the ".scss" extension'
+	extension: 'imports must omit the ".scss" extension',
 });
 
 const PARAMS_REGEXP = /^(['"]?)(.+?)(['"]?)$/;
@@ -24,14 +24,14 @@ module.exports = stylelint.createPlugin(
 				ruleName,
 				{
 					actual: options,
-					possible: [true, false]
+					possible: [true, false],
 				},
 				{
 					actual: secondaryOptions,
 					optional: true,
 					possible: {
-						disableFix: [true, false]
-					}
+						disableFix: [true, false],
+					},
 				}
 			);
 
@@ -63,7 +63,7 @@ module.exports = stylelint.createPlugin(
 							message: messages.extension,
 							node: rule,
 							result,
-							ruleName
+							ruleName,
 						});
 					}
 				}

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/single-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/single-imports.js
@@ -8,7 +8,7 @@ const stylelint = require('stylelint');
 const ruleName = 'liferay/single-imports';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
-	single: 'one import rule per resource'
+	single: 'one import rule per resource',
 });
 
 const MATCHERS = Object.entries({
@@ -16,7 +16,7 @@ const MATCHERS = Object.entries({
 	SEPARATOR: /^,/,
 	SINGLE_QUOTED_STRING: /^'[^']*'/,
 	URL: /^url\s*\([^)]*\)/,
-	WHITESPACE: /^\s+/
+	WHITESPACE: /^\s+/,
 });
 
 function tokenize(params) {
@@ -36,7 +36,7 @@ function tokenize(params) {
 
 				tokens.push({
 					kind,
-					text: match[0]
+					text: match[0],
 				});
 
 				i += text.length;
@@ -64,14 +64,14 @@ module.exports = stylelint.createPlugin(
 				ruleName,
 				{
 					actual: options,
-					possible: [true, false]
+					possible: [true, false],
 				},
 				{
 					actual: secondaryOptions,
 					optional: true,
 					possible: {
-						disableFix: [true, false]
-					}
+						disableFix: [true, false],
+					},
 				}
 			);
 
@@ -128,7 +128,7 @@ module.exports = stylelint.createPlugin(
 							message: messages.single,
 							node: rule,
 							result,
-							ruleName
+							ruleName,
 						});
 					}
 				}

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
@@ -8,7 +8,7 @@ const stylelint = require('stylelint');
 const ruleName = 'liferay/sort-imports';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
-	sort: 'imports must be sorted by target name'
+	sort: 'imports must be sorted by target name',
 });
 
 function precededByBlankLine(node) {
@@ -26,14 +26,14 @@ module.exports = stylelint.createPlugin(
 				ruleName,
 				{
 					actual: options,
-					possible: [true, false]
+					possible: [true, false],
 				},
 				{
 					actual: secondaryOptions,
 					optional: true,
 					possible: {
-						disableFix: [true, false]
-					}
+						disableFix: [true, false],
+					},
 				}
 			);
 
@@ -120,7 +120,7 @@ module.exports = stylelint.createPlugin(
 								message: `${messages.sort} (expected: ${order})`,
 								node: group[firstMismatch],
 								result,
-								ruleName
+								ruleName,
 							});
 						}
 					}

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/trim-comments.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/trim-comments.js
@@ -9,7 +9,7 @@ const ruleName = 'liferay/trim-comments';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
 	noLeadingBlanks: 'No blank leading lines in comments',
-	noTrailingBlanks: 'No blank trailing lines in comments'
+	noTrailingBlanks: 'No blank trailing lines in comments',
 });
 
 // In practice, PostCSS represents whitespace-only comments with empty
@@ -65,14 +65,14 @@ module.exports = stylelint.createPlugin(
 				ruleName,
 				{
 					actual: options,
-					possible: [true, false]
+					possible: [true, false],
 				},
 				{
 					actual: secondaryOptions,
 					optional: true,
 					possible: {
-						disableFix: [true, false]
-					}
+						disableFix: [true, false],
+					},
 				}
 			);
 
@@ -92,7 +92,7 @@ module.exports = stylelint.createPlugin(
 								message,
 								node: comment,
 								result,
-								ruleName
+								ruleName,
 							});
 						};
 

--- a/packages/liferay-npm-scripts/src/scripts/prettier.js
+++ b/packages/liferay-npm-scripts/src/scripts/prettier.js
@@ -94,7 +94,7 @@ function main(...args) {
 		'-c': unsupported,
 		'-h': help,
 		'-l': unsupported,
-		'-v': version
+		'-v': version,
 	};
 
 	for (i = 0; i < args.length; i++) {
@@ -131,13 +131,13 @@ function main(...args) {
 			getPaths([arg], [], IGNORE_FILE).forEach(filepath => {
 				files.push({
 					contents: null,
-					filepath
+					filepath,
 				});
 			});
 		} else {
 			files.push({
 				contents: null,
-				filepath: arg
+				filepath: arg,
 			});
 		}
 	}
@@ -157,8 +157,8 @@ function main(...args) {
 		files = [
 			{
 				contents: fs.readFileSync(0, 'utf8'),
-				filepath: options.stdinFilepath
-			}
+				filepath: options.stdinFilepath,
+			},
 		];
 	}
 
@@ -172,7 +172,7 @@ function main(...args) {
 
 		const prettierOptions = {
 			...config,
-			filepath
+			filepath,
 		};
 
 		if (isJSP(filepath)) {
@@ -207,7 +207,7 @@ Object.assign(main, {
 
 	resolveConfig: () => Promise.resolve(null),
 
-	version: prettier.version
+	version: prettier.version,
 });
 
 function exit() {

--- a/packages/liferay-npm-scripts/src/scripts/storybook.js
+++ b/packages/liferay-npm-scripts/src/scripts/storybook.js
@@ -16,7 +16,7 @@ const STORYBOOK_CONFIG = getMergedConfig('npmscripts').storybook;
 
 const NODE_PATHS = [
 	path.join(__dirname, '../../../../node_modules'),
-	path.join(__dirname, '../../node_modules')
+	path.join(__dirname, '../../node_modules'),
 ];
 
 const STORYBOOK_CONFIG_DIR_PATH = path.join(__dirname, '../storybook');
@@ -27,7 +27,7 @@ const STORYBOOK_CONFIG_FILES = [
 	'frontend-js-web.mock.js',
 	'middleware.js',
 	'preview-head.html',
-	'webpack.config.js'
+	'webpack.config.js',
 ];
 
 const PORTAL_ROOT = process.cwd().split('/modules')[0];
@@ -123,14 +123,14 @@ function storybook() {
 
 		// Set portal root directory to retrieve static resources from.
 		'--static-dir',
-		PORTAL_ROOT
+		PORTAL_ROOT,
 	];
 
 	spawnSync('start-storybook', args, {
 		env: {
 			...process.env,
-			NODE_PATH: buildNodePath()
-		}
+			NODE_PATH: buildNodePath(),
+		},
 	});
 }
 

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -40,7 +40,7 @@ module.exports = function(arrArgs = []) {
 
 		const env = {
 			...process.env,
-			NODE_ENV: 'test'
+			NODE_ENV: 'test',
 		};
 
 		const {NODE_ENV} = process.env;
@@ -56,7 +56,7 @@ module.exports = function(arrArgs = []) {
 		}
 
 		spawnSync('jest', ['--config', CONFIG_PATH, ...arrArgs.slice(1)], {
-			env
+			env,
 		});
 
 		if (useSoy) {

--- a/packages/liferay-npm-scripts/src/scripts/theme.js
+++ b/packages/liferay-npm-scripts/src/scripts/theme.js
@@ -18,7 +18,7 @@ const BUILD_ARGS = {
 	),
 	'--unstyled-path': path.normalize(
 		`${MODULES_DIR}/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled`
-	)
+	),
 };
 
 /**
@@ -102,5 +102,5 @@ module.exports = {
 	checkExistingBuildArgs,
 	findModulesDirectory,
 	prepareAdditionalBuildArgs,
-	run
+	run,
 };

--- a/packages/liferay-npm-scripts/src/scripts/webpack.js
+++ b/packages/liferay-npm-scripts/src/scripts/webpack.js
@@ -27,14 +27,14 @@ module.exports = function(...args) {
 			// a new array instead.
 			const otherArgs = [
 				...args.slice(0, watch),
-				...args.slice(watch + 1)
+				...args.slice(watch + 1),
 			];
 
 			withWebpackConfig(WEBPACK_DEV_CONFIG_FILE, configFilePath => {
 				spawnSync('webpack-dev-server', [
 					'--config',
 					configFilePath,
-					...otherArgs
+					...otherArgs,
 				]);
 			});
 		}

--- a/packages/liferay-npm-scripts/src/storybook/README.md
+++ b/packages/liferay-npm-scripts/src/storybook/README.md
@@ -76,7 +76,7 @@ A11y and viewport addons are automatically included. To use the actions and knob
 ```javascript
 import {
 	StorybookAddonActions,
-	StorybookAddonKnobs
+	StorybookAddonKnobs,
 } from 'liferay-npm-scripts/src/storybook';
 
 const {action} = StorybookAddonActions;
@@ -111,8 +111,8 @@ module.exports = {
 		port: '9000',
 
 		// URL of a running portal instance to proxy `/o` resources.
-		portalURL: 'http://0.0.0.0:8080'
-	}
+		portalURL: 'http://0.0.0.0:8080',
+	},
 };
 ```
 
@@ -125,7 +125,7 @@ import React from 'react';
 import {
 	STORYBOOK_CONSTANTS,
 	StorybookAddonActions,
-	StorybookReact
+	StorybookReact,
 } from 'liferay-npm-scripts/src/storybook';
 
 import '../../src/main/resources/META-INF/resources/css/main.scss';
@@ -138,7 +138,7 @@ const {action} = StorybookAddonActions;
 
 addDecorator(storyFn => {
 	const context = {
-		spritemap: STORYBOOK_CONSTANTS.SPRITEMAP_PATH
+		spritemap: STORYBOOK_CONSTANTS.SPRITEMAP_PATH,
 	};
 
 	return (
@@ -155,12 +155,12 @@ storiesOf('Components|Conjunction', module).add('default', () => (
 		supportedConjunctions={[
 			{
 				label: Liferay.Language.get('and'),
-				name: 'AND'
+				name: 'AND',
 			},
 			{
 				label: Liferay.Language.get('or'),
-				name: 'OR'
-			}
+				name: 'OR',
+			},
 		]}
 	/>
 ));

--- a/packages/liferay-npm-scripts/src/storybook/frontend-js-web.mock.js
+++ b/packages/liferay-npm-scripts/src/storybook/frontend-js-web.mock.js
@@ -18,7 +18,7 @@ module.exports = {
 	fetch,
 	navigate: (url, listeners) => console.log({listeners, url}),
 	openSimpleInputModal: config => console.log(config),
-	openToast: config => console.log(config)
+	openToast: config => console.log(config),
 };
 
 /* eslint-enable no-console */

--- a/packages/liferay-npm-scripts/src/storybook/index.js
+++ b/packages/liferay-npm-scripts/src/storybook/index.js
@@ -9,12 +9,12 @@ import * as StorybookReact from '@storybook/react';
 
 const STORYBOOK_CONSTANTS = {
 	SPRITEMAP_PATH:
-		'/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/images/clay/icons.svg'
+		'/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/images/clay/icons.svg',
 };
 
 export {
 	STORYBOOK_CONSTANTS,
 	StorybookAddonActions,
 	StorybookAddonKnobs,
-	StorybookReact
+	StorybookReact,
 };

--- a/packages/liferay-npm-scripts/src/storybook/middleware.js
+++ b/packages/liferay-npm-scripts/src/storybook/middleware.js
@@ -19,7 +19,7 @@ module.exports = function expressMiddleware(router) {
 		'/o',
 		proxy({
 			changeOrigin: true,
-			target: STORYBOOK_CONFIG.portalURL
+			target: STORYBOOK_CONFIG.portalURL,
 		})
 	);
 };

--- a/packages/liferay-npm-scripts/src/storybook/webpack.config.js
+++ b/packages/liferay-npm-scripts/src/storybook/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = async ({config}) => {
 		{
 			include: path.resolve(CWD),
 			loaders: ['style-loader', 'css-loader', 'sass-loader'],
-			test: /\.scss$/
+			test: /\.scss$/,
 		},
 		{
 			exclude: /node_modules/,
@@ -34,16 +34,16 @@ module.exports = async ({config}) => {
 				{
 					loader: 'liferay-lang-key-dev-loader',
 					options: {
-						path: path.join(__dirname, 'Language.properties')
-					}
-				}
-			]
-		}
+						path: path.join(__dirname, 'Language.properties'),
+					},
+				},
+			],
+		},
 	];
 
 	config.plugins.push(
 		new webpack.DefinePlugin({
-			'process.env.STORYBOOK_CWD': JSON.stringify(CWD)
+			'process.env.STORYBOOK_CWD': JSON.stringify(CWD),
 		})
 	);
 

--- a/packages/liferay-npm-scripts/src/utils/SignalHandler.js
+++ b/packages/liferay-npm-scripts/src/utils/SignalHandler.js
@@ -15,7 +15,7 @@ const SIGNALS = {
 	SIGHUP: 1,
 	SIGINT: 2,
 	SIGQUIT: 3,
-	SIGTERM: 15
+	SIGTERM: 15,
 };
 
 const SignalHandler = {
@@ -33,7 +33,7 @@ const SignalHandler = {
 		SignalHandler.install();
 
 		return getDisposable(callback, index++);
-	}
+	},
 };
 
 function getDisposable(callback, id) {
@@ -44,7 +44,7 @@ function getDisposable(callback, id) {
 			callback();
 
 			callbacks.delete(id);
-		}
+		},
 	};
 }
 

--- a/packages/liferay-npm-scripts/src/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/src/utils/deepMerge.js
@@ -61,7 +61,7 @@ function checkBabelName(name, kind) {
 
 			// @org/babel-plugin-foo -> @org/foo
 			// babel-plugin-foo      -> foo
-			'^(@[\\w-]+/)?babel-plugin-([\\w-]+)': '$1$2'
+			'^(@[\\w-]+/)?babel-plugin-([\\w-]+)': '$1$2',
 			/* eslint-enable sort-keys */
 		},
 		preset: {
@@ -72,9 +72,9 @@ function checkBabelName(name, kind) {
 
 			// @org/babel-preset-foo -> @org/foo
 			// babel-preset-foo      -> foo
-			'^(@[\\w-]+/)?babel-preset-([\\w-]+)': '$1$2'
+			'^(@[\\w-]+/)?babel-preset-([\\w-]+)': '$1$2',
 			/* eslint-enable sort-keys */
-		}
+		},
 	};
 
 	Object.entries(NORMALIZERS[kind]).reduce((done, [pattern, replacement]) => {
@@ -132,7 +132,7 @@ function getBabelOptions(item) {
 function babelMerge(key) {
 	const kind = {
 		plugins: 'plugin',
-		presets: 'preset'
+		presets: 'preset',
 	}[key];
 
 	if (kind === 'plugin' || kind === 'preset') {
@@ -152,7 +152,7 @@ function babelMerge(key) {
 					const mergedOptions = merge.all(
 						[
 							getBabelOptions(targetItem),
-							getBabelOptions(sourceItem)
+							getBabelOptions(sourceItem),
 						].filter(Boolean),
 						options
 					);
@@ -199,7 +199,7 @@ function babelMerge(key) {
 const MODE = Object.freeze({
 	BABEL: 2,
 	DEFAULT: 0,
-	OVERWRITE_ARRAYS: 1
+	OVERWRITE_ARRAYS: 1,
 });
 
 /**
@@ -212,17 +212,17 @@ function deepMerge(items, mode = MODE.DEFAULT) {
 	switch (mode) {
 		case MODE.DEFAULT:
 			return merge.all(items, {
-				arrayMerge: combineMerge
+				arrayMerge: combineMerge,
 			});
 
 		case MODE.OVERWRITE_ARRAYS:
 			return merge.all(items, {
-				arrayMerge: overwriteMerge
+				arrayMerge: overwriteMerge,
 			});
 
 		case MODE.BABEL:
 			return merge.all(items, {
-				customMerge: babelMerge
+				customMerge: babelMerge,
 			});
 
 		default:

--- a/packages/liferay-npm-scripts/src/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/expandGlobs.js
@@ -10,7 +10,7 @@ const getRegExpForGlob = require('./getRegExpForGlob');
 
 const DEFAULT_OPTIONS = {
 	maxDepth: Infinity,
-	type: 'file'
+	type: 'file',
 };
 
 /**
@@ -20,7 +20,7 @@ const DEFAULT_OPTIONS = {
 function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 	const {maxDepth, type} = {
 		...DEFAULT_OPTIONS,
-		...options
+		...options,
 	};
 	const ignorers = [];
 	const matchers = matchGlobs.map(getRegExpForGlob);

--- a/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
+++ b/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
@@ -26,7 +26,7 @@ function generateSoyDependencies(dependencies) {
 				// infer the directory from the package root
 				resolvedDependency = path.dirname(
 					resolve.sync(`${dependency}/package.json`, {
-						basedir: cwd
+						basedir: cwd,
 					})
 				);
 			} catch (err) {

--- a/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -64,7 +64,7 @@ function getJestModuleNameMapper() {
 			const mappings = {};
 			const projects = expandGlobs(workspaces.packages, IGNORE_GLOBS, {
 				maxDepth: 3,
-				type: 'directory'
+				type: 'directory',
 			});
 
 			projects.forEach(project => {
@@ -93,7 +93,7 @@ function getJestModuleNameMapper() {
 			});
 
 			return {
-				moduleNameMapper: mappings
+				moduleNameMapper: mappings,
 			};
 		} catch (error) {
 			log(`getJestModuleNameMapper(): error \`${error}\``);

--- a/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
@@ -50,7 +50,7 @@ function filter(object, property, callback) {
 				[key]:
 					key === property
 						? callback(value)
-						: filter(value, property, callback)
+						: filter(value, property, callback),
 			};
 		}, {});
 	} else {
@@ -111,21 +111,21 @@ function getMergedConfig(type, property) {
 		case 'bundler':
 			mergedConfig = deepMerge([
 				require('../config/npm-bundler'),
-				getUserConfig('npmbundler')
+				getUserConfig('npmbundler'),
 			]);
 			break;
 
 		case 'stylelint':
 			mergedConfig = deepMerge([
 				require('../config/stylelint'),
-				getUserConfig('stylelint')
+				getUserConfig('stylelint'),
 			]);
 			break;
 
 		case 'eslint':
 			mergedConfig = deepMerge([
 				require('../config/eslint.config'),
-				getUserConfig('eslint')
+				getUserConfig('eslint'),
 			]);
 			break;
 
@@ -133,14 +133,14 @@ function getMergedConfig(type, property) {
 			mergedConfig = deepMerge([
 				require('../config/jest.config'),
 				require('../utils/getJestModuleNameMapper')(),
-				getUserConfig('jest')
+				getUserConfig('jest'),
 			]);
 			break;
 
 		case 'prettier':
 			mergedConfig = deepMerge([
 				require('../config/prettier'),
-				getUserConfig('prettier', {upwards: true})
+				getUserConfig('prettier', {upwards: true}),
 			]);
 			break;
 

--- a/packages/liferay-npm-scripts/src/utils/getRegExpForGlob.js
+++ b/packages/liferay-npm-scripts/src/utils/getRegExpForGlob.js
@@ -54,7 +54,7 @@ function getRegExpForGlob(glob) {
 
 	const state = {
 		input: glob,
-		lastMatch: null
+		lastMatch: null,
 	};
 
 	const negated = scan('!', state);

--- a/packages/liferay-npm-scripts/src/utils/mergeBabelLoaderOptions.js
+++ b/packages/liferay-npm-scripts/src/utils/mergeBabelLoaderOptions.js
@@ -37,7 +37,7 @@ function mergeBabelLoaderOptions(webpackConfig) {
 			if (typeof useEntry === 'string') {
 				use[i] = {
 					loader: useEntry,
-					options: {...BABEL_CONFIG}
+					options: {...BABEL_CONFIG},
 				};
 			} else {
 				use[i].options = {...BABEL_CONFIG, ...useEntry.options};

--- a/packages/liferay-npm-scripts/src/utils/runBabel.js
+++ b/packages/liferay-npm-scripts/src/utils/runBabel.js
@@ -18,7 +18,7 @@ function runBabel(...args) {
 			'--no-babelrc',
 			'--config-file',
 			babelRcPath,
-			...args
+			...args,
 		]);
 	});
 }

--- a/packages/liferay-npm-scripts/src/utils/runBundler.js
+++ b/packages/liferay-npm-scripts/src/utils/runBundler.js
@@ -20,7 +20,7 @@ function runBundler(...args) {
 			spawnSync('liferay-npm-bundler', [
 				'--config',
 				npmbundlerRcPath,
-				...args
+				...args,
 			]);
 		}
 	);

--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -28,7 +28,7 @@ function buildSoy() {
 		'--soyDeps',
 		generateSoyDependencies(BUILD_CONFIG.dependencies),
 		'--externalMsgFormat',
-		"Liferay.Language.get('$2')"
+		"Liferay.Language.get('$2')",
 	]);
 
 	runBabel(SOY_TEMP_DIR, '--out-dir', BUILD_CONFIG.output, '--source-maps');
@@ -138,5 +138,5 @@ module.exports = {
 	buildSoy,
 	cleanSoy,
 	soyExists,
-	translateSoy
+	translateSoy,
 };

--- a/packages/liferay-npm-scripts/src/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/src/utils/spawnSync.js
@@ -35,7 +35,7 @@ function spawnSync(command, args = [], options = {}) {
 
 	const {error, signal, status} = spawn.sync(executable, args, {
 		stdio: 'inherit',
-		...options
+		...options,
 	});
 
 	if (status) {

--- a/packages/liferay-npm-scripts/support/jest/matchers/toLintStyles.js
+++ b/packages/liferay-npm-scripts/support/jest/matchers/toLintStyles.js
@@ -28,17 +28,17 @@ expect.extend({
 			config: {
 				plugins: [location],
 				rules: {
-					[instance.ruleName]: options === undefined ? true : options
+					[instance.ruleName]: options === undefined ? true : options,
 				},
-				syntax: 'scss'
+				syntax: 'scss',
 			},
-			fix
+			fix,
 		});
 
 		const expected = {errors};
 
 		const received = {
-			errors: results.results[0].warnings
+			errors: results.results[0].warnings,
 		};
 
 		if (fix) {
@@ -53,7 +53,7 @@ expect.extend({
 				const settings = {
 					comment: `${count} error${count !== 1 ? 's' : ''}`,
 					isNot: this.isNot,
-					promise: this.promise
+					promise: this.promise,
 				};
 
 				const hint =
@@ -74,7 +74,7 @@ expect.extend({
 					);
 				} else {
 					const diffString = diff(expected, received, {
-						expand: this.expand
+						expand: this.expand,
 					});
 
 					if (diffString && diffString.includes('- Expect')) {
@@ -90,7 +90,7 @@ expect.extend({
 					}
 				}
 			},
-			pass: this.equals(received, expected)
+			pass: this.equals(received, expected),
 		};
-	}
+	},
 });

--- a/packages/liferay-npm-scripts/test/jsp/Lexer.js
+++ b/packages/liferay-npm-scripts/test/jsp/Lexer.js
@@ -44,7 +44,7 @@ describe('Lexer()', () => {
 
 			return choose({
 				A: match('a'),
-				B: match('b')
+				B: match('b'),
 			});
 		});
 
@@ -66,7 +66,7 @@ describe('Lexer()', () => {
 
 			return choose({
 				A: match('a'),
-				B: match('b')
+				B: match('b'),
 			});
 		});
 
@@ -77,7 +77,7 @@ describe('Lexer()', () => {
 		expect(tokens[0]).toEqual({
 			contents: 'a',
 			index: 0,
-			name: 'A'
+			name: 'A',
 		});
 
 		// Peek ahead using `next` before the iterator gets that far.
@@ -86,7 +86,7 @@ describe('Lexer()', () => {
 		expect(tokens[1]).toEqual({
 			contents: 'b',
 			index: 1,
-			name: 'B'
+			name: 'B',
 		});
 
 		// Tokens are doubly linked:
@@ -98,7 +98,7 @@ describe('Lexer()', () => {
 		expect(tokens[2]).toEqual({
 			contents: 'a',
 			index: 2,
-			name: 'A'
+			name: 'A',
 		});
 
 		expect(tokens[2].previous).toBe(tokens[1]);
@@ -116,19 +116,19 @@ describe('Lexer()', () => {
 		expect(tokens[3]).toEqual({
 			contents: 'b',
 			index: 3,
-			name: 'B'
+			name: 'B',
 		});
 
 		expect(tokens[4]).toEqual({
 			contents: 'a',
 			index: 4,
-			name: 'A'
+			name: 'A',
 		});
 
 		expect(tokens[5]).toEqual({
 			contents: 'b',
 			index: 5,
-			name: 'B'
+			name: 'B',
 		});
 
 		expect(iterator.next().done).toBe(true);
@@ -166,8 +166,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'thingthing',
 					index: 0,
-					name: 'THING'
-				}
+					name: 'THING',
+				},
 			]);
 		});
 
@@ -198,8 +198,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'foo:foo',
 					index: 0,
-					name: 'TOKEN'
-				}
+					name: 'TOKEN',
+				},
 			]);
 
 			// Note how ORIGINAL is used to match COPY, but after SEPARATOR we
@@ -209,7 +209,7 @@ describe('Lexer()', () => {
 				'ORIGINAL',
 				'COPY',
 				'SEPARATOR',
-				'ORIGINAL'
+				'ORIGINAL',
 			]);
 		});
 	});
@@ -236,16 +236,16 @@ describe('Lexer()', () => {
 				{
 					contents: 'foobarbaz',
 					index: 0,
-					name: 'ALL'
-				}
+					name: 'ALL',
+				},
 			]);
 
 			expect([...lexer.lex('bazbarfoo')]).toEqual([
 				{
 					contents: 'bazbarfoo',
 					index: 0,
-					name: 'ALL'
-				}
+					name: 'ALL',
+				},
 			]);
 		});
 
@@ -299,7 +299,7 @@ describe('Lexer()', () => {
 					/* eslint-disable sort-keys */
 					FOO,
 					BAR,
-					BAZ
+					BAZ,
 					/* eslint-enable sort-keys */
 				});
 			});
@@ -308,18 +308,18 @@ describe('Lexer()', () => {
 				{
 					contents: 'foo',
 					index: 0,
-					name: 'FOO'
+					name: 'FOO',
 				},
 				{
 					contents: 'bar',
 					index: 3,
-					name: 'BAR'
+					name: 'BAR',
 				},
 				{
 					contents: 'baz',
 					index: 6,
-					name: 'BAZ'
-				}
+					name: 'BAZ',
+				},
 			]);
 		});
 
@@ -335,7 +335,7 @@ describe('Lexer()', () => {
 					new Map([
 						['FOO', FOO],
 						['BAR', BAR],
-						['BAZ', BAZ]
+						['BAZ', BAZ],
 					])
 				);
 			});
@@ -344,18 +344,18 @@ describe('Lexer()', () => {
 				{
 					contents: 'foo',
 					index: 0,
-					name: 'FOO'
+					name: 'FOO',
 				},
 				{
 					contents: 'bar',
 					index: 3,
-					name: 'BAR'
+					name: 'BAR',
 				},
 				{
 					contents: 'baz',
 					index: 6,
-					name: 'BAZ'
-				}
+					name: 'BAZ',
+				},
 			]);
 		});
 	});
@@ -376,8 +376,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'onetwo',
 					index: 0,
-					name: 'PAIR'
-				}
+					name: 'PAIR',
+				},
 			]);
 		});
 	});
@@ -403,8 +403,8 @@ describe('Lexer()', () => {
 					{
 						contents: 'thing',
 						index: 0,
-						name: 'THING'
-					}
+						name: 'THING',
+					},
 				]);
 			});
 
@@ -414,7 +414,7 @@ describe('Lexer()', () => {
 				expect(iterator.next().value).toEqual({
 					contents: 'thing',
 					index: 0,
-					name: 'THING'
+					name: 'THING',
 				});
 
 				expect(iterator.next().done).toBe(true);
@@ -447,8 +447,8 @@ describe('Lexer()', () => {
 					{
 						contents: 'foo10',
 						index: 0,
-						name: 'THING'
-					}
+						name: 'THING',
+					},
 				]);
 			});
 
@@ -484,16 +484,16 @@ describe('Lexer()', () => {
 				{
 					contents: 'foobaz',
 					index: 0,
-					name: 'MAYBE'
-				}
+					name: 'MAYBE',
+				},
 			]);
 
 			expect([...lexer.lex('foobarbaz')]).toEqual([
 				{
 					contents: 'foobarbaz',
 					index: 0,
-					name: 'MAYBE'
-				}
+					name: 'MAYBE',
+				},
 			]);
 		});
 	});
@@ -516,8 +516,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'onetwothree',
 					index: 0,
-					name: 'SERIES'
-				}
+					name: 'SERIES',
+				},
 			]);
 		});
 	});
@@ -569,8 +569,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'ababaabb',
 					index: 0,
-					name: 'WORD'
-				}
+					name: 'WORD',
+				},
 			]);
 
 			expect(() => [...lexer.lex('axb')]).toThrow(/Failed to match/);
@@ -582,8 +582,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'ababzzzaabb',
 					index: 0,
-					name: 'WORD'
-				}
+					name: 'WORD',
+				},
 			]);
 		});
 	});
@@ -706,8 +706,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'abcjk',
 					index: 0,
-					name: '...'
-				}
+					name: '...',
+				},
 			]);
 
 			expect(snapshots).toEqual([
@@ -716,8 +716,8 @@ describe('Lexer()', () => {
 					'match: b',
 					[
 						['a', true],
-						['b', true]
-					]
+						['b', true],
+					],
 				],
 				['match: c', [['b', true]]],
 				[
@@ -725,16 +725,16 @@ describe('Lexer()', () => {
 					[
 						['a', true],
 						['b', true],
-						['c:2', true]
-					]
+						['c:2', true],
+					],
 				],
 				[
 					'match: c',
 					[
 						['a', true],
 						['b', true],
-						['c:3', true]
-					]
+						['c:3', true],
+					],
 				],
 				[
 					'match: j',
@@ -742,8 +742,8 @@ describe('Lexer()', () => {
 						['a', true],
 						['b', true],
 						['c:3', true],
-						['j', true]
-					]
+						['j', true],
+					],
 				],
 				[
 					'match: k',
@@ -752,9 +752,9 @@ describe('Lexer()', () => {
 						['b', true],
 						['c:3', true],
 						['j', true],
-						['k', true]
-					]
-				]
+						['k', true],
+					],
+				],
 			]);
 		});
 	});
@@ -777,8 +777,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'bar',
 					index: 0,
-					name: 'ONE_OF'
-				}
+					name: 'ONE_OF',
+				},
 			]);
 		});
 	});
@@ -799,8 +799,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'foo',
 					index: 0,
-					name: 'PASS'
-				}
+					name: 'PASS',
+				},
 			]);
 		});
 	});
@@ -821,16 +821,16 @@ describe('Lexer()', () => {
 				{
 					contents: 'foo',
 					index: 0,
-					name: 'REPEAT'
-				}
+					name: 'REPEAT',
+				},
 			]);
 
 			expect([...lexer.lex('foofoofoo')]).toEqual([
 				{
 					contents: 'foofoofoo',
 					index: 0,
-					name: 'REPEAT'
-				}
+					name: 'REPEAT',
+				},
 			]);
 		});
 	});
@@ -853,8 +853,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'foobarbaz',
 					index: 0,
-					name: 'SEQUENCE'
-				}
+					name: 'SEQUENCE',
+				},
 			]);
 		});
 	});
@@ -879,21 +879,21 @@ describe('Lexer()', () => {
 				{
 					contents: 'x',
 					index: 0,
-					name: 'TO'
-				}
+					name: 'TO',
+				},
 			]);
 
 			expect([...lexer.lex('aaxaaaax')]).toEqual([
 				{
 					contents: 'aax',
 					index: 0,
-					name: 'TO'
+					name: 'TO',
 				},
 				{
 					contents: 'aaaax',
 					index: 3,
-					name: 'TO'
-				}
+					name: 'TO',
+				},
 			]);
 		});
 
@@ -931,8 +931,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'x',
 					index: 0,
-					name: 'X'
-				}
+					name: 'X',
+				},
 			]);
 
 			// n-times.
@@ -940,13 +940,13 @@ describe('Lexer()', () => {
 				{
 					contents: 'aaa',
 					index: 0,
-					name: 'A'
+					name: 'A',
 				},
 				{
 					contents: 'x',
 					index: 3,
-					name: 'X'
-				}
+					name: 'X',
+				},
 			]);
 		});
 
@@ -955,8 +955,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'aaaa',
 					index: 0,
-					name: 'A'
-				}
+					name: 'A',
+				},
 			]);
 		});
 	});
@@ -981,8 +981,8 @@ describe('Lexer()', () => {
 				{
 					contents: 'abbbbb',
 					index: 0,
-					name: 'WHEN'
-				}
+					name: 'WHEN',
+				},
 			]);
 
 			expect(() => [...lexer.lex('foo')]).toThrow(

--- a/packages/liferay-npm-scripts/test/jsp/ReversibleMap.js
+++ b/packages/liferay-npm-scripts/test/jsp/ReversibleMap.js
@@ -12,7 +12,7 @@ describe('ReversibleMap()', () => {
 		map = new ReversibleMap([
 			['a', 1],
 			['b', 2],
-			['c', 3]
+			['c', 3],
 		]);
 	});
 
@@ -32,7 +32,7 @@ describe('ReversibleMap()', () => {
 			expect([...map.entries()]).toEqual([
 				['a', 0],
 				['c', 3],
-				['d', 4]
+				['d', 4],
 			]);
 
 			map.undo[2]();
@@ -41,7 +41,7 @@ describe('ReversibleMap()', () => {
 				['a', 0],
 				['b', 2],
 				['c', 3],
-				['d', 4]
+				['d', 4],
 			]);
 
 			map.undo[1]();
@@ -50,7 +50,7 @@ describe('ReversibleMap()', () => {
 				['a', 1],
 				['b', 2],
 				['c', 3],
-				['d', 4]
+				['d', 4],
 			]);
 
 			map.undo[0]();
@@ -58,7 +58,7 @@ describe('ReversibleMap()', () => {
 			expect([...map.entries()]).toEqual([
 				['a', 1],
 				['b', 2],
-				['c', 3]
+				['c', 3],
 			]);
 		});
 	});
@@ -79,7 +79,7 @@ describe('ReversibleMap()', () => {
 				['c', 3],
 				['d', 4],
 				['e', 5],
-				['f', 6]
+				['f', 6],
 			]);
 
 			// Goes as far back as previous checkpoint (the 2nd) and removes it.
@@ -92,7 +92,7 @@ describe('ReversibleMap()', () => {
 				['b', 2],
 				['c', 3],
 				['d', 4],
-				['e', 5]
+				['e', 5],
 			]);
 
 			// Goes to previous checkpoint (the 1st) and removes it.
@@ -104,7 +104,7 @@ describe('ReversibleMap()', () => {
 				['a', 1],
 				['b', 2],
 				['c', 3],
-				['d', 4]
+				['d', 4],
 			]);
 
 			// Completely flushes the queue (no more checkpoints).
@@ -115,7 +115,7 @@ describe('ReversibleMap()', () => {
 			expect([...map.entries()]).toEqual([
 				['a', 1],
 				['b', 2],
-				['c', 3]
+				['c', 3],
 			]);
 		});
 
@@ -129,7 +129,7 @@ describe('ReversibleMap()', () => {
 				['a', 1],
 				['b', 2],
 				['c', 3],
-				['d', 4]
+				['d', 4],
 			]);
 
 			map.rollback();
@@ -140,7 +140,7 @@ describe('ReversibleMap()', () => {
 				['a', 1],
 				['b', 2],
 				['c', 3],
-				['d', 4]
+				['d', 4],
 			]);
 
 			map.rollback();
@@ -150,7 +150,7 @@ describe('ReversibleMap()', () => {
 			expect([...map.entries()]).toEqual([
 				['a', 1],
 				['b', 2],
-				['c', 3]
+				['c', 3],
 			]);
 		});
 	});
@@ -165,7 +165,7 @@ describe('ReversibleMap()', () => {
 				['a', 1],
 				['b', 2],
 				['c', 3],
-				['done', true]
+				['done', true],
 			]);
 
 			map.rollback();
@@ -174,7 +174,7 @@ describe('ReversibleMap()', () => {
 				['a', 1],
 				['b', 2],
 				['c', 3],
-				['done', true]
+				['done', true],
 			]);
 		});
 	});
@@ -191,7 +191,7 @@ describe('ReversibleMap()', () => {
 				['b', 2],
 				['c', 3],
 				['deep', ['stuff']],
-				['other', null]
+				['other', null],
 			]);
 
 			map.rollback();
@@ -201,7 +201,7 @@ describe('ReversibleMap()', () => {
 				['a', 1],
 				['b', 2],
 				['c', 3],
-				['deep', ['stuff']]
+				['deep', ['stuff']],
 			]);
 		});
 	});

--- a/packages/liferay-npm-scripts/test/jsp/__snapshots__/formatJSP.js.snap
+++ b/packages/liferay-npm-scripts/test/jsp/__snapshots__/formatJSP.js.snap
@@ -114,7 +114,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 						constrain: true,
 						destroyOnHide: true,
 						modal: true,
-						width: 680
+						width: 680,
 					},
 					id: '_<%= HtmlUtil.escapeJS(portletResource) %>_selectFolder',
 					title:
@@ -126,14 +126,14 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 						<portlet:param name=\\"ignoreRootFolder\\" value=\\"<%= Boolean.TRUE.toString() %>\\" />
 					</liferay-portlet:renderURL>
 
-					uri: '<%= HtmlUtil.escapeJS(selectFolderURL.toString()) %>'
+					uri: '<%= HtmlUtil.escapeJS(selectFolderURL.toString()) %>',
 				},
 				function(event) {
 					var folderData = {
 						idString: 'rootFolderId',
 						idValue: event.folderid,
 						nameString: 'rootFolderName',
-						nameValue: event.foldername
+						nameValue: event.foldername,
 					};
 
 					Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
@@ -149,8 +149,8 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 			data: {
 				mimeTypes: Liferay.Util.listSelect(
 					Liferay.Util.getFormElement(form, 'currentMimeTypes')
-				)
-			}
+				),
+			},
 		});
 	}
 </script>"
@@ -285,7 +285,7 @@ if (organization != null) {
 			selectDesc: 'nameCurrentValue',
 			selectId: 'countryId',
 			selectSort: '<%= true %>',
-			selectVal: '<%= countryId %>'
+			selectVal: '<%= countryId %>',
 		},
 		{
 			select: '<portlet:namespace />regionId',
@@ -293,8 +293,8 @@ if (organization != null) {
 			selectDesc: 'name',
 			selectDisableOnEmpty: true,
 			selectId: 'regionId',
-			selectVal: '<%= regionId %>'
-		}
+			selectVal: '<%= regionId %>',
+		},
 	]);
 </aui:script>
 
@@ -666,8 +666,8 @@ if (Validator.isNotNull(scriptContent)) {
 
 						instance._bindUIACBase();
 						instance._syncUIACBase();
-					}
-				}
+					},
+				},
 			});
 
 			var getItems = function() {
@@ -676,7 +676,7 @@ if (Validator.isNotNull(scriptContent)) {
 				paletteItems.each(function(item, index) {
 					results.push({
 						data: item.text().trim(),
-						node: item.ancestor()
+						node: item.ancestor(),
 					});
 				});
 
@@ -704,7 +704,7 @@ if (Validator.isNotNull(scriptContent)) {
 				nodes: '.palette-item-container',
 				resultFilters: 'phraseMatch',
 				resultTextLocator: 'data',
-				source: getItems()
+				source: getItems(),
 			});
 
 			paletteSearch.on('results', function(event) {
@@ -819,7 +819,7 @@ if (Validator.isNotNull(scriptContent)) {
 
 		if (AutoComplete) {
 			var processor = new AutoComplete({
-				variables: <%= ddmDisplayContext.getAutocompleteJSON(request, language) %>
+				variables: <%= ddmDisplayContext.getAutocompleteJSON(request, language) %>,
 			});
 
 			if (processor) {
@@ -829,7 +829,7 @@ if (Validator.isNotNull(scriptContent)) {
 					processor: processor,
 					render: true,
 					visible: false,
-					zIndex: 10000
+					zIndex: 10000,
 				});
 			}
 			else {
@@ -853,15 +853,15 @@ if (Validator.isNotNull(scriptContent)) {
 				boundingBox: editorNode,
 				height: 400,
 				mode: '<%= EditorModeUtil.getEditorMode(langType) %>',
-				width: '100%'
+				width: '100%',
 			}).render();
 
 			new A.Resize({
 				handles: ['br'],
 				node: editorNode,
 				on: {
-					resize: resizeEditor
-				}
+					resize: resizeEditor,
+				},
 			});
 
 			if (editorContentElement) {
@@ -889,12 +889,12 @@ if (Validator.isNotNull(scriptContent)) {
 					animated: true,
 					container: paletteDataContainer,
 					content: '.palette-item-content',
-					header: '.palette-item-header'
+					header: '.palette-item-header',
 				});
 
 				new A.TooltipDelegate({
 					align: {
-						points: [A.WidgetPositionAlign.LC, A.WidgetPositionAlign.RC]
+						points: [A.WidgetPositionAlign.LC, A.WidgetPositionAlign.RC],
 					},
 					duration: 0.5,
 					html: true,
@@ -902,7 +902,7 @@ if (Validator.isNotNull(scriptContent)) {
 					trigger:
 						'#<portlet:namespace />templatePaletteContainer .palette-item',
 					visible: false,
-					zIndex: 6
+					zIndex: 6,
 				});
 
 				createLiveSearch();
@@ -1240,7 +1240,7 @@ exports[`formatJSP() formatting entire fixtures page.jsp matches snapshot 1`] = 
 	<aui:script>
 		var SOME_OBJ = {
 			\${foo}: 'bar',
-			\${bar}: 'baz'
+			\${bar}: 'baz',
 		};
 	</aui:script>
 
@@ -1825,7 +1825,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 						{
 							dialog: {
 								constrain: true,
-								modal: true
+								modal: true,
 							},
 
 							<%
@@ -1846,7 +1846,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 							selectRegularRoleURL.setWindowState(LiferayWindowState.POP_UP);
 							%>
 
-							uri: '<%= selectRegularRoleURL.toString() %>'
+							uri: '<%= selectRegularRoleURL.toString() %>',
 						},
 						function(event) {
 							<portlet:namespace />selectRole(
@@ -2101,7 +2101,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 						{
 							dialog: {
 								constrain: true,
-								modal: true
+								modal: true,
 							},
 
 							<%
@@ -2125,7 +2125,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 							selectOrganizationRoleURL.setWindowState(LiferayWindowState.POP_UP);
 							%>
 
-							uri: '<%= selectOrganizationRoleURL.toString() %>'
+							uri: '<%= selectOrganizationRoleURL.toString() %>',
 						},
 						function(event) {
 							<portlet:namespace />selectRole(
@@ -2324,7 +2324,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 						{
 							dialog: {
 								constrain: true,
-								modal: true
+								modal: true,
 							},
 
 							<%
@@ -2347,7 +2347,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 							selectSiteRoleURL.setWindowState(LiferayWindowState.POP_UP);
 							%>
 
-							uri: '<%= selectSiteRoleURL.toString() %>'
+							uri: '<%= selectSiteRoleURL.toString() %>',
 						},
 						function(event) {
 							<portlet:namespace />selectRole(
@@ -3188,13 +3188,13 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 			{
 				dialog: {
 					constrain: true,
-					modal: true
+					modal: true,
 				},
 				eventName: '<portlet:namespace />selectDDMStructureField',
 				id: '<portlet:namespace />selectDDMStructure' + delegateTarget.id,
 				title:
 					'<liferay-ui:message arguments=\\"structure-field\\" key=\\"select-x\\" />',
-				uri: uri
+				uri: uri,
 			},
 			function(event) {
 				setDDMFields(
@@ -3449,7 +3449,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 	window.<portlet:namespace />calendarListsMenu = new Liferay.SimpleMenu({
 		align: {
-			points: [A.WidgetPositionAlign.TL, A.WidgetPositionAlign.BL]
+			points: [A.WidgetPositionAlign.TL, A.WidgetPositionAlign.BL],
 		},
 		constrain: true,
 		items: [
@@ -3484,10 +3484,10 @@ String backURL = PortalUtil.getCurrentURL(request);
 												<portlet:namespace />scheduler.load();
 											}
 										);
-									}
+									},
 								},
 								destroyOnHide: true,
-								modal: true
+								modal: true,
 							},
 							refreshWindow: window,
 							title: '<liferay-ui:message key=\\"add-calendar\\" />',
@@ -3500,13 +3500,13 @@ String backURL = PortalUtil.getCurrentURL(request);
 							uri: Liferay.CalendarUtil.fillURLParameters(
 								decodeURIComponent('<%= editCalendarURL %>'),
 								{
-									calendarResourceId: calendarResourceId
+									calendarResourceId: calendarResourceId,
 								}
-							)
+							),
 						});
 					}
 				},
-				id: 'add'
+				id: 'add',
 			},
 			{
 				caption: '<liferay-ui:message key=\\"manage-calendars\\" />',
@@ -3525,12 +3525,12 @@ String backURL = PortalUtil.getCurrentURL(request);
 						window.location.href = Liferay.CalendarUtil.fillURLParameters(
 							decodeURIComponent('<%= calendarsURL %>'),
 							{
-								calendarResourceId: calendarResourceId
+								calendarResourceId: calendarResourceId,
 							}
 						);
 					}
 				},
-				id: 'manage'
+				id: 'manage',
 			},
 			{
 				caption: '<liferay-ui:message key=\\"permissions\\" />',
@@ -3548,18 +3548,18 @@ String backURL = PortalUtil.getCurrentURL(request);
 					Liferay.Util.openWindow({
 						dialog: {
 							destroyOnHide: true,
-							modal: true
+							modal: true,
 						},
 						dialogIframe: {
-							bodyCssClass: 'dialog-with-footer'
+							bodyCssClass: 'dialog-with-footer',
 						},
 						refreshWindow: window,
 						title: '<liferay-ui:message key=\\"permissions\\" />',
-						uri: decodeURIComponent('<%= permissionsURL %>')
+						uri: decodeURIComponent('<%= permissionsURL %>'),
 					});
 				},
-				id: 'permissions'
-			}
+				id: 'permissions',
+			},
 		],
 		on: {
 			visibleChange: function(event) {
@@ -3578,11 +3578,11 @@ String backURL = PortalUtil.getCurrentURL(request);
 				}
 
 				instance.set('hiddenItems', hiddenItems);
-			}
+			},
 		},
 		visible: false,
 		width: 290,
-		zIndex: 500
+		zIndex: 500,
 	}).render();
 
 	window.<portlet:namespace />calendarsMenu = {
@@ -3607,22 +3607,22 @@ String backURL = PortalUtil.getCurrentURL(request);
 							after: {
 								destroy: function(event) {
 									<portlet:namespace />scheduler.load();
-								}
+								},
 							},
 							destroyOnHide: true,
-							modal: true
+							modal: true,
 						},
 						refreshWindow: window,
 						title: '<liferay-ui:message key=\\"new-calendar-booking\\" />',
 						uri: Liferay.CalendarUtil.fillURLParameters(
 							decodeURIComponent('<%= addCalendarBookingURL %>'),
 							{
-								calendarId: activeCalendar.get('calendarId')
+								calendarId: activeCalendar.get('calendarId'),
 							}
-						)
+						),
 					});
 				},
-				id: 'addEvent'
+				id: 'addEvent',
 			},
 			{
 				caption: '<liferay-ui:message key=\\"hide-calendar\\" />',
@@ -3637,7 +3637,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 					instance.set('visible', false);
 				},
-				id: 'hide'
+				id: 'hide',
 			},
 			{
 				caption: '<liferay-ui:message key=\\"calendar-settings\\" />',
@@ -3682,10 +3682,10 @@ String backURL = PortalUtil.getCurrentURL(request);
 											<portlet:namespace />scheduler.load();
 										}
 									);
-								}
+								},
 							},
 							destroyOnHide: true,
-							modal: true
+							modal: true,
 						},
 						refreshWindow: window,
 						title: '<liferay-ui:message key=\\"calendar-settings\\" />',
@@ -3701,12 +3701,12 @@ String backURL = PortalUtil.getCurrentURL(request);
 								calendarId: activeCalendar.get('calendarId'),
 								calendarResourceId: activeCalendar.get(
 									'calendarResourceId'
-								)
+								),
 							}
-						)
+						),
 					});
 				},
-				id: 'settings'
+				id: 'settings',
 			},
 			{
 				caption: '<liferay-ui:message key=\\"permissions\\" />',
@@ -3722,13 +3722,13 @@ String backURL = PortalUtil.getCurrentURL(request);
 							after: {
 								destroy: function(event) {
 									<portlet:namespace />scheduler.load();
-								}
+								},
 							},
 							destroyOnHide: true,
-							modal: true
+							modal: true,
 						},
 						dialogIframe: {
-							bodyCssClass: 'dialog-with-footer'
+							bodyCssClass: 'dialog-with-footer',
 						},
 						refreshWindow: window,
 						title: '<liferay-ui:message key=\\"permissions\\" />',
@@ -3749,12 +3749,12 @@ String backURL = PortalUtil.getCurrentURL(request);
 									'name'
 								),
 								resourceGroupId: activeCalendar.get('groupId'),
-								resourcePrimKey: activeCalendar.get('calendarId')
+								resourcePrimKey: activeCalendar.get('calendarId'),
 							}
-						)
+						),
 					});
 				},
-				id: 'permissions'
+				id: 'permissions',
 			},
 			{
 				caption: '<liferay-ui:message key=\\"delete\\" />',
@@ -3796,7 +3796,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 						);
 					}
 				},
-				id: 'delete'
+				id: 'delete',
 			},
 
 			<c:if test=\\"<%= enableRSS %>\\">
@@ -3816,7 +3816,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 						var url = Liferay.CalendarUtil.fillURLParameters(
 							decodeURIComponent('<%= calendarRSSURL %>'),
 							{
-								calendarId: activeCalendar.get('calendarId')
+								calendarId: activeCalendar.get('calendarId'),
 							}
 						);
 
@@ -3824,18 +3824,18 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 						instance.set('visible', false);
 					},
-					id: 'subscribe'
+					id: 'subscribe',
 				},
 			</c:if>
 
 			{
 				caption: '-',
-				id: 'separator1'
+				id: 'separator1',
 			},
 			{
 				caption: '<div class=\\"calendar-portlet-color-picker\\"></div>',
-				id: 'colorPicker'
-			}
+				id: 'colorPicker',
+			},
 		],
 		on: {
 			visibleChange: function(event) {
@@ -3883,7 +3883,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 					<portlet:namespace />colorPicker.setAttrs({
 						color: calendar.get('color'),
-						visible: true
+						visible: true,
 					});
 
 					var colorPickerContainer = instance
@@ -3894,9 +3894,9 @@ String backURL = PortalUtil.getCurrentURL(request);
 						window.<portlet:namespace />colorPicker.get('boundingBox')
 					);
 				}
-			}
+			},
 		},
-		width: 225
+		width: 225,
 	};
 
 	<portlet:namespace />colorPicker = new Liferay.SimpleColorPicker({
@@ -3910,14 +3910,14 @@ String backURL = PortalUtil.getCurrentURL(request);
 					var calendarList = simpleMenu.get('host');
 
 					calendarList.activeItem.set('color', event.newVal, {
-						silent: true
+						silent: true,
 					});
 
 					simpleMenu.set('visible', false);
 				}
-			}
+			},
 		},
-		visible: false
+		visible: false,
 	}).render();
 
 	A.one('#<portlet:namespace />calendarListContainer').delegate(
@@ -3934,7 +3934,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 				toggler: currentTarget,
 				visible: !window.<portlet:namespace />calendarListsMenu.get(
 					'visible'
-				)
+				),
 			});
 		},
 		'.calendar-resource-arrow'
@@ -3944,7 +3944,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 		animated: true,
 		container: '#<portlet:namespace />calendarListContainer',
 		content: '.calendar-portlet-calendar-list',
-		header: '.calendar-portlet-list-header'
+		header: '.calendar-portlet-list-header',
 	});
 
 	<c:if test=\\"<%= themeDisplay.isSignedIn() %>\\">
@@ -4079,7 +4079,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 						node.toggleClass('yui3-calendar-day-selected', selected);
 					},
-					rules: rulesDefinition
+					rules: rulesDefinition,
 				});
 
 				<portlet:namespace />miniCalendar.selectDates(selectedDates);
@@ -4092,15 +4092,15 @@ String backURL = PortalUtil.getCurrentURL(request);
 			dateChange: <portlet:namespace />refreshVisibleCalendarRenderingRules,
 			dateClick: function(event) {
 				<portlet:namespace />scheduler.setAttrs({
-					date: event.date
+					date: event.date,
 				});
-			}
+			},
 		},
 		date: new Date(<%= String.valueOf(date) %>),
 		headerRenderer:
 			'<%= HtmlUtil.escapeJS(LanguageUtil.get(request, \\"b-y\\")) %>',
 		locale: '<%= themeDisplay.getLocale() %>',
-		'strings.first_weekday': <%= weekStartsOn %>
+		'strings.first_weekday': <%= weekStartsOn %>,
 	}).render('#<portlet:namespace />miniCalendarContainer');
 
 	<portlet:namespace />scheduler.after(
@@ -4329,7 +4329,7 @@ PowwowMeeting powwowMeeting = PowwowMeetingLocalServiceUtil.fetchPowwowMeeting(p
 			container: '#<portlet:namespace />internationalNumbersToggler',
 			content: '.international-numbers-content',
 			expanded: false,
-			header: '.international-numbers-header'
+			header: '.international-numbers-header',
 		});
 
 		//Load global phone numbers
@@ -4337,20 +4337,20 @@ PowwowMeeting powwowMeeting = PowwowMeetingLocalServiceUtil.fetchPowwowMeeting(p
 		var columns = [
 			{
 				key: 'lcountry',
-				label: 'country'
+				label: 'country',
 			},
 			{
 				key: 'lphone',
-				label: 'phone'
+				label: 'phone',
 			},
 			{
 				key: 'rcountry',
-				label: 'country'
+				label: 'country',
 			},
 			{
 				key: 'rphone',
-				label: 'phone'
-			}
+				label: 'phone',
+			},
 		];
 
 		var interationalNumbersDisplay = [];
@@ -4365,7 +4365,7 @@ PowwowMeeting powwowMeeting = PowwowMeetingLocalServiceUtil.fetchPowwowMeeting(p
 
 					interationalNumbersDisplay.push({
 						country: '<%= country %>',
-						number: '<%= number %>'
+						number: '<%= number %>',
 					});
 
 		<%
@@ -4401,14 +4401,14 @@ PowwowMeeting powwowMeeting = PowwowMeetingLocalServiceUtil.fetchPowwowMeeting(p
 				lcountry: dataLeft[i].country,
 				lphone: dataLeft[i].number,
 				rcountry: rcountry,
-				rphone: rphone
+				rphone: rphone,
 			});
 		}
 
 		new A.DataTable({
 			className: 'table table-bordered',
 			columns: columns,
-			data: data
+			data: data,
 		}).render('#<portlet:namespace />internationalNumbersTable');
 	</c:if>
 </aui:script>"

--- a/packages/liferay-npm-scripts/test/jsp/extractJS.js
+++ b/packages/liferay-npm-scripts/test/jsp/extractJS.js
@@ -28,18 +28,18 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 1,
-						line: 4
+						line: 4,
 					},
 					index: 1,
 					length: 61,
 					start: {
 						column: 25,
-						line: 2
-					}
+						line: 2,
+					},
 				},
 				scriptAttributes: ' use="other"',
-				tagNamespace: 'aui:'
-			}
+				tagNamespace: 'aui:',
+			},
 		]);
 	});
 
@@ -63,18 +63,18 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 1,
-						line: 4
+						line: 4,
 					},
 					index: 1,
 					length: 35,
 					start: {
 						column: 9,
-						line: 2
-					}
+						line: 2,
+					},
 				},
 				scriptAttributes: '',
-				tagNamespace: undefined
-			}
+				tagNamespace: undefined,
+			},
 		]);
 	});
 
@@ -91,18 +91,18 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 24,
-						line: 1
+						line: 1,
 					},
 					index: 0,
 					length: 32,
 					start: {
 						column: 9,
-						line: 1
-					}
+						line: 1,
+					},
 				},
 				scriptAttributes: '',
-				tagNamespace: undefined
-			}
+				tagNamespace: undefined,
+			},
 		]);
 	});
 
@@ -143,11 +143,11 @@ describe('extractJS()', () => {
 					end: {column: 4, line: 4},
 					index: 4,
 					length: 113,
-					start: {column: 84, line: 2}
+					start: {column: 84, line: 2},
 				},
 				scriptAttributes:
-					' id="<portlet:namespace />eventRecorderHeaderTpl" type="text/javascript"'
-			}
+					' id="<portlet:namespace />eventRecorderHeaderTpl" type="text/javascript"',
+			},
 		]);
 	});
 
@@ -170,17 +170,17 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 2,
-						line: 32
+						line: 32,
 					},
 					index: 819,
 					length: 49,
 					start: {
 						column: 14,
-						line: 30
-					}
+						line: 30,
+					},
 				},
 				scriptAttributes: '',
-				tagNamespace: 'aui:'
+				tagNamespace: 'aui:',
 			},
 			{
 				closeTag: '</aui:script>',
@@ -214,17 +214,17 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 2,
-						line: 46
+						line: 46,
 					},
 					index: 871,
 					length: 197,
 					start: {
 						column: 40,
-						line: 34
-					}
+						line: 34,
+					},
 				},
 				scriptAttributes: ' use="aui-base,event,node"',
-				tagNamespace: 'aui:'
+				tagNamespace: 'aui:',
 			},
 			{
 				closeTag: '</aui:script>',
@@ -246,17 +246,17 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 2,
-						line: 54
+						line: 54,
 					},
 					index: 1071,
 					length: 74,
 					start: {
 						column: 14,
-						line: 48
-					}
+						line: 48,
+					},
 				},
 				scriptAttributes: '',
-				tagNamespace: 'aui:'
+				tagNamespace: 'aui:',
 			},
 			{
 				closeTag: '</aui:script>',
@@ -268,17 +268,17 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 22,
-						line: 81
+						line: 81,
 					},
 					index: 1716,
 					length: 47,
 					start: {
 						column: 14,
-						line: 80
-					}
+						line: 80,
+					},
 				},
 				scriptAttributes: '',
-				tagNamespace: 'aui:'
+				tagNamespace: 'aui:',
 			},
 			{
 				closeTag: '</aui:script>',
@@ -298,17 +298,17 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 2,
-						line: 88
+						line: 88,
 					},
 					index: 1766,
 					length: 90,
 					start: {
 						column: 14,
-						line: 83
-					}
+						line: 83,
+					},
 				},
 				scriptAttributes: '',
-				tagNamespace: 'aui:'
+				tagNamespace: 'aui:',
 			},
 			{
 				closeTag: '</aui:script>',
@@ -329,18 +329,18 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 2,
-						line: 94
+						line: 94,
 					},
 					index: 1859,
 					length: 143,
 					start: {
 						column: 72,
-						line: 90
-					}
+						line: 90,
+					},
 				},
 				scriptAttributes:
 					' require="foo/bar/baz, baz/foo_bar, bar/baz/foo as FooBar"',
-				tagNamespace: 'aui:'
+				tagNamespace: 'aui:',
 			},
 			{
 				closeTag: '</aui:script>',
@@ -350,18 +350,18 @@ describe('extractJS()', () => {
 				range: {
 					end: {
 						column: 2,
-						line: 97
+						line: 97,
 					},
 					index: 2005,
 					length: 38,
 					start: {
 						column: 25,
-						line: 96
-					}
+						line: 96,
+					},
 				},
 				scriptAttributes: ' require=""',
-				tagNamespace: 'aui:'
-			}
+				tagNamespace: 'aui:',
+			},
 		]);
 	});
 });

--- a/packages/liferay-npm-scripts/test/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/formatJSP.js
@@ -327,7 +327,7 @@ describe('formatJSP()', () => {
 			'source.jsp',
 			'view.jsp',
 			'view_calendar_menus.jspf',
-			'view_meeting.jsp'
+			'view_meeting.jsp',
 
 			// Not including these (rejected by Prettier, see "known
 			// limitations" below):

--- a/packages/liferay-npm-scripts/test/jsp/lex.js
+++ b/packages/liferay-npm-scripts/test/jsp/lex.js
@@ -16,8 +16,8 @@ describe('lex()', () => {
 			{
 				contents: 'contents',
 				index: 0,
-				name: 'TEMPLATE_TEXT'
-			}
+				name: 'TEMPLATE_TEXT',
+			},
 		]);
 	});
 
@@ -28,8 +28,8 @@ describe('lex()', () => {
 			{
 				contents: 'contents',
 				index: 0,
-				name: 'TEMPLATE_TEXT'
-			}
+				name: 'TEMPLATE_TEXT',
+			},
 		]);
 	});
 
@@ -38,8 +38,8 @@ describe('lex()', () => {
 			{
 				contents: '<%-- my comment --%>',
 				index: 0,
-				name: 'JSP_COMMENT'
-			}
+				name: 'JSP_COMMENT',
+			},
 		]);
 	});
 
@@ -48,13 +48,13 @@ describe('lex()', () => {
 			{
 				contents: '<%-- one --%>',
 				index: 0,
-				name: 'JSP_COMMENT'
+				name: 'JSP_COMMENT',
 			},
 			{
 				contents: '<%-- two --%>',
 				index: 13,
-				name: 'JSP_COMMENT'
-			}
+				name: 'JSP_COMMENT',
+			},
 		]);
 	});
 
@@ -69,16 +69,16 @@ describe('lex()', () => {
 			{
 				contents: '<%@ include file="double/quoted/file" %>',
 				index: 0,
-				name: 'JSP_DIRECTIVE'
-			}
+				name: 'JSP_DIRECTIVE',
+			},
 		]);
 
 		expect(lex("<%@ include file='single/quoted/file' %>").tokens).toEqual([
 			{
 				contents: "<%@ include file='single/quoted/file' %>",
 				index: 0,
-				name: 'JSP_DIRECTIVE'
-			}
+				name: 'JSP_DIRECTIVE',
+			},
 		]);
 
 		expect(
@@ -87,32 +87,32 @@ describe('lex()', () => {
 			{
 				contents: '<%@ include file="\\"stuff\\\\¿here?&quot;" %>',
 				index: 0,
-				name: 'JSP_DIRECTIVE'
-			}
+				name: 'JSP_DIRECTIVE',
+			},
 		]);
 
 		expect(lex('<%@ page language="en" %>').tokens).toEqual([
 			{
 				contents: '<%@ page language="en" %>',
 				index: 0,
-				name: 'JSP_DIRECTIVE'
-			}
+				name: 'JSP_DIRECTIVE',
+			},
 		]);
 
 		expect(lex('<%@ taglib prefix="foo" tagdir="bar" %>').tokens).toEqual([
 			{
 				contents: '<%@ taglib prefix="foo" tagdir="bar" %>',
 				index: 0,
-				name: 'JSP_DIRECTIVE'
-			}
+				name: 'JSP_DIRECTIVE',
+			},
 		]);
 
 		expect(lex('<%@ taglib prefix="foo" uri="bar" %>').tokens).toEqual([
 			{
 				contents: '<%@ taglib prefix="foo" uri="bar" %>',
 				index: 0,
-				name: 'JSP_DIRECTIVE'
-			}
+				name: 'JSP_DIRECTIVE',
+			},
 		]);
 
 		// Note it agnostic about attribute order.
@@ -120,8 +120,8 @@ describe('lex()', () => {
 			{
 				contents: '<%@ taglib uri="bar" prefix="foo" %>',
 				index: 0,
-				name: 'JSP_DIRECTIVE'
-			}
+				name: 'JSP_DIRECTIVE',
+			},
 		]);
 
 		// But it requires all attributes to be present.
@@ -139,8 +139,8 @@ describe('lex()', () => {
 			{
 				contents,
 				index: 0,
-				name: 'JSP_DECLARATION'
-			}
+				name: 'JSP_DECLARATION',
+			},
 		]);
 	});
 
@@ -149,8 +149,8 @@ describe('lex()', () => {
 			{
 				contents: '<%= Target.method("foo") %>',
 				index: 0,
-				name: 'JSP_EXPRESSION'
-			}
+				name: 'JSP_EXPRESSION',
+			},
 		]);
 	});
 
@@ -163,8 +163,8 @@ describe('lex()', () => {
 			{
 				contents,
 				index: 0,
-				name: 'JSP_SCRIPTLET'
-			}
+				name: 'JSP_SCRIPTLET',
+			},
 		]);
 	});
 
@@ -176,8 +176,8 @@ describe('lex()', () => {
 			{
 				contents: '${Foo.Bar}',
 				index: 0,
-				name: 'EL_EXPRESSION'
-			}
+				name: 'EL_EXPRESSION',
+			},
 		]);
 
 		// Deferred evaluation.
@@ -185,8 +185,8 @@ describe('lex()', () => {
 			{
 				contents: '#{Foo.Bar}',
 				index: 0,
-				name: 'EL_EXPRESSION'
-			}
+				name: 'EL_EXPRESSION',
+			},
 		]);
 	});
 
@@ -195,13 +195,13 @@ describe('lex()', () => {
 			{
 				contents: '#{',
 				index: 0,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: 'Foo.Bar}',
 				index: 2,
-				name: 'TEMPLATE_TEXT'
-			}
+				name: 'TEMPLATE_TEXT',
+			},
 		]);
 	});
 
@@ -215,28 +215,28 @@ describe('lex()', () => {
 			{
 				contents: '\n\t\t\t',
 				index: 0,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: '<%@ page isELIgnored="true" %>',
 				index: 4,
-				name: 'JSP_DIRECTIVE'
+				name: 'JSP_DIRECTIVE',
 			},
 			{
 				contents: '\n\t\t\t',
 				index: 34,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: '#{',
 				index: 38,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: 'Foo}\n\t\t',
 				index: 40,
-				name: 'TEMPLATE_TEXT'
-			}
+				name: 'TEMPLATE_TEXT',
+			},
 		]);
 	});
 
@@ -250,28 +250,28 @@ describe('lex()', () => {
 			{
 				contents: '\n\t\t\t',
 				index: 0,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: '<%@ page isELIgnored="false" %>',
 				index: 4,
-				name: 'JSP_DIRECTIVE'
+				name: 'JSP_DIRECTIVE',
 			},
 			{
 				contents: '\n\t\t\t',
 				index: 35,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: '#{Foo}',
 				index: 39,
-				name: 'EL_EXPRESSION'
+				name: 'EL_EXPRESSION',
 			},
 			{
 				contents: '\n\t\t',
 				index: 45,
-				name: 'TEMPLATE_TEXT'
-			}
+				name: 'TEMPLATE_TEXT',
+			},
 		]);
 	});
 
@@ -281,8 +281,8 @@ describe('lex()', () => {
 			{
 				contents: '<portlet:namespace />',
 				index: 0,
-				name: 'PORTLET_NAMESPACE'
-			}
+				name: 'PORTLET_NAMESPACE',
+			},
 		]);
 
 		// Without whitespace.
@@ -290,8 +290,8 @@ describe('lex()', () => {
 			{
 				contents: '<portlet:namespace/>',
 				index: 0,
-				name: 'PORTLET_NAMESPACE'
-			}
+				name: 'PORTLET_NAMESPACE',
+			},
 		]);
 	});
 
@@ -301,8 +301,8 @@ describe('lex()', () => {
 			{
 				contents: '<custom:tag with="stuff" />',
 				index: 0,
-				name: 'CUSTOM_ACTION'
-			}
+				name: 'CUSTOM_ACTION',
+			},
 		]);
 
 		// Same without whitspace at end.
@@ -310,8 +310,8 @@ describe('lex()', () => {
 			{
 				contents: '<custom:tag with="stuff"/>',
 				index: 0,
-				name: 'CUSTOM_ACTION'
-			}
+				name: 'CUSTOM_ACTION',
+			},
 		]);
 
 		// A self-closing tag with an attribute that contains a JSP expression.
@@ -320,8 +320,8 @@ describe('lex()', () => {
 				{
 					contents: '<custom:tag with="<%= SomeVariable %>" />',
 					index: 0,
-					name: 'CUSTOM_ACTION'
-				}
+					name: 'CUSTOM_ACTION',
+				},
 			]
 		);
 
@@ -330,8 +330,8 @@ describe('lex()', () => {
 			{
 				contents: '<c:if test="<%= enableRSS %>">',
 				index: 0,
-				name: 'CUSTOM_ACTION_START'
-			}
+				name: 'CUSTOM_ACTION_START',
+			},
 		]);
 
 		// Empty body.
@@ -339,8 +339,8 @@ describe('lex()', () => {
 			{
 				contents: '<custom:tag with="stuff"></custom:tag>',
 				index: 0,
-				name: 'CUSTOM_ACTION'
-			}
+				name: 'CUSTOM_ACTION',
+			},
 		]);
 
 		// Tag with duplicate attributes.
@@ -375,14 +375,14 @@ describe('lex()', () => {
 			{
 				contents: 'ul class="abc">\n\t\t\t\t',
 				index: 5,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{contents: '<', index: 25, name: 'TEMPLATE_TEXT'},
 			{contents: 'li>xyz', index: 26, name: 'TEMPLATE_TEXT'},
 			{contents: '<', index: 32, name: 'TEMPLATE_TEXT'},
 			{contents: '/li>\n\t\t\t', index: 33, name: 'TEMPLATE_TEXT'},
 			{contents: '<', index: 41, name: 'TEMPLATE_TEXT'},
-			{contents: '/ul>\n\t\t', index: 42, name: 'TEMPLATE_TEXT'}
+			{contents: '/ul>\n\t\t', index: 42, name: 'TEMPLATE_TEXT'},
 		]);
 	});
 
@@ -391,8 +391,8 @@ describe('lex()', () => {
 			{
 				contents: 'Random text',
 				index: 0,
-				name: 'TEMPLATE_TEXT'
-			}
+				name: 'TEMPLATE_TEXT',
+			},
 		]);
 
 		// Note that the spec starts a new token whenever it sees a delimiting
@@ -402,18 +402,18 @@ describe('lex()', () => {
 			{
 				contents: 'one ',
 				index: 0,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: '<',
 				index: 4,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: ' two',
 				index: 5,
-				name: 'TEMPLATE_TEXT'
-			}
+				name: 'TEMPLATE_TEXT',
+			},
 		]);
 	});
 
@@ -427,29 +427,29 @@ describe('lex()', () => {
 			{
 				contents: '\n\t\t\t\t',
 				index: 0,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: '<',
 				index: 5,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents: 'div class="browse-image-controls ',
 				index: 6,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents:
 					'<%= (fileEntryId != 0) ? "hide" : StringPool.BLANK %>',
 				index: 39,
-				name: 'JSP_EXPRESSION'
+				name: 'JSP_EXPRESSION',
 			},
 			{
 				contents: '">\n\t\t',
 				index: 92,
-				name: 'TEMPLATE_TEXT'
-			}
+				name: 'TEMPLATE_TEXT',
+			},
 		]);
 
 		// Contrast that with this invalid example that was in the
@@ -472,19 +472,19 @@ describe('lex()', () => {
 			{
 				contents: '\n\t\t\t\t',
 				index: 0,
-				name: 'TEMPLATE_TEXT'
+				name: 'TEMPLATE_TEXT',
 			},
 			{
 				contents:
 					'<aui:nav cssClass="${currentTab == tab ? \'active\' : \'\'} foo abc <%= \\"scriptletblock\\" %>"></aui:nav>',
 				index: 5,
-				name: 'CUSTOM_ACTION'
+				name: 'CUSTOM_ACTION',
 			},
 			{
 				contents: '\n\t\t\t',
 				index: 106,
-				name: 'TEMPLATE_TEXT'
-			}
+				name: 'TEMPLATE_TEXT',
+			},
 		]);
 	});
 
@@ -502,7 +502,7 @@ describe('lex()', () => {
 			'source.jsp',
 			'view.jsp',
 			'view_calendar_menus.jspf',
-			'view_meeting.jsp'
+			'view_meeting.jsp',
 		])('%s matches snapshot', async fixture => {
 			const source = await getFixture(path.join('jsp', fixture));
 

--- a/packages/liferay-npm-scripts/test/jsp/lintJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/lintJSP.js
@@ -54,11 +54,11 @@ describe('lintJSP()', () => {
 					line: 3,
 					message: 'Redundant double negation.',
 					ruleId: 'no-extra-boolean-cast',
-					severity: 2
-				})
+					severity: 2,
+				}),
 			],
 			source: expect.stringContaining('var bool = !!!other;'),
-			warningCount: 0
+			warningCount: 0,
 		});
 	});
 
@@ -88,11 +88,11 @@ describe('lintJSP()', () => {
 					line: 3,
 					message: "Unexpected 'debugger' statement.",
 					ruleId: 'no-debugger',
-					severity: 2
-				})
+					severity: 2,
+				}),
 			],
 			source: expect.stringContaining('debugger;'),
-			warningCount: 0
+			warningCount: 0,
 		});
 	});
 
@@ -123,11 +123,11 @@ describe('lintJSP()', () => {
 					line: 3,
 					message: "Parsing error: The keyword 'const' is reserved",
 					ruleId: null,
-					severity: 2
-				})
+					severity: 2,
+				}),
 			],
 			source: expect.stringContaining('const x = 1;'),
-			warningCount: 0
+			warningCount: 0,
 		});
 	});
 
@@ -158,11 +158,11 @@ describe('lintJSP()', () => {
 					line: 3,
 					message: 'Parsing error: Unexpected token )',
 					ruleId: null,
-					severity: 2
-				})
+					severity: 2,
+				}),
 			],
 			source: expect.stringContaining('var x = () => 1;'),
-			warningCount: 0
+			warningCount: 0,
 		});
 	});
 
@@ -196,18 +196,18 @@ describe('lintJSP()', () => {
 					line: 3,
 					message: 'Redundant double negation.',
 					ruleId: 'no-extra-boolean-cast',
-					severity: 2
+					severity: 2,
 				}),
 				expect.objectContaining({
 					column: 1,
 					line: 4,
 					message: "Unexpected 'debugger' statement.",
 					ruleId: 'no-debugger',
-					severity: 2
-				})
+					severity: 2,
+				}),
 			],
 			source: expect.stringContaining('debugger;'),
-			warningCount: 0
+			warningCount: 0,
 		});
 	});
 
@@ -267,11 +267,11 @@ describe('lintJSP()', () => {
 						line: 3,
 						message: 'Redundant double negation.',
 						ruleId: 'no-extra-boolean-cast',
-						severity: 2
-					})
+						severity: 2,
+					}),
 				],
 				source: expect.stringContaining('var bool = !!!other;'),
-				warningCount: 0
+				warningCount: 0,
 			});
 		});
 
@@ -297,11 +297,11 @@ describe('lintJSP()', () => {
 						line: 3,
 						message: 'Redundant double negation.',
 						ruleId: 'no-extra-boolean-cast',
-						severity: 2
-					})
+						severity: 2,
+					}),
 				],
 				source: expect.stringContaining('var bool = !!!other;'),
-				warningCount: 0
+				warningCount: 0,
 			});
 		});
 
@@ -333,11 +333,11 @@ describe('lintJSP()', () => {
 						line: 4,
 						message: "Unexpected 'debugger' statement.",
 						ruleId: 'no-debugger',
-						severity: 2
-					})
+						severity: 2,
+					}),
 				],
 				source: expect.stringContaining('debugger;'),
-				warningCount: 0
+				warningCount: 0,
 			});
 		});
 	});
@@ -374,11 +374,11 @@ describe('lintJSP()', () => {
 						line: 4,
 						message: "Unexpected 'debugger' statement.",
 						ruleId: 'no-debugger',
-						severity: 2
-					})
+						severity: 2,
+					}),
 				],
 				source: expect.stringContaining('debugger;'),
-				warningCount: 0
+				warningCount: 0,
 			});
 		});
 	});

--- a/packages/liferay-npm-scripts/test/jsp/restoreTags.js
+++ b/packages/liferay-npm-scripts/test/jsp/restoreTags.js
@@ -62,7 +62,7 @@ describe('restoreTags()', () => {
 
 		const tags = [
 			'<my-long-namespace:this-tag>',
-			'</my-long-namespace:this-tag>'
+			'</my-long-namespace:this-tag>',
 		];
 
 		const result = restoreTags(text, tags);

--- a/packages/liferay-npm-scripts/test/jsp/substituteTags.js
+++ b/packages/liferay-npm-scripts/test/jsp/substituteTags.js
@@ -97,7 +97,7 @@ describe('substituteTags()', () => {
 
 		expect(tags).toEqual([
 			'<% FooThing myFoo = new FooThing(); %>',
-			'<%= myFoo.body() %>'
+			'<%= myFoo.body() %>',
 		]);
 	});
 
@@ -133,7 +133,7 @@ describe('substituteTags()', () => {
 			'<%= myFoo.body() %>',
 			dedent(3)`<%
 			}
-			%>`
+			%>`,
 		]);
 	});
 
@@ -233,7 +233,7 @@ describe('substituteTags()', () => {
 			'<a:tag>\n' +
 				'\t<a:param thing="1" />\n' +
 				'\t<a:other thing="2" />\n' +
-				'</a:tag>'
+				'</a:tag>',
 		]);
 	});
 
@@ -268,7 +268,7 @@ describe('substituteTags()', () => {
 			'<c:if test="<%= a %>">',
 			'<c:if test="<%= b %>">',
 			'</c:if>',
-			'</c:if>'
+			'</c:if>',
 		]);
 	});
 
@@ -286,7 +286,7 @@ describe('substituteTags()', () => {
 			'source.jsp',
 			'view.jsp',
 			'view_calendar_menus.jspf',
-			'view_meeting.jsp'
+			'view_meeting.jsp',
 		])('%s matches snapshot', async fixture => {
 			const source = await getFixture(path.join('jsp', fixture));
 

--- a/packages/liferay-npm-scripts/test/jsp/tagReplacements.js
+++ b/packages/liferay-npm-scripts/test/jsp/tagReplacements.js
@@ -6,7 +6,7 @@
 const {
 	getCloseTagReplacement,
 	getOpenTagReplacement,
-	getSelfClosingTagReplacement
+	getSelfClosingTagReplacement,
 } = require('../../src/jsp/tagReplacements');
 
 describe('getCloseTagReplacement()', () => {

--- a/packages/liferay-npm-scripts/test/jsp/trim.js
+++ b/packages/liferay-npm-scripts/test/jsp/trim.js
@@ -13,7 +13,7 @@ describe('trim()', () => {
 		expect(trim(input)).toEqual({
 			prefix: '\n',
 			suffix: '',
-			trimmed: '\t\t\talert();'
+			trimmed: '\t\t\talert();',
 		});
 	});
 
@@ -24,7 +24,7 @@ describe('trim()', () => {
 		expect(trim(input)).toEqual({
 			prefix: '',
 			suffix: '\t\t',
-			trimmed: 'alert();'
+			trimmed: 'alert();',
 		});
 	});
 
@@ -36,7 +36,7 @@ describe('trim()', () => {
 		expect(trim(input)).toEqual({
 			prefix: '\n',
 			suffix: '\t\t',
-			trimmed: '\t\t\talert();'
+			trimmed: '\t\t\talert();',
 		});
 	});
 
@@ -44,7 +44,7 @@ describe('trim()', () => {
 		expect(trim('alert();')).toEqual({
 			prefix: '',
 			suffix: '',
-			trimmed: 'alert();'
+			trimmed: 'alert();',
 		});
 	});
 });

--- a/packages/liferay-npm-scripts/test/prettier/index.js
+++ b/packages/liferay-npm-scripts/test/prettier/index.js
@@ -73,7 +73,7 @@ describe('prettier/index.js', () => {
 			return prettier.format(source, {
 				...config,
 				filepath: 'some/directory/__sample__.js',
-				...options
+				...options,
 			});
 		}
 
@@ -104,7 +104,7 @@ describe('prettier/index.js', () => {
 					}
 			`,
 					{
-						filepath: 'some/directory/__sample__.scss'
+						filepath: 'some/directory/__sample__.scss',
 					}
 				)
 			).toBe(code`

--- a/packages/liferay-npm-scripts/test/scripts/format.js
+++ b/packages/liferay-npm-scripts/test/scripts/format.js
@@ -21,7 +21,7 @@ describe('scripts/format.js', () => {
 
 	const source = {
 		js: 'alert("hello");',
-		jsp: '<%= "hello" %>'
+		jsp: '<%= "hello" %>',
 	};
 
 	beforeEach(() => {

--- a/packages/liferay-npm-scripts/test/scripts/lint.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint.js
@@ -82,14 +82,14 @@ describe('scripts/lint.js', () => {
 			await run(async ({eslint, lint, log}) => {
 				const executeOnFiles = eslint.CLIEngine.prototype.executeOnFiles.mockReturnValue(
 					{
-						results: []
+						results: [],
 					}
 				);
 
 				await lint();
 
 				expect(executeOnFiles).toBeCalledWith([
-					'apps/segments/segments-web/src/index.es.js'
+					'apps/segments/segments-web/src/index.es.js',
 				]);
 
 				// No errors or warnings, so no results.
@@ -110,18 +110,18 @@ describe('scripts/lint.js', () => {
 										line: 20,
 										message: 'Avoid explosions.',
 										ruleId: 'no-boom',
-										severity: 2
-									}
-								]
-							}
-						]
+										severity: 2,
+									},
+								],
+							},
+						],
 					}
 				);
 
 				await expect(lint()).rejects.toThrow();
 
 				expect(executeOnFiles).toBeCalledWith([
-					'apps/segments/segments-web/src/index.es.js'
+					'apps/segments/segments-web/src/index.es.js',
 				]);
 
 				expect(log.mock.calls.length).toBe(1);

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-block-comments.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-block-comments.js
@@ -12,7 +12,7 @@ describe('liferay/no-block-comments', () => {
 				// A good comment.
 				a { color: #000 };
 			`,
-			errors: []
+			errors: [],
 		});
 	});
 
@@ -29,9 +29,9 @@ describe('liferay/no-block-comments', () => {
 					rule: 'liferay/no-block-comments',
 					severity: 'error',
 					text:
-						'No block-based comments (/* ... */); use line-based (//) comment syntax instead (liferay/no-block-comments)'
-				}
-			]
+						'No block-based comments (/* ... */); use line-based (//) comment syntax instead (liferay/no-block-comments)',
+				},
+			],
 		});
 	});
 
@@ -42,7 +42,7 @@ describe('liferay/no-block-comments', () => {
 				a { color: #000 };
 			`,
 			errors: [],
-			options: false
+			options: false,
 		});
 	});
 });

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-import-extension.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-import-extension.js
@@ -13,7 +13,7 @@ describe('liferay/no-import-extension', () => {
 				@import 'stuff';
 				@import 'thing.css';
 			`,
-			errors: []
+			errors: [],
 		});
 	});
 
@@ -30,7 +30,7 @@ describe('liferay/no-import-extension', () => {
 				// Rule ignores even this (bogus) url.
 				@import url('weird.scss');
 			`,
-			errors: []
+			errors: [],
 		});
 	});
 
@@ -44,7 +44,7 @@ describe('liferay/no-import-extension', () => {
 			output: `
 				@import 'a';
 				@import "b";
-			`
+			`,
 		});
 	});
 
@@ -55,7 +55,7 @@ describe('liferay/no-import-extension', () => {
 				@import "b.scss";
 			`,
 			errors: [],
-			options: false
+			options: false,
 		});
 	});
 });

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/single-imports.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/single-imports.js
@@ -15,7 +15,7 @@ describe('liferay/single-imports', () => {
 				@import url('other.css');
 				@import url("that.css");
 			`,
-			errors: []
+			errors: [],
 		});
 	});
 
@@ -46,7 +46,7 @@ describe('liferay/single-imports', () => {
 				@import url('third.css');
 
 				a { color: #000 };
-			`
+			`,
 		});
 	});
 
@@ -77,7 +77,7 @@ describe('liferay/single-imports', () => {
 				"@import 'second';\n" +
 				"@import url('third.css');\n" +
 				'\n' +
-				'a { color: #000 };\n'
+				'a { color: #000 };\n',
 		});
 	});
 
@@ -89,7 +89,7 @@ describe('liferay/single-imports', () => {
 				a { color: #000 };
 			`,
 			errors: [],
-			options: false
+			options: false,
 		});
 	});
 });

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/sort-imports.js
@@ -14,7 +14,7 @@ describe('liferay/sort-imports', () => {
 
 				a { color: #000; }
 			`,
-			errors: []
+			errors: [],
 		});
 	});
 
@@ -30,7 +30,7 @@ describe('liferay/sort-imports', () => {
 
 				a { color: #000; }
 			`,
-			errors: []
+			errors: [],
 		});
 	});
 
@@ -41,7 +41,7 @@ describe('liferay/sort-imports', () => {
 				a { color: #000; }
 				@import 'aaa';
 			`,
-			errors: []
+			errors: [],
 		});
 	});
 
@@ -61,7 +61,7 @@ describe('liferay/sort-imports', () => {
 				@import 'c';
 
 				a { color: #000 };
-			`
+			`,
 		});
 	});
 
@@ -89,7 +89,7 @@ describe('liferay/sort-imports', () => {
 				@import 'c';
 
 				a { color: #000 };
-			`
+			`,
 		});
 	});
 
@@ -102,7 +102,7 @@ describe('liferay/sort-imports', () => {
 				a { color: #000 };
 			`,
 			errors: [],
-			options: false
+			options: false,
 		});
 	});
 });

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/trim-comments.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/trim-comments.js
@@ -13,7 +13,7 @@ describe('liferay/trim-comments', () => {
 				// More.
 				a { color: #000; }
 			`,
-			errors: []
+			errors: [],
 		});
 	});
 
@@ -35,7 +35,7 @@ describe('liferay/trim-comments', () => {
 					rule: 'liferay/trim-comments',
 					severity: 'error',
 					text:
-						'No blank leading lines in comments (liferay/trim-comments)'
+						'No blank leading lines in comments (liferay/trim-comments)',
 				},
 				{
 					column: 5,
@@ -43,9 +43,9 @@ describe('liferay/trim-comments', () => {
 					rule: 'liferay/trim-comments',
 					severity: 'error',
 					text:
-						'No blank leading lines in comments (liferay/trim-comments)'
-				}
-			]
+						'No blank leading lines in comments (liferay/trim-comments)',
+				},
+			],
 		});
 	});
 
@@ -67,7 +67,7 @@ describe('liferay/trim-comments', () => {
 					rule: 'liferay/trim-comments',
 					severity: 'error',
 					text:
-						'No blank trailing lines in comments (liferay/trim-comments)'
+						'No blank trailing lines in comments (liferay/trim-comments)',
 				},
 				{
 					column: 5,
@@ -75,9 +75,9 @@ describe('liferay/trim-comments', () => {
 					rule: 'liferay/trim-comments',
 					severity: 'error',
 					text:
-						'No blank trailing lines in comments (liferay/trim-comments)'
-				}
-			]
+						'No blank trailing lines in comments (liferay/trim-comments)',
+				},
+			],
 		});
 	});
 
@@ -96,7 +96,7 @@ describe('liferay/trim-comments', () => {
 					rule: 'liferay/trim-comments',
 					severity: 'error',
 					text:
-						'No blank leading lines in comments (liferay/trim-comments)'
+						'No blank leading lines in comments (liferay/trim-comments)',
 				},
 				{
 					column: 5,
@@ -104,9 +104,9 @@ describe('liferay/trim-comments', () => {
 					rule: 'liferay/trim-comments',
 					severity: 'error',
 					text:
-						'No blank trailing lines in comments (liferay/trim-comments)'
-				}
-			]
+						'No blank trailing lines in comments (liferay/trim-comments)',
+				},
+			],
 		});
 	});
 
@@ -142,7 +142,7 @@ describe('liferay/trim-comments', () => {
 				a { color: #111; }
 
 				// One last bad thing.
-			`
+			`,
 		});
 	});
 
@@ -155,7 +155,7 @@ describe('liferay/trim-comments', () => {
 				a { color: #000; }
 			`,
 			errors: [],
-			options: [false]
+			options: [false],
 		});
 	});
 });

--- a/packages/liferay-npm-scripts/test/scripts/theme.js
+++ b/packages/liferay-npm-scripts/test/scripts/theme.js
@@ -136,7 +136,7 @@ describe('scripts/theme.js', () => {
 				'--styled-path',
 				STYLED,
 				'--unstyled-path',
-				UNSTYLED
+				UNSTYLED,
 			]);
 		});
 
@@ -150,7 +150,7 @@ describe('scripts/theme.js', () => {
 				'--styled-path',
 				STYLED,
 				'--unstyled-path',
-				UNSTYLED
+				UNSTYLED,
 			]);
 		});
 	});
@@ -175,7 +175,7 @@ describe('scripts/theme.js', () => {
 					'--styled-path',
 					STYLED,
 					'--unstyled-path',
-					UNSTYLED
+					UNSTYLED,
 				]);
 			});
 
@@ -191,7 +191,7 @@ describe('scripts/theme.js', () => {
 					'--styled-path',
 					STYLED,
 					'--unstyled-path',
-					UNSTYLED
+					UNSTYLED,
 				]);
 			});
 

--- a/packages/liferay-npm-scripts/test/scripts/webpack.js
+++ b/packages/liferay-npm-scripts/test/scripts/webpack.js
@@ -33,7 +33,7 @@ describe('scripts/webpack.js', () => {
 
 		expect(spawnSync).toHaveBeenCalledWith('webpack', [
 			'--config',
-			expect.stringMatching(/[/\\]webpack\.config\.js$/)
+			expect.stringMatching(/[/\\]webpack\.config\.js$/),
 		]);
 	});
 
@@ -43,7 +43,7 @@ describe('scripts/webpack.js', () => {
 		expect(spawnSync).toHaveBeenCalledWith('webpack', [
 			'--config',
 			expect.stringMatching(/[/\\]webpack\.config\.js$/),
-			'--verbose'
+			'--verbose',
 		]);
 	});
 
@@ -54,7 +54,7 @@ describe('scripts/webpack.js', () => {
 
 		expect(spawnSync).toHaveBeenCalledWith('webpack-dev-server', [
 			'--config',
-			expect.stringMatching(/[/\\]webpack\.config\.dev\.js$/)
+			expect.stringMatching(/[/\\]webpack\.config\.dev\.js$/),
 		]);
 	});
 
@@ -65,7 +65,7 @@ describe('scripts/webpack.js', () => {
 		expect(spawnSync).toHaveBeenCalledWith('webpack-dev-server', [
 			'--config',
 			expect.stringMatching(/[/\\]webpack\.config\.dev\.js$/),
-			'--lazy'
+			'--lazy',
 		]);
 	});
 

--- a/packages/liferay-npm-scripts/test/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/test/utils/deepMerge.js
@@ -21,7 +21,7 @@ describe('deepMerge()', () => {
 				deepMerge(
 					[
 						[1, 2],
-						['a', 'b']
+						['a', 'b'],
 					],
 					deepMerge.MODE.DEFAULT
 				)
@@ -35,7 +35,7 @@ describe('deepMerge()', () => {
 				deepMerge(
 					[
 						[1, 2, 3],
-						['a', 'b', 'c']
+						['a', 'b', 'c'],
 					],
 					deepMerge.MODE.OVERWRITE_ARRAYS
 				)
@@ -49,16 +49,16 @@ describe('deepMerge()', () => {
 				deepMerge(
 					[
 						{
-							plugins: ['a', 'b']
+							plugins: ['a', 'b'],
 						},
 						{
-							plugins: ['c', 'd']
-						}
+							plugins: ['c', 'd'],
+						},
 					],
 					deepMerge.MODE.BABEL
 				)
 			).toEqual({
-				plugins: ['a', 'b', 'c', 'd']
+				plugins: ['a', 'b', 'c', 'd'],
 			});
 		});
 
@@ -67,16 +67,16 @@ describe('deepMerge()', () => {
 				deepMerge(
 					[
 						{
-							plugins: ['a', 'b']
+							plugins: ['a', 'b'],
 						},
 						{
-							plugins: ['a', 'b', 'c']
-						}
+							plugins: ['a', 'b', 'c'],
+						},
 					],
 					deepMerge.MODE.BABEL
 				)
 			).toEqual({
-				plugins: ['a', 'b', 'c']
+				plugins: ['a', 'b', 'c'],
 			});
 		});
 
@@ -85,16 +85,16 @@ describe('deepMerge()', () => {
 				deepMerge(
 					[
 						{
-							plugins: ['b', 'a']
+							plugins: ['b', 'a'],
 						},
 						{
-							plugins: ['c', 'b', 'a']
-						}
+							plugins: ['c', 'b', 'a'],
+						},
 					],
 					deepMerge.MODE.BABEL
 				)
 			).toEqual({
-				plugins: ['b', 'a', 'c']
+				plugins: ['b', 'a', 'c'],
 			});
 		});
 
@@ -103,16 +103,16 @@ describe('deepMerge()', () => {
 				deepMerge(
 					[
 						{
-							plugins: [['a', {option: 1}], 'b']
+							plugins: [['a', {option: 1}], 'b'],
 						},
 						{
-							plugins: ['a', 'c']
-						}
+							plugins: ['a', 'c'],
+						},
 					],
 					deepMerge.MODE.BABEL
 				)
 			).toEqual({
-				plugins: [['a', {option: 1}], 'b', 'c']
+				plugins: [['a', {option: 1}], 'b', 'c'],
 			});
 		});
 
@@ -121,16 +121,16 @@ describe('deepMerge()', () => {
 				deepMerge(
 					[
 						{
-							plugins: ['a', 'b']
+							plugins: ['a', 'b'],
 						},
 						{
-							plugins: ['c', ['b', {option: 2}]]
-						}
+							plugins: ['c', ['b', {option: 2}]],
+						},
 					],
 					deepMerge.MODE.BABEL
 				)
 			).toEqual({
-				plugins: ['a', ['b', {option: 2}], 'c']
+				plugins: ['a', ['b', {option: 2}], 'c'],
 			});
 		});
 
@@ -139,16 +139,16 @@ describe('deepMerge()', () => {
 				deepMerge(
 					[
 						{
-							plugins: ['a', ['b', {bar: false, foo: true}]]
+							plugins: ['a', ['b', {bar: false, foo: true}]],
 						},
 						{
-							plugins: [['b', {baz: null, foo: false}], 'c']
-						}
+							plugins: [['b', {baz: null, foo: false}], 'c'],
+						},
 					],
 					deepMerge.MODE.BABEL
 				)
 			).toEqual({
-				plugins: ['a', ['b', {bar: false, baz: null, foo: false}], 'c']
+				plugins: ['a', ['b', {bar: false, baz: null, foo: false}], 'c'],
 			});
 		});
 
@@ -157,16 +157,16 @@ describe('deepMerge()', () => {
 				deepMerge(
 					[
 						{
-							plugins: [['a'], 'b', ['z', {}]]
+							plugins: [['a'], 'b', ['z', {}]],
 						},
 						{
-							plugins: [['a', {}], 'c', ['d', {}], ['e']]
-						}
+							plugins: [['a', {}], 'c', ['d', {}], ['e']],
+						},
 					],
 					deepMerge.MODE.BABEL
 				)
 			).toEqual({
-				plugins: ['a', 'b', 'z', 'c', 'd', 'e']
+				plugins: ['a', 'b', 'z', 'c', 'd', 'e'],
 			});
 		});
 
@@ -176,18 +176,18 @@ describe('deepMerge()', () => {
 					[
 						{
 							ignore: ['./mocks/*.js'],
-							plugins: ['a', ['b', {option: 1}]]
+							plugins: ['a', ['b', {option: 1}]],
 						},
 						{
 							ignore: ['./tests/*.disabled.js'],
-							plugins: ['c']
-						}
+							plugins: ['c'],
+						},
 					],
 					deepMerge.MODE.BABEL
 				)
 			).toEqual({
 				ignore: ['./mocks/*.js', './tests/*.disabled.js'],
-				plugins: ['a', ['b', {option: 1}], 'c']
+				plugins: ['a', ['b', {option: 1}], 'c'],
 			});
 		});
 
@@ -203,14 +203,14 @@ describe('deepMerge()', () => {
 								'a',
 								['b', {option: 1}],
 								['c', {option: 2}],
-								'd'
+								'd',
 							],
 							presets: [
 								['a', {targets: [1, 2]}],
 								'b',
 								'c',
-								['d', {foo: 1}]
-							]
+								['d', {foo: 1}],
+							],
 						},
 						{
 							extends: 'other',
@@ -219,9 +219,9 @@ describe('deepMerge()', () => {
 								'a',
 								['d', {bar: 3, foo: 2}],
 								['e', {true: false}],
-								'c'
-							]
-						}
+								'c',
+							],
+						},
 					],
 					deepMerge.MODE.BABEL
 				)
@@ -234,8 +234,8 @@ describe('deepMerge()', () => {
 					'b',
 					'c',
 					['d', {bar: 3, foo: 2}],
-					['e', {true: false}]
-				]
+					['e', {true: false}],
+				],
 			});
 		});
 
@@ -246,23 +246,23 @@ describe('deepMerge()', () => {
 						'module-resolver',
 						{
 							alias: {
-								test: './test/js/'
+								test: './test/js/',
 							},
 							root: [
-								'./src/main/resources/META-INF/resources/js/'
-							]
-						}
-					]
+								'./src/main/resources/META-INF/resources/js/',
+							],
+						},
+					],
 				],
-				presets: ['@babel/preset-react']
+				presets: ['@babel/preset-react'],
 			};
 
 			const defaultConfig = {
 				plugins: [
 					'@babel/proposal-class-properties',
-					'@babel/proposal-object-rest-spread'
+					'@babel/proposal-object-rest-spread',
 				],
-				presets: ['@babel/preset-env']
+				presets: ['@babel/preset-env'],
 			};
 
 			expect(
@@ -275,22 +275,22 @@ describe('deepMerge()', () => {
 						'module-resolver',
 						{
 							alias: {
-								test: './test/js/'
+								test: './test/js/',
 							},
 							root: [
-								'./src/main/resources/META-INF/resources/js/'
-							]
-						}
-					]
+								'./src/main/resources/META-INF/resources/js/',
+							],
+						},
+					],
 				],
-				presets: ['@babel/preset-env', '@babel/preset-react']
+				presets: ['@babel/preset-env', '@babel/preset-react'],
 			});
 		});
 
 		it("doesn't break when a stale .babelrc.js file is left on disk", () => {
 			// This is the original project-local .babelrc.js config.
 			const project = {
-				presets: ['@babel/preset-react']
+				presets: ['@babel/preset-react'],
 			};
 
 			// This is the config provided by liferay-npm-scripts.
@@ -302,19 +302,19 @@ describe('deepMerge()', () => {
 								'@babel/preset-env',
 								{
 									targets: {
-										node: '10.15'
-									}
-								}
-							]
+										node: '10.15',
+									},
+								},
+							],
 						],
-						test: '**/test/**/*.js'
-					}
+						test: '**/test/**/*.js',
+					},
 				],
 				plugins: [
 					'@babel/proposal-class-properties',
-					'@babel/proposal-object-rest-spread'
+					'@babel/proposal-object-rest-spread',
 				],
-				presets: ['@babel/preset-env']
+				presets: ['@babel/preset-env'],
 			};
 
 			// This should be the result of merging "defaults" and "project"; imagine that
@@ -327,19 +327,19 @@ describe('deepMerge()', () => {
 								'@babel/preset-env',
 								{
 									targets: {
-										node: '10.15'
-									}
-								}
-							]
+										node: '10.15',
+									},
+								},
+							],
 						],
-						test: '**/test/**/*.js'
-					}
+						test: '**/test/**/*.js',
+					},
 				],
 				plugins: [
 					'@babel/proposal-class-properties',
-					'@babel/proposal-object-rest-spread'
+					'@babel/proposal-object-rest-spread',
 				],
-				presets: ['@babel/preset-env', '@babel/preset-react']
+				presets: ['@babel/preset-env', '@babel/preset-react'],
 			};
 
 			expect(

--- a/packages/liferay-npm-scripts/test/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/expandGlobs.js
@@ -49,7 +49,7 @@ const PORTAL_GLOBS = [
 	'/apps/*/*/.*.js',
 	'/apps/*/*/{src,test}/**/*.es.js',
 	'/apps/*/*/{src,test}/**/*.js',
-	'/apps/*/*/{src,test}/**/*.scss'
+	'/apps/*/*/{src,test}/**/*.scss',
 ].reduce((acc, glob) => acc.concat(preprocessGlob(glob)), []);
 
 const PORTAL_IGNORE_GLOBS = [
@@ -69,7 +69,7 @@ const PORTAL_IGNORE_GLOBS = [
 	'apps/portal-portlet-bridge/portal-portlet-bridge-soy-impl/src/test/resources/com/liferay/portal/portlet/bridge/soy/internal/dependencies/**/*.js',
 	'apps/fragment/fragment-demo-data-creator-impl/src/main/resources/com/liferay/fragment/demo/data/creator/internal/dependencies/**/*.js',
 	'apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/**/*.js',
-	'/yarn-*.js'
+	'/yarn-*.js',
 ];
 
 describe('expandGlobs()', () => {
@@ -113,7 +113,7 @@ describe('expandGlobs()', () => {
 		expect(matches).toEqual([
 			'.eslintrc.js',
 			'apps/app-builder/app-builder-web/.eslintrc.js',
-			'node_modules/domain-browser/.eslintrc.js'
+			'node_modules/domain-browser/.eslintrc.js',
 		]);
 	});
 
@@ -128,7 +128,7 @@ describe('expandGlobs()', () => {
 			'apps/frontend-css/frontend-css-web',
 			'apps/frontend-js/frontend-js-web',
 			'apps/journal/journal-web',
-			'apps/layout/layout-content-page-editor-web'
+			'apps/layout/layout-content-page-editor-web',
 		]);
 	});
 
@@ -139,7 +139,7 @@ describe('expandGlobs()', () => {
 			'.eslintrc.js',
 			'.prettierrc.js',
 			'node_modules/domain-browser/.eslintrc.js',
-			'npmscripts.config.js'
+			'npmscripts.config.js',
 		]);
 	});
 
@@ -153,7 +153,7 @@ describe('expandGlobs()', () => {
 			'apps/frontend-theme-porygon',
 			'apps/layout/layout-content-page-editor-web',
 			'apps/portal-portlet-bridge',
-			'sdk/gradle-plugins-theme-builder'
+			'sdk/gradle-plugins-theme-builder',
 		]);
 	});
 
@@ -194,7 +194,7 @@ describe('expandGlobs()', () => {
 			'apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/main.scss',
 			'apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMStructuresManagementToolbarDefaultEventHandler.es.js',
 			'apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/js/actions/updateRowColumnsNumber.es.js',
-			'npmscripts.config.js'
+			'npmscripts.config.js',
 		]);
 	});
 

--- a/packages/liferay-npm-scripts/test/utils/filterGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/filterGlobs.js
@@ -16,7 +16,7 @@ describe('filterGlobs()', () => {
 		expect(filterGlobs(globs, '.js', '.ts', '.tsx')).toEqual([
 			'**/*.js',
 			'**/*.ts',
-			'**/*.tsx'
+			'**/*.tsx',
 		]);
 	});
 

--- a/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
@@ -38,16 +38,16 @@ describe('getMergedConfig()', () => {
 					return jest.fn(() => ({
 						liferay: {
 							excludes: {
-								presets: ['@babel/preset-react']
-							}
+								presets: ['@babel/preset-react'],
+							},
 						},
 
 						// This bit isn't real config, but it shows that
 						// we can filter down below the top level:
 						overrides: [
 							{
-								presets: ['fancy', '@babel/preset-react']
-							}
+								presets: ['fancy', '@babel/preset-react'],
+							},
 						],
 
 						plugins: [
@@ -57,10 +57,10 @@ describe('getMergedConfig()', () => {
 									components: true,
 									namespaceAttributes: true,
 									prefix: 'IncrementalDOM',
-									runtime: 'iDOMHelpers'
-								}
-							]
-						]
+									runtime: 'iDOMHelpers',
+								},
+							],
+						],
 					}));
 				});
 
@@ -70,7 +70,7 @@ describe('getMergedConfig()', () => {
 
 				expect(config.overrides[0].presets).toMatchObject([
 					['@babel/preset-env', expect.anything()],
-					'fancy'
+					'fancy',
 				]);
 			});
 		});

--- a/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js
+++ b/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js
@@ -15,9 +15,9 @@ expect.extend({
 
 				return `expected path ${file} ${predicate} glob ${glob}`;
 			},
-			pass
+			pass,
 		};
-	}
+	},
 });
 
 describe('getRegExpForGlob()', () => {

--- a/packages/liferay-npm-scripts/test/utils/permute.js
+++ b/packages/liferay-npm-scripts/test/utils/permute.js
@@ -17,7 +17,7 @@ describe('permute()', () => {
 	it('permutes a array of two items', () => {
 		expect(permute(['a', 'b'])).toEqual([
 			['a', 'b'],
-			['b', 'a']
+			['b', 'a'],
 		]);
 	});
 
@@ -28,7 +28,7 @@ describe('permute()', () => {
 			['c', 'a', 'b'],
 			['a', 'c', 'b'],
 			['b', 'c', 'a'],
-			['c', 'b', 'a']
+			['c', 'b', 'a'],
 		]);
 	});
 });

--- a/packages/liferay-npm-scripts/test/utils/preprocessGlob.js
+++ b/packages/liferay-npm-scripts/test/utils/preprocessGlob.js
@@ -27,7 +27,7 @@ describe('preprocessGlob()', () => {
 			'a/c/e/f',
 			'a/c/e/g',
 			'a/d/e/f',
-			'a/d/e/g'
+			'a/d/e/g',
 		]);
 	});
 

--- a/packages/liferay-npm-scripts/test/utils/spawnMultiple.js
+++ b/packages/liferay-npm-scripts/test/utils/spawnMultiple.js
@@ -29,7 +29,7 @@ describe('spawnMultiple()', () => {
 			jest.fn(() => {
 				throw new SpawnError('Boom');
 			}),
-			jest.fn()
+			jest.fn(),
 		];
 
 		await expect(spawnMultiple(...jobs)).rejects.toThrow(SpawnError);
@@ -45,7 +45,7 @@ describe('spawnMultiple()', () => {
 			jest.fn(() => {
 				throw new Error('Boom');
 			}),
-			jest.fn()
+			jest.fn(),
 		];
 
 		await expect(spawnMultiple(...jobs)).rejects.toThrow(Error);


### PR DESCRIPTION
This wasn't previously safe to do because IE will choke on a trailing comma, but now that basically all JS is passing through Babel and getting transformed away, we can go ahead.

The exceptions to this are theme JS, of which there is almost none, and JS in JSP, which is not affected (because we adjust Prettier to make sure that it never adds commas in that context).

Test plan: In a test run over liferay-portal, produces [this 77k-line diff](https://gist.github.com/wincent/2643a647345a98ffb4df9b559aba3688).

Contrast that with this, where we skip the special casing of JSP, and it would produce [this 88k-line diff](https://gist.github.com/wincent/223f31e62f74cf542bd8f1b9df087826), which would evidently cause problems in IE.

Closes: https://github.com/liferay/liferay-npm-tools/issues/380

Related: https://github.com/liferay/liferay-frontend-guidelines/issues/120