### PR TITLE
chore: update for compliance with current Outbound Licensing Policy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,13 @@
+# 3-Clause BSD License
+
+Copyright (c) 2019, Liferay Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/copyright.js
+++ b/copyright.js
@@ -1,6 +1,5 @@
 /**
- * © <%= YEAR %> Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © <%= YEAR %> Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js
+++ b/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-jest-junit-reporter/src/index.js
+++ b/packages/liferay-jest-junit-reporter/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-jest-junit-reporter/test/index.js
+++ b/packages/liferay-jest-junit-reporter/test/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-insights/index.js
+++ b/packages/liferay-js-insights/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-insights/insights/dependencies.js
+++ b/packages/liferay-js-insights/insights/dependencies.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-insights/insights/loc.js
+++ b/packages/liferay-js-insights/insights/loc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-insights/reporters/airtable.js
+++ b/packages/liferay-js-insights/reporters/airtable.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-insights/reporters/json.js
+++ b/packages/liferay-js-insights/reporters/json.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-insights/reporters/table.js
+++ b/packages/liferay-js-insights/reporters/table.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-publish/bin/liferay-js-publish.js
+++ b/packages/liferay-js-publish/bin/liferay-js-publish.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-publish/src/git.js
+++ b/packages/liferay-js-publish/src/git.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-publish/src/index.js
+++ b/packages/liferay-js-publish/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-js-publish/src/run.js
+++ b/packages/liferay-js-publish/src/run.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/segments/segments-web/src/index.es.js
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/lint/modules/apps/segments/segments-web/src/index.es.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/__fixtures__/scripts/webpack/sample/webpack.config.dev.js
+++ b/packages/liferay-npm-scripts/__fixtures__/scripts/webpack/sample/webpack.config.dev.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
+++ b/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/contrib/prettier/prettier.js
+++ b/packages/liferay-npm-scripts/contrib/prettier/prettier.js
@@ -1,6 +1,5 @@
 /**
- * © 2020 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/config/eslint.config.js
+++ b/packages/liferay-npm-scripts/src/config/eslint.config.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/config/jest.config.js
+++ b/packages/liferay-npm-scripts/src/config/jest.config.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/config/npmscripts.config.js
+++ b/packages/liferay-npm-scripts/src/config/npmscripts.config.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jest/mocks/Headers.js
+++ b/packages/liferay-npm-scripts/src/jest/mocks/Headers.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jest/mocks/Liferay.js
+++ b/packages/liferay-npm-scripts/src/jest/mocks/Liferay.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jest/resolver.js
+++ b/packages/liferay-npm-scripts/src/jest/resolver.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jest/setup.js
+++ b/packages/liferay-npm-scripts/src/jest/setup.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jest/setupAfterEnv.js
+++ b/packages/liferay-npm-scripts/src/jest/setupAfterEnv.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jest/transformBabel.js
+++ b/packages/liferay-npm-scripts/src/jest/transformBabel.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jest/transformSass.js
+++ b/packages/liferay-npm-scripts/src/jest/transformSass.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jest/transformSoy.js
+++ b/packages/liferay-npm-scripts/src/jest/transformSoy.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jest/transformStyles.js
+++ b/packages/liferay-npm-scripts/src/jest/transformStyles.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/Lexer.js
+++ b/packages/liferay-npm-scripts/src/jsp/Lexer.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/ReversibleMap.js
+++ b/packages/liferay-npm-scripts/src/jsp/ReversibleMap.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/dedent.js
+++ b/packages/liferay-npm-scripts/src/jsp/dedent.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/extractJS.js
+++ b/packages/liferay-npm-scripts/src/jsp/extractJS.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/formatJSP.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/getPaddedReplacement.js
+++ b/packages/liferay-npm-scripts/src/jsp/getPaddedReplacement.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/indent.js
+++ b/packages/liferay-npm-scripts/src/jsp/indent.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/isJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/isJSP.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/lex.js
+++ b/packages/liferay-npm-scripts/src/jsp/lex.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/lintJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/lintJSP.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/padLines.js
+++ b/packages/liferay-npm-scripts/src/jsp/padLines.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/processJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/processJSP.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/restoreTags.js
+++ b/packages/liferay-npm-scripts/src/jsp/restoreTags.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/stripIndents.js
+++ b/packages/liferay-npm-scripts/src/jsp/stripIndents.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/substituteTags.js
+++ b/packages/liferay-npm-scripts/src/jsp/substituteTags.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/tagReplacements.js
+++ b/packages/liferay-npm-scripts/src/jsp/tagReplacements.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/toFiller.js
+++ b/packages/liferay-npm-scripts/src/jsp/toFiller.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/jsp/trim.js
+++ b/packages/liferay-npm-scripts/src/jsp/trim.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/presets/standard/dependencies/clay.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/dependencies/clay.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/presets/standard/dependencies/liferay.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/dependencies/liferay.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/presets/standard/dependencies/metal.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/dependencies/metal.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/prettier/index.js
+++ b/packages/liferay-npm-scripts/src/prettier/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/prettier/rules/newline-before-block-statements.js
+++ b/packages/liferay-npm-scripts/src/prettier/rules/newline-before-block-statements.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/check.js
+++ b/packages/liferay-npm-scripts/src/scripts/check.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/check/preflight.js
+++ b/packages/liferay-npm-scripts/src/scripts/check/preflight.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/fix.js
+++ b/packages/liferay-npm-scripts/src/scripts/fix.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/isSCSS.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/isSCSS.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/lintSCSS.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/lintSCSS.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-block-comments.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-block-comments.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-import-extension.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-import-extension.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/trim-comments.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/trim-comments.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/prettier.js
+++ b/packages/liferay-npm-scripts/src/scripts/prettier.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/storybook.js
+++ b/packages/liferay-npm-scripts/src/scripts/storybook.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/theme.js
+++ b/packages/liferay-npm-scripts/src/scripts/theme.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/scripts/webpack.js
+++ b/packages/liferay-npm-scripts/src/scripts/webpack.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/storybook/addons.js
+++ b/packages/liferay-npm-scripts/src/storybook/addons.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/storybook/config.js
+++ b/packages/liferay-npm-scripts/src/storybook/config.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/storybook/frontend-js-web.mock.js
+++ b/packages/liferay-npm-scripts/src/storybook/frontend-js-web.mock.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/storybook/index.js
+++ b/packages/liferay-npm-scripts/src/storybook/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/storybook/middleware.js
+++ b/packages/liferay-npm-scripts/src/storybook/middleware.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/storybook/webpack.config.js
+++ b/packages/liferay-npm-scripts/src/storybook/webpack.config.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/SignalHandler.js
+++ b/packages/liferay-npm-scripts/src/utils/SignalHandler.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/src/utils/deepMerge.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/expandGlobs.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/src/utils/filterChangedFiles.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/filterGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/filterGlobs.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/findRoot.js
+++ b/packages/liferay-npm-scripts/src/utils/findRoot.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
+++ b/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/getPaths.js
+++ b/packages/liferay-npm-scripts/src/utils/getPaths.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/getRegExpForGlob.js
+++ b/packages/liferay-npm-scripts/src/utils/getRegExpForGlob.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/getUserConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getUserConfig.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/git.js
+++ b/packages/liferay-npm-scripts/src/utils/git.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/hasExtension.js
+++ b/packages/liferay-npm-scripts/src/utils/hasExtension.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/log.js
+++ b/packages/liferay-npm-scripts/src/utils/log.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/mergeBabelLoaderOptions.js
+++ b/packages/liferay-npm-scripts/src/utils/mergeBabelLoaderOptions.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/permute.js
+++ b/packages/liferay-npm-scripts/src/utils/permute.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
+++ b/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/readIgnoreFile.js
+++ b/packages/liferay-npm-scripts/src/utils/readIgnoreFile.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/run.js
+++ b/packages/liferay-npm-scripts/src/utils/run.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/runBabel.js
+++ b/packages/liferay-npm-scripts/src/utils/runBabel.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/runBundler.js
+++ b/packages/liferay-npm-scripts/src/utils/runBundler.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/setEnv.js
+++ b/packages/liferay-npm-scripts/src/utils/setEnv.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/spawnMultiple.js
+++ b/packages/liferay-npm-scripts/src/utils/spawnMultiple.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/src/utils/spawnSync.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/validateConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/validateConfig.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/src/utils/withTempFile.js
+++ b/packages/liferay-npm-scripts/src/utils/withTempFile.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/support/dedent.js
+++ b/packages/liferay-npm-scripts/support/dedent.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/support/getFixture.js
+++ b/packages/liferay-npm-scripts/support/getFixture.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/support/jest/matchers.js
+++ b/packages/liferay-npm-scripts/support/jest/matchers.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/support/jest/matchers/toLintStyles.js
+++ b/packages/liferay-npm-scripts/support/jest/matchers/toLintStyles.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/config/babel.json.js
+++ b/packages/liferay-npm-scripts/test/config/babel.json.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/index.js
+++ b/packages/liferay-npm-scripts/test/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/Lexer.js
+++ b/packages/liferay-npm-scripts/test/jsp/Lexer.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/ReversibleMap.js
+++ b/packages/liferay-npm-scripts/test/jsp/ReversibleMap.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/dedent.js
+++ b/packages/liferay-npm-scripts/test/jsp/dedent.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/extractJS.js
+++ b/packages/liferay-npm-scripts/test/jsp/extractJS.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/formatJSP.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/getPaddedReplacement.js
+++ b/packages/liferay-npm-scripts/test/jsp/getPaddedReplacement.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/indent.js
+++ b/packages/liferay-npm-scripts/test/jsp/indent.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/isJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/isJSP.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/lex.js
+++ b/packages/liferay-npm-scripts/test/jsp/lex.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/lintJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/lintJSP.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/padLines.js
+++ b/packages/liferay-npm-scripts/test/jsp/padLines.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/restoreTags.js
+++ b/packages/liferay-npm-scripts/test/jsp/restoreTags.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/stripIndents.js
+++ b/packages/liferay-npm-scripts/test/jsp/stripIndents.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/substituteTags.js
+++ b/packages/liferay-npm-scripts/test/jsp/substituteTags.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/tagReplacements.js
+++ b/packages/liferay-npm-scripts/test/jsp/tagReplacements.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/toFiller.js
+++ b/packages/liferay-npm-scripts/test/jsp/toFiller.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/jsp/trim.js
+++ b/packages/liferay-npm-scripts/test/jsp/trim.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/prettier/index.js
+++ b/packages/liferay-npm-scripts/test/prettier/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/scripts/format.js
+++ b/packages/liferay-npm-scripts/test/scripts/format.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/scripts/lint.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-block-comments.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-block-comments.js
@@ -1,6 +1,5 @@
 /**
- * © 2020 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-import-extension.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/no-import-extension.js
@@ -1,6 +1,5 @@
 /**
- * © 2020 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/sort-imports.js
@@ -1,6 +1,5 @@
 /**
- * © 2020 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/trim-comments.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/trim-comments.js
@@ -1,6 +1,5 @@
 /**
- * © 2020 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/scripts/theme.js
+++ b/packages/liferay-npm-scripts/test/scripts/theme.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/scripts/webpack.js
+++ b/packages/liferay-npm-scripts/test/scripts/webpack.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/test/utils/deepMerge.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/expandGlobs.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/filterGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/filterGlobs.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/findRoot.js
+++ b/packages/liferay-npm-scripts/test/utils/findRoot.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js
+++ b/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/permute.js
+++ b/packages/liferay-npm-scripts/test/utils/permute.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/preprocessGlob.js
+++ b/packages/liferay-npm-scripts/test/utils/preprocessGlob.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/spawnMultiple.js
+++ b/packages/liferay-npm-scripts/test/utils/spawnMultiple.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/liferay-npm-scripts/test/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/test/utils/spawnSync.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 


### PR DESCRIPTION
This change is analogous to the one I just made in:

https://github.com/liferay/eslint-config-liferay/pull/151

It updates the license header format to match the latest policy:

https://grow.liferay.com/excellence/Liferay+Outbound+Licensing+Policy

Did this by updating `copyright.js`, running `yarn lint:fix`, and then applying manual fixes to the three `bin` files (because of their use of "shebang" lines, the linter adds a redundant copy of the header). I used a Vim macro to reset the year to its original value (2019) instead of letting the linter update it to 2020.