### PR TITLE
revert: undo reporter changes related to IFI-780

### DIFF
--- a/packages/liferay-jest-junit-reporter/package.json
+++ b/packages/liferay-jest-junit-reporter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "liferay-jest-junit-reporter",
-	"version": "1.1.0-beta.1",
+	"version": "1.0.1",
 	"description": "A JUnit reporter for Jest and Liferay CI",
 	"main": "src/index.js",
 	"scripts": {

--- a/packages/liferay-jest-junit-reporter/src/index.js
+++ b/packages/liferay-jest-junit-reporter/src/index.js
@@ -37,8 +37,6 @@ module.exports = report => {
 		}
 	};
 
-	const moduleName = generalMetrics._attr.package.substr(0,generalMetrics._attr.package.indexOf('.'))
-
 	const testResults = report.testResults
 		.reduce(
 			(results, suite) =>
@@ -58,8 +56,7 @@ module.exports = report => {
 					_attr: {
 						classname: formatDirectoryPath(
 							path.dirname(testCase.testFilePath)
-						)
-							.concat('.[',moduleName,']'),
+						),
 						name: testCase.fullName,
 						time: testCase.duration / 1000
 					}

--- a/packages/liferay-jest-junit-reporter/src/index.js
+++ b/packages/liferay-jest-junit-reporter/src/index.js
@@ -22,9 +22,6 @@ function formatDirectoryPath(dirPath) {
 }
 
 module.exports = report => {
-	const pkg = formatDirectoryPath(process.cwd());
-	const moduleName = pkg.split('.')[0];
-
 	const generalMetrics = {
 		_attr: {
 			errors: 0,
@@ -32,13 +29,15 @@ module.exports = report => {
 			hostname: '',
 			id: 0,
 			name: 'Jest',
-			package: pkg,
+			package: formatDirectoryPath(process.cwd()),
 			skipped: 0,
 			tests: report.numTotalTests,
 			time: 0,
 			timestamp: report.startTime
 		}
 	};
+
+	const moduleName = generalMetrics._attr.package.substr(0,generalMetrics._attr.package.indexOf('.'))
 
 	const testResults = report.testResults
 		.reduce(
@@ -57,9 +56,10 @@ module.exports = report => {
 			const results = [
 				{
 					_attr: {
-						classname: `${formatDirectoryPath(
+						classname: formatDirectoryPath(
 							path.dirname(testCase.testFilePath)
-						)}.[${moduleName}]`,
+						)
+							.concat('.[',moduleName,']'),
 						name: testCase.fullName,
 						time: testCase.duration / 1000
 					}

--- a/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
+++ b/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
@@ -2,8 +2,8 @@
 
 exports[`liferay-jest-junit-reporter writes a file for a failing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
-<testsuite errors=\\"0\\" failures=\\"1\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter.reporter-example\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
-  <testcase classname=\\"test-module.bar.[reporter]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
+<testsuite errors=\\"0\\" failures=\\"1\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
+  <testcase classname=\\"test-module.bar.[reporter-tests]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
     <failure message=\\"Error: expect(received).toBe(expected) // Object.is equality\\">Error: expect(received).toBe(expected) // Object.is equality
 
 Expected: false
@@ -22,8 +22,8 @@ Received: true
 
 exports[`liferay-jest-junit-reporter writes a file for a passing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
-<testsuite errors=\\"0\\" failures=\\"0\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter.reporter-example\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
-  <testcase classname=\\"test-module.bar.[reporter]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
+<testsuite errors=\\"0\\" failures=\\"0\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
+  <testcase classname=\\"test-module.bar.[reporter-tests]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
   </testcase>
 </testsuite>"
 `;

--- a/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
+++ b/packages/liferay-jest-junit-reporter/test/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`liferay-jest-junit-reporter writes a file for a failing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <testsuite errors=\\"0\\" failures=\\"1\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
-  <testcase classname=\\"test-module.bar.[reporter-tests]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
+  <testcase classname=\\"test-module.bar\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
     <failure message=\\"Error: expect(received).toBe(expected) // Object.is equality\\">Error: expect(received).toBe(expected) // Object.is equality
 
 Expected: false
@@ -23,7 +23,7 @@ Received: true
 exports[`liferay-jest-junit-reporter writes a file for a passing test 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <testsuite errors=\\"0\\" failures=\\"0\\" hostname=\\"\\" id=\\"0\\" name=\\"Jest\\" package=\\"reporter-tests\\" skipped=\\"0\\" tests=\\"1\\" time=\\"0\\" timestamp=\\"1000\\">
-  <testcase classname=\\"test-module.bar.[reporter-tests]\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
+  <testcase classname=\\"test-module.bar\\" name=\\"Field DocumentLibrary should not be readOnly\\" time=\\"0.046\\">
   </testcase>
 </testsuite>"
 `;

--- a/packages/liferay-jest-junit-reporter/test/index.js
+++ b/packages/liferay-jest-junit-reporter/test/index.js
@@ -58,10 +58,7 @@ describe('liferay-jest-junit-reporter', () => {
 		jest.resetAllMocks();
 
 		// Prevent user-specific context from appearing in snapshots.
-		jest.spyOn(process, 'cwd').mockImplementation(
-			() =>
-				'/User/liferay-user/code/portal/liferay-portal/modules/apps/reporter/reporter-example'
-		);
+		jest.spyOn(process, 'cwd').mockImplementation(() => 'reporter-tests');
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
Given [John's comment on IFI-780](https://issues.liferay.com/browse/IFI-780):

> This solution does not resolve the root issue.

So, let's revert b50a923 and the follow-ups (418f691 and d52cc87). If we want to take another stab at this in the future we should start again. At the moment, our last non-beta release was 1.0.1 and we'd like to make another (see https://github.com/liferay/liferay-npm-tools/pull/386), but the latest on "master" is 1.1.0-beta.1 and we can't release on top of that. So, we roll back the version change as well (a268cb4) to clear the way for a subsequent release. We'll bump the version number all the way to v1.2.0 to avoid the confusion that may arise from having a "latest" version that is a lower number than a prior release from many months ago.