### PR TITLE
refactor(reporter): remove explicit devDependencies

### DIFF
--- a/packages/liferay-jest-junit-reporter/package.json
+++ b/packages/liferay-jest-junit-reporter/package.json
@@ -22,9 +22,6 @@
 		"strip-ansi": "6.0.0",
 		"xml": "^1.0.1"
 	},
-	"devDependencies": {
-		"jest": "^24.5.0"
-	},
 	"jest": {
 		"testMatch": [
 			"**/test/**/*.js"


### PR DESCRIPTION
We shouldn't have explicit devDependencies in our monorepos; they should all be shared and declared at the top level.

Jest already is, so everything continues to work exactly as before (and note: no changes to the lock file).