### PR TITLE
feat(script)!: sort imports in SCSS files

### DIFF
--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -36,7 +36,7 @@ Do you need to use `liferay-npm-bridge-generator`? Just add a `.npmbridgerc` fil
 liferay-npm-scripts check
 ```
 
-`check` runs ESLint to catch semantic problems (equivalent to running `eslint` without the `--fix` option) and Prettier to catch formatting issues (equivalent to running `prettier` with the `--check` flag) for the globs specified in your `npmscripts.config.js` configuration (or, in the absence of explicit configuration, in [the default preset](./src/presets/standard/index.js#L25-L32)).
+`check` runs [ESLint](https://eslint.org/) to catch semantic problems in JS (equivalent to running `eslint` without the `--fix` option), [stylelint](https://stylelint.io/) to catch problems in SCSS files, and [Prettier](https://prettier.io/) to catch formatting issues (equivalent to running `prettier` with the `--check` flag), for the globs specified in your `npmscripts.config.js` configuration (or, in the absence of explicit configuration, in [the default preset](./src/presets/standard/index.js#L25-L32)).
 
 This is the task that runs in liferay-portal projects when you run `yarn checkFormat`.
 
@@ -46,7 +46,7 @@ This is the task that runs in liferay-portal projects when you run `yarn checkFo
 liferay-npm-scripts fix
 ```
 
-`fix` runs ESLint and fixes autofixable issues (equivalent to passing the `--fix` option) and runs Prettier to enforce formatting (equivalent to calling `prettier` with the `--write` flag) for the globs specified in your `npmscripts.config.js` configuration (or, in the absence of explicit configuration, in [the default preset](./src/presets/standard/index.js#L17-L24)).
+`fix` runs [ESLint](https://eslint.org/) and [stylelint](https://stylelint.io/) to identify and fix autofixable issues in JS and SCSS, and [Prettier](https://prettier.io/) to enforce formatting (equivalent to calling `prettier` with the `--write` flag) for the globs specified in your `npmscripts.config.js` configuration (or, in the absence of explicit configuration, in [the default preset](./src/presets/standard/index.js#L17-L24)).
 
 This is the task that runs in liferay-portal projects when you run `yarn format` (or `gradlew formatSource -a`, or `ant format-source`).
 
@@ -203,3 +203,11 @@ Want to use a different `NODE_ENV`? Try doing something like
 ```sh
 NODE_ENV=development liferay-npm-scripts build
 ```
+
+## Appendix: stylelint rules
+
+The [shared stylelint configuration](./src/config/stylelint.json) lists the rules that are activated from among [the bundled rules](https://stylelint.io/user-guide/rules/list) in addition to the following custom rules that we've developed:
+
+-   [`liferay/no-block-comments`](./test/scripts/lint/stylelint/plugins/no-block-comments.js): Disallows block-style comments (`/* ... */`).
+-   [`liferay/sort-imports`](./test/scripts/lint/stylelint/plugins/sort-imports.js): Requires `@import` statements to be alphabetically sorted (separate groups of imports with a blank line to force manual ordering).
+-   [`liferay/trim-comments`](./test/scripts/lint/stylelint/plugins/trim-comments.js): Trims leading and trailing blank lines from comments.

--- a/packages/liferay-npm-scripts/src/config/stylelint.json
+++ b/packages/liferay-npm-scripts/src/config/stylelint.json
@@ -30,6 +30,7 @@
 		"function-url-quotes": "never",
 		"length-zero-no-unit": true,
 		"liferay/no-block-comments": true,
+		"liferay/sort-imports": true,
 		"liferay/trim-comments": true,
 		"media-feature-name-no-unknown": true,
 		"no-duplicate-at-import-rules": true,

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
@@ -1,0 +1,135 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const stylelint = require('stylelint');
+
+const ruleName = 'liferay/sort-imports';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+	sort: 'imports must be sorted by target name'
+});
+
+function precededByBlankLine(node) {
+	const match = node.raws.before.match(/\n/g);
+
+	return match && match.length > 1;
+}
+
+module.exports = stylelint.createPlugin(
+	ruleName,
+	(options, secondaryOptions, context) => {
+		return function(root, result) {
+			const validOptions = stylelint.utils.validateOptions(
+				result,
+				ruleName,
+				{
+					actual: options,
+					possible: [true, false]
+				},
+				{
+					actual: secondaryOptions,
+					optional: true,
+					possible: {
+						disableFix: [true, false]
+					}
+				}
+			);
+
+			if (!validOptions || !options) {
+				return;
+			}
+
+			const disableFix = secondaryOptions && secondaryOptions.disableFix;
+
+			const fix = context ? context.fix && !disableFix : false;
+
+			const imports = [];
+
+			let group;
+
+			root.walkAtRules('import', rule => {
+				const prev = rule.prev();
+
+				if (
+					!prev ||
+					prev.type !== 'atrule' ||
+					precededByBlankLine(rule)
+				) {
+					group = [];
+
+					imports.push(group);
+				}
+
+				group.push(rule);
+			});
+
+			for (let i = 0; i < imports.length; i++) {
+				const group = imports[i];
+
+				for (let j = 0; j < group.length; j++) {
+					const desired = [...group].sort((a, b) => {
+						const aName = a.params.slice(1, -1);
+						const bName = b.params.slice(1, -1);
+
+						if (aName < bName) {
+							return -1;
+						} else if (aName > bName) {
+							return 1;
+						} else {
+							return 0;
+						}
+					});
+
+					// Try to make error messages (somewhat) minimal
+					// by only reporting from the first to the last
+					// mismatch (ie. not a full Myers diff algorithm).
+					const [firstMismatch, lastMismatch] = group.reduce(
+						([first, last], node, index) => {
+							if (node !== desired[index]) {
+								if (first === -1) {
+									first = index;
+								}
+								last = index;
+							}
+
+							return [first, last];
+						},
+						[-1, -1]
+					);
+
+					if (firstMismatch !== -1) {
+						const order = desired
+							.slice(firstMismatch, lastMismatch + 1)
+							.map(node => node.params)
+							.join(' << ');
+
+						if (fix) {
+							for (
+								let k = firstMismatch;
+								k <= lastMismatch;
+								k++
+							) {
+								group[k].replaceWith(
+									group[k].clone({params: desired[k].params})
+								);
+							}
+						} else {
+							stylelint.utils.report({
+								message: `${messages.sort} (expected: ${order})`,
+								node: group[firstMismatch],
+								result,
+								ruleName
+							});
+						}
+					}
+				}
+			}
+		};
+	}
+);
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
@@ -101,11 +101,6 @@ module.exports = stylelint.createPlugin(
 					);
 
 					if (firstMismatch !== -1) {
-						const order = desired
-							.slice(firstMismatch, lastMismatch + 1)
-							.map(node => node.params)
-							.join(' << ');
-
 						if (fix) {
 							for (
 								let k = firstMismatch;
@@ -117,6 +112,11 @@ module.exports = stylelint.createPlugin(
 								);
 							}
 						} else {
+							const order = desired
+								.slice(firstMismatch, lastMismatch + 1)
+								.map(node => node.params)
+								.join(' << ');
+
 							stylelint.utils.report({
 								message: `${messages.sort} (expected: ${order})`,
 								node: group[firstMismatch],

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/sort-imports.js
@@ -1,0 +1,109 @@
+/**
+ * © 2020 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+describe('liferay/sort-imports', () => {
+	const plugin = 'liferay/sort-imports';
+
+	it('accepts well-ordered imports', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'stuff';
+				@import 'thing';
+
+				a { color: #000; }
+			`,
+			errors: []
+		});
+	});
+
+	it('interprets blank lines as group separators', async () => {
+		// We don't care about order between groups, only within groups.
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'stuff';
+				@import 'thing';
+
+				@import 'other';
+				@import 'things';
+
+				a { color: #000; }
+			`,
+			errors: []
+		});
+	});
+
+	it('interprets non-imports as group separators', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'zzz';
+				a { color: #000; }
+				@import 'aaa';
+			`,
+			errors: []
+		});
+	});
+
+	it('autofixes a single group', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'b';
+				@import 'c';
+				@import 'a';
+
+				a { color: #000 };
+			`,
+			errors: [],
+			output: `
+				@import 'a';
+				@import 'b';
+				@import 'c';
+
+				a { color: #000 };
+			`
+		});
+	});
+
+	it('autofixes multiple groups', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'xyz';
+				@import 'abc';
+				@import 'hjk';
+
+				@import 'b';
+				@import 'c';
+				@import 'a';
+
+				a { color: #000 };
+			`,
+			errors: [],
+			output: `
+				@import 'abc';
+				@import 'hjk';
+				@import 'xyz';
+
+				@import 'a';
+				@import 'b';
+				@import 'c';
+
+				a { color: #000 };
+			`
+		});
+	});
+
+	it('can be turned off', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'b';
+				@import 'a';
+
+				a { color: #000 };
+			`,
+			errors: [],
+			options: false
+		});
+	});
+});


### PR DESCRIPTION
We sort alphabetically, with blank lines used to divide imports into groups. We only sort within groups, never across groups, which means that you can force things to be imported in a certain order if necessary.

Example output on liferay-portal:

https://gist.github.com/wincent/d5e48a398930b327c9cc29291ee35dc3

Example autofix:

https://gist.github.com/wincent/c9dd73cda61e2c3519a280301ba2458a

Note that in there I inserted a blank-line after an `@import "variables"` in page_editor just to show how this can be used to prevent an autosort from being applied; if you look in another file in page_editor in that diff, you'll see what happens if you don't do that.

Closes: https://github.com/liferay/liferay-npm-tools/issues/389