### PR TITLE
fix(scripts): avoid linting files under "tmp/"

### DIFF
--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -7,10 +7,10 @@ const clay = require('./dependencies/clay');
 const liferay = require('./dependencies/liferay');
 const metal = require('./dependencies/metal');
 
-const JS_GLOBS = ['{src,test}/**/*.js'];
+const JS_GLOBS = ['/{src,test}/**/*.js'];
 const JSON_GLOBS = ['/*.json'];
-const JSP_GLOBS = ['src/**/*.{jsp,jspf}'];
-const SCSS_GLOBS = ['{src,test}/**/*.scss'];
+const JSP_GLOBS = ['/src/**/*.{jsp,jspf}'];
+const SCSS_GLOBS = ['/{src,test}/**/*.scss'];
 
 const CHECK_AND_FIX_GLOBS = [
 	...JS_GLOBS,


### PR DESCRIPTION
As reported [here](https://github.com/brianchandotcom/liferay-portal/pull/85415#issuecomment-592218863), Brian was seeing a bunch of lint errors in frontend-js-aui-web for files
that weren't even touched by the pull. My analysis is:

-   The files with errors were all under "tmp/".
-   You would not expect these files to be checked because we use [globs targeting files under "src/" and "test/", not "tmp/"](https://github.com/liferay/liferay-npm-tools/blob/eee51cbfa7a0ef6a558dc36f6132ea03f0595c5f/packages/liferay-npm-scripts/src/presets/standard/index.js#L10).
-   Any time you "clean" [the "tmp/" directory will get blown away](https://github.com/liferay/liferay-portal/blob/235df4cb7357fbc4116c0240ffef7e03fb0fd0f0/modules/apps/frontend-js/frontend-js-aui-web/build.gradle#L55).
-   By design, [globs match at any level](https://github.com/liferay/liferay-npm-tools/blob/eee51cbfa7a0ef6a558dc36f6132ea03f0595c5f/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js#L25-L31) (unless explicitly anchored).

All together, that means that when you SF from the top level, the "tmp/" files do not get formatted because the glob we are using [looks like this](https://github.com/liferay/liferay-portal/blob/235df4cb7357fbc4116c0240ffef7e03fb0fd0f0/modules/npmscripts.config.js#L18):

    /{,dxp/}apps/*/*/{src,test}/**/*.{js,scss}

If you run SF from frontend-js-aui-web, however, the "tmp/" files match because our glob looks like this:

    {src,test}/**/*.js

Which in turn means that files like these match (note the "test/*.js" at the end of each path):

-   tmp/META-INF/resources/aui/test/test-coverage.js
-   tmp/META-INF/resources/aui/test/test-debug.js
-   tmp/META-INF/resources/aui/test/test-min.js
-   tmp/META-INF/resources/aui/test/test.js

Two fixes which work:

-   We can either [edit the ignore files in liferay-portal like so](https://gist.github.com/wincent/30e5152d2adf1df9f27c4e1c307f2f38).
-   Or we can do what I am doing in this commit, which is to change the default globs. I think this one is the better solution, even though it means cutting a liferay-npm-scripts release, because it makes the configuration more exactly match our intent: there is nothing special about a directory named "src" or "test" unless it is at a specific location in the tree, so let's be explicit about that.

    And as a rule of thumb, whitelists are preferable to blacklists, because they tend to be more future-proof (the downside of them growing stale is generally more limited).