### PR TITLE
feat(scripts): disallow explicit .scss extension in imports

### DIFF
--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -209,5 +209,6 @@ NODE_ENV=development liferay-npm-scripts build
 The [shared stylelint configuration](./src/config/stylelint.json) lists the rules that are activated from among [the bundled rules](https://stylelint.io/user-guide/rules/list) in addition to the following custom rules that we've developed:
 
 -   [`liferay/no-block-comments`](./test/scripts/lint/stylelint/plugins/no-block-comments.js): Disallows block-style comments (`/* ... */`).
+-   [`liferay/no-import-extension`](./test/scripts/lint/stylelint/plugins/no-import-extension.js): Disallows the use of an explicit ".scss" extension in Sass `@import` statements.
 -   [`liferay/sort-imports`](./test/scripts/lint/stylelint/plugins/sort-imports.js): Requires `@import` statements to be alphabetically sorted (separate groups of imports with a blank line to force manual ordering).
 -   [`liferay/trim-comments`](./test/scripts/lint/stylelint/plugins/trim-comments.js): Trims leading and trailing blank lines from comments.

--- a/packages/liferay-npm-scripts/src/config/stylelint.json
+++ b/packages/liferay-npm-scripts/src/config/stylelint.json
@@ -30,6 +30,7 @@
 		"function-url-quotes": "never",
 		"length-zero-no-unit": true,
 		"liferay/no-block-comments": true,
+		"liferay/no-import-extension": true,
 		"liferay/sort-imports": true,
 		"liferay/trim-comments": true,
 		"media-feature-name-no-unknown": true,

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-import-extension.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-import-extension.js
@@ -1,0 +1,77 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const stylelint = require('stylelint');
+
+const ruleName = 'liferay/no-import-extension';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+	extension: 'imports must omit the ".scss" extension'
+});
+
+const PARAMS_REGEXP = /^(['"]?)(.+?)(['"]?)$/;
+
+const SCSS_EXT = '.scss';
+
+module.exports = stylelint.createPlugin(
+	ruleName,
+	(options, secondaryOptions, context) => {
+		return function(root, result) {
+			const validOptions = stylelint.utils.validateOptions(
+				result,
+				ruleName,
+				{
+					actual: options,
+					possible: [true, false]
+				},
+				{
+					actual: secondaryOptions,
+					optional: true,
+					possible: {
+						disableFix: [true, false]
+					}
+				}
+			);
+
+			if (!validOptions || !options) {
+				return;
+			}
+
+			const disableFix = secondaryOptions && secondaryOptions.disableFix;
+
+			const fix = context ? context.fix && !disableFix : false;
+
+			root.walkAtRules('import', rule => {
+				if (rule.params.startsWith('url(')) {
+					return;
+				}
+
+				const [, left, params, right] = rule.params.match(
+					PARAMS_REGEXP
+				);
+
+				if (params.endsWith(SCSS_EXT)) {
+					const desired =
+						left + params.slice(0, -SCSS_EXT.length) + right;
+
+					if (fix) {
+						rule.replaceWith(rule.clone({params: desired}));
+					} else {
+						stylelint.utils.report({
+							message: messages.extension,
+							node: rule,
+							result,
+							ruleName
+						});
+					}
+				}
+			});
+		};
+	}
+);
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-import-extension.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-import-extension.js
@@ -1,0 +1,62 @@
+/**
+ * © 2020 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+describe('liferay/no-import-extension', () => {
+	const plugin = 'liferay/no-import-extension';
+
+	it('accepts imports without ".scss" extensions', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import "example";
+				@import 'stuff';
+				@import 'thing.css';
+			`,
+			errors: []
+		});
+	});
+
+	it('does not touch `url()` imports', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import url('foo');
+				@import url("bar");
+				@import url("baz.css");
+
+				// Note how SCSS allows us to skip quotes around URLs.
+				@import url(bar);
+
+				// Rule ignores even this (bogus) url.
+				@import url('weird.scss');
+			`,
+			errors: []
+		});
+	});
+
+	it('autofixes', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'a.scss';
+				@import "b.scss";
+			`,
+			errors: [],
+			output: `
+				@import 'a';
+				@import "b";
+			`
+		});
+	});
+
+	it('can be turned off', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'a.scss';
+				@import "b.scss";
+			`,
+			errors: [],
+			options: false
+		});
+	});
+});


### PR DESCRIPTION
This is just a simple implementation of the rule that doesn't try to handle compound import statements eg.

    @import 'a', 'b', 'c';

because we don't have any of those in liferay-portal. We can add a separate rule to enforce that that invariant remains true, if we want to.

Test plan: Copy this over to liferay-portal and see it make [these changes](https://gist.github.com/wincent/189c5772ae8487b2220a1b638a7bb137).

Closes: https://github.com/liferay/liferay-npm-tools/issues/391