### PR TITLE
fix(scripts): avoid false positives involving no-unused-vars

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -32,7 +32,7 @@
 		"@testing-library/jest-dom": "4.0.0",
 		"@testing-library/react": "8.0.7",
 		"@testing-library/user-event": "4.2.4",
-		"babel-eslint": "^10.0.2",
+		"babel-eslint": "^10.0.3",
 		"babel-jest": "^25.1.0",
 		"babel-loader": "8.0.6",
 		"babel-plugin-transform-react-remove-prop-types": "0.4.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2824,7 +2824,7 @@ babel-core@^6.26.0, babel-core@^6.26.3:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-eslint@^10.0.2:
+babel-eslint@^10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
   integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==


### PR DESCRIPTION
In liferay-portal right now, [we've resolved our babel-eslint dependency to v10.0.2](https://github.com/liferay/liferay-portal/blob/52b997396c42fa102a7d850d5f3521d63377423c/modules/yarn.lock#L3637), but that [has a bug in it](https://github.com/eslint/eslint/issues/12117
) causing false positives of the no-unused-vars rule in relation with `for` loops.

By tightening the requirement here, we can force liferay-portal to use the fixed version (we're already on the latest, fixed version of ESLint itself, so no need to worry about that).

Test plan:

Remove [this suppression](https://github.com/liferay/liferay-portal/blob/52b997396c42fa102a7d850d5f3521d63377423c/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/soy/Flags.es.js#L113) from the flags-taglib project.

See the spurious lint warning:

```
flags-taglib ❯ portool yarn checkFormat
info: using /Users/greghurrell/code/portal/liferay-portal/build/node/bin/node
yarn run v1.17.3
$ liferay-npm-scripts check
Prettier checked 12 files
/Users/greghurrell/code/portal/liferay-portal/modules/apps/flags/flags-taglib/src/main/resources/META-INF/resources/flags/soy/Flags.es.js
  113:14  error  'name' is defined but never used.  no-unused-vars

✖ 1 problem (1 error, 0 warnings)
```

Force usage of babel-eslint 10.0.3 (with `yarn add`, confirming with `yarn why` that it really is the only version in use in liferay-portal) and then retest:

```
flags-taglib! ❯ portool yarn checkFormat
info: using /Users/greghurrell/code/portal/liferay-portal/build/node/bin/node
yarn run v1.17.3
$ liferay-npm-scripts check
Prettier checked 12 files

✨  Done in 2.02s.
```