### PR TITLE
feat(scripts): enforce one SCSS import per line

### DIFF
--- a/packages/liferay-npm-scripts/README.md
+++ b/packages/liferay-npm-scripts/README.md
@@ -210,5 +210,6 @@ The [shared stylelint configuration](./src/config/stylelint.json) lists the rule
 
 -   [`liferay/no-block-comments`](./test/scripts/lint/stylelint/plugins/no-block-comments.js): Disallows block-style comments (`/* ... */`).
 -   [`liferay/no-import-extension`](./test/scripts/lint/stylelint/plugins/no-import-extension.js): Disallows the use of an explicit ".scss" extension in Sass `@import` statements.
+-   [`liferay/single-imports`](./test/scripts/lint/stylelint/plugins/single-imports.js): Requires one `@import` statement per imported resource.
 -   [`liferay/sort-imports`](./test/scripts/lint/stylelint/plugins/sort-imports.js): Requires `@import` statements to be alphabetically sorted (separate groups of imports with a blank line to force manual ordering).
 -   [`liferay/trim-comments`](./test/scripts/lint/stylelint/plugins/trim-comments.js): Trims leading and trailing blank lines from comments.

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/single-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/single-imports.js
@@ -1,0 +1,141 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const stylelint = require('stylelint');
+
+const ruleName = 'liferay/single-imports';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+	single: 'one import rule per resource'
+});
+
+const MATCHERS = Object.entries({
+	DOUBLE_QUOTED_STRING: /^"[^"]*"/,
+	SEPARATOR: /^,/,
+	SINGLE_QUOTED_STRING: /^'[^']*'/,
+	URL: /^url\s*\([^)]*\)/,
+	WHITESPACE: /^\s+/
+});
+
+function tokenize(params) {
+	const tokens = [];
+
+	// Slow but simple iteration through string.
+	let i = 0;
+
+	for (; i < params.length; ) {
+		const remaining = params.slice(i);
+
+		const matched = MATCHERS.some(([kind, matcher]) => {
+			const match = matcher.exec(remaining);
+
+			if (match) {
+				const text = match[0];
+
+				tokens.push({
+					kind,
+					text: match[0]
+				});
+
+				i += text.length;
+
+				return true;
+			}
+		});
+
+		if (!matched) {
+			throw new Error(
+				`Unable to tokenize ${JSON.stringify(params)} at index ${i}`
+			);
+		}
+	}
+
+	return tokens;
+}
+
+module.exports = stylelint.createPlugin(
+	ruleName,
+	(options, secondaryOptions, context) => {
+		return function(root, result) {
+			const validOptions = stylelint.utils.validateOptions(
+				result,
+				ruleName,
+				{
+					actual: options,
+					possible: [true, false]
+				},
+				{
+					actual: secondaryOptions,
+					optional: true,
+					possible: {
+						disableFix: [true, false]
+					}
+				}
+			);
+
+			if (!validOptions || !options) {
+				return;
+			}
+
+			const disableFix = secondaryOptions && secondaryOptions.disableFix;
+
+			const fix = context ? context.fix && !disableFix : false;
+
+			root.walkAtRules('import', rule => {
+				const tokens = tokenize(rule.params);
+
+				const resources = tokens.filter(token => {
+					return (
+						token.kind === 'DOUBLE_QUOTED_STRING' ||
+						token.kind === 'SINGLE_QUOTED_STRING' ||
+						token.kind === 'URL'
+					);
+				});
+
+				if (resources.length > 1) {
+					if (fix) {
+						const replacements = resources.map(resource =>
+							rule.clone({params: resource.text})
+						);
+
+						rule.replaceWith(...replacements);
+
+						// If the original rule had a blank line before it, we
+						// must trim the blank from all but the first
+						// replacement.
+						//
+						// Note that changes to "raws" have to be made after
+						// the `replaceWith` call, or they won't have any
+						// effect.
+						const trailing = /(.*?)(\n+)([ \t]*)$/.exec(
+							rule.raws.before
+						);
+
+						replacements.forEach((resource, i) => {
+							if (i) {
+								if (trailing && trailing[2].length > 1) {
+									resource.raws.before =
+										trailing[1] +
+										trailing[2].slice(1) +
+										trailing[3];
+								}
+							}
+						});
+					} else {
+						stylelint.utils.report({
+							message: messages.single,
+							node: rule,
+							result,
+							ruleName
+						});
+					}
+				}
+			});
+		};
+	}
+);
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/single-imports.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/single-imports.js
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+describe('liferay/single-imports', () => {
+	const plugin = 'liferay/single-imports';
+
+	it('accepts single imports', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'stuff';
+				@import "thing";
+				@import url(example.css);
+				@import url('other.css');
+				@import url("that.css");
+			`,
+			errors: []
+		});
+	});
+
+	it('autofixes an import with multiple resources', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'a', "b", url(c.css), url('d.css'), url("e.css");
+				@import 'f', 'g';
+
+				@import 'first',
+					'second',
+					url('third.css');
+
+				a { color: #000 };
+			`,
+			errors: [],
+			output: `
+				@import 'a';
+				@import "b";
+				@import url(c.css);
+				@import url('d.css');
+				@import url("e.css");
+				@import 'f';
+				@import 'g';
+
+				@import 'first';
+				@import 'second';
+				@import url('third.css');
+
+				a { color: #000 };
+			`
+		});
+	});
+
+	it('autofixes imports in column 0', async () => {
+		// Seeing as indented code like that in the test above isn't going to be
+		// typical in our codebase.
+		await expect(plugin).toLintStyles({
+			code:
+				`@import 'a', "b", url(c.css), url('d.css'), url("e.css");\n` +
+				"@import 'f', 'g';\n" +
+				'\n' +
+				"@import 'first',\n" +
+				"\t'second',\n" +
+				"\turl('third.css');\n" +
+				'\n' +
+				'a { color: #000 };\n',
+			errors: [],
+			output:
+				"@import 'a';\n" +
+				'@import "b";\n' +
+				'@import url(c.css);\n' +
+				"@import url('d.css');\n" +
+				'@import url("e.css");\n' +
+				"@import 'f';\n" +
+				"@import 'g';\n" +
+				'\n' +
+				"@import 'first';\n" +
+				"@import 'second';\n" +
+				"@import url('third.css');\n" +
+				'\n' +
+				'a { color: #000 };\n'
+		});
+	});
+
+	it('can be turned off', async () => {
+		await expect(plugin).toLintStyles({
+			code: `
+				@import 'a', 'b';
+
+				a { color: #000 };
+			`,
+			errors: [],
+			options: false
+		});
+	});
+});


### PR DESCRIPTION
Incorrect:

    @import 'a', "b", url(c.css), url('d.css'), url("e.css");
    @import 'f', 'g';

    @import 'first',
            'second',
            url('third.css');

Correct:

    @import 'a';
    @import "b";
    @import url(c.css);
    @import url('d.css');
    @import url("e.css");
    @import 'f';
    @import 'g';

    @import 'first';
    @import 'second';
    @import url('third.css');

As usual, this is relatively straightforward and only the whitespace-handling is tricky. Take the `@import 'first'...` above, for example: because it is preceded by a blank line, if we just clone it and create three imports for `'first'`, `'second'` and `url('third.css')`, then they will each have a blank line before them, and we don't want that.

So, add some special casing in there to detect blank lines and strip them from the 2nd, 3rd (etc) cloned nodes but keep them on the 1st node. This works for the examples in the tests, but I am not trying to handle "crazy" whitespace like trailing tabs because I would expect that Prettier will generally keep that kind of thing out of the codebase.