### PR TITLE
fix(meta): make globs work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
 	"private": true,
 	"scripts": {
 		"ci": "yarn format:check && yarn lint && yarn test",
-		"format": "prettier --write '**/*.js' '**/*.json' '**/*.md'",
-		"format:check": "prettier --list-different '**/*.js' '**/*.json' '**/*.md'",
-		"lint": "eslint '.*.js' '**/*.js'",
-		"lint:fix": "eslint --fix '.*.js' '**/*.js'",
+		"format": "prettier --write \"**/*.js\" \"**/*.json\" \"**/*.md\"",
+		"format:check": "prettier --list-different \"**/*.js\" \"**/*.json\" \"**/*.md\"",
+		"lint": "eslint \".*.js\" \"**/*.js\"",
+		"lint:fix": "eslint --fix \".*.js\" \"**/*.js\"",
 		"preversion": "echo Cannot version top-level private package; false",
 		"test": "jest"
 	},


### PR DESCRIPTION
Analogous change to this one on the alloy-editor repo:

https://github.com/liferay/alloy-editor/pull/1374

Just in case anybody is ever foolhardy enough to try doing development on this repo on Windows.