### PR TITLE
feat(changelog): add support for per-package monorepo changelogs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,16 @@ yarn ci
 # If any checks fail, fix them, submit a PR, and when it is merged,
 # start again. Otherwise...
 
-# Update the version number:
+# Change to the directory of the package you wish to publish:
 cd packages/liferay-npm-scripts
+
+# Update the changelog:
+../liferay-changelog-generator --version=liferay-npm-scripts/v29.0.1
+
+# Review and stage the generated changes:
+git add -p
+
+# Update the version number:
 yarn version --minor # or --major, or --patch
 ```
 
@@ -31,8 +39,10 @@ Running `yarn version` has the following effects:
 
 -   The "preversion" script will run, which effectively runs `yarn ci` again.
 -   The "package.json" gets updated with the new version number.
--   A tagged commit is created.
+-   A tagged commit is created, including the changes to the changelog that you previously staged.
 -   The "postversion" script will run, which automatically does `git push` and performs a `yarn publish`, prompting for confirmation along the way.
+
+Copy the relevant section from the changelog to the corresponding entry on the [releases page](https://github.com/liferay/liferay-npm-tools/releases).
 
 After the release, you can confirm that the packages are correctly listed in the NPM registry:
 
@@ -94,7 +104,10 @@ yarn ci
 # Move into the package's directory
 cd packages/liferay-npm-scripts
 
-# Pick a prerelease version number
+# Update the changelog.
+../liferay-changelog-generator --version=$PACKAGE_NAME/v9.5.0-beta.1
+
+# Bump to the prerelease version number
 yarn version --new-version 9.5.0-beta.1
 
 # Because you are not on the "master" branch,

--- a/packages/liferay-changelog-generator/CHANGELOG.md
+++ b/packages/liferay-changelog-generator/CHANGELOG.md
@@ -2,14 +2,20 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-changelog-generator/v1.1.0...liferay-changelog-generator/v1.2.0)
 
+### :new: Features
+
 -   feat: make changelog output identical to Prettier ([\#230](https://github.com/liferay/liferay-npm-tools/pull/230))
 
 ## [liferay-changelog-generator/v1.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-changelog-generator/v1.1.0) (2019-09-05)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-changelog-generator/v1.0.0...liferay-changelog-generator/v1.1.0)
 
+### :new: Features
+
 -   feat(changelog-generator): add short options ([\#228](https://github.com/liferay/liferay-npm-tools/pull/228))
 
 ## [liferay-changelog-generator/v1.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-changelog-generator/v1.0.0) (2019-09-05)
+
+### :new: Features
 
 -   feat: add liferay-changelog-generator ([\#222](https://github.com/liferay/liferay-npm-tools/pull/222))

--- a/packages/liferay-changelog-generator/CHANGELOG.md
+++ b/packages/liferay-changelog-generator/CHANGELOG.md
@@ -1,0 +1,15 @@
+## [liferay-changelog-generator/v1.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-changelog-generator/v1.2.0) (2019-09-05)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-changelog-generator/v1.1.0...liferay-changelog-generator/v1.2.0)
+
+-   feat: make changelog output identical to Prettier ([\#230](https://github.com/liferay/liferay-npm-tools/pull/230))
+
+## [liferay-changelog-generator/v1.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-changelog-generator/v1.1.0) (2019-09-05)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-changelog-generator/v1.0.0...liferay-changelog-generator/v1.1.0)
+
+-   feat(changelog-generator): add short options ([\#228](https://github.com/liferay/liferay-npm-tools/pull/228))
+
+## [liferay-changelog-generator/v1.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-changelog-generator/v1.0.0) (2019-09-05)
+
+-   feat: add liferay-changelog-generator ([\#222](https://github.com/liferay/liferay-npm-tools/pull/222))

--- a/packages/liferay-changelog-generator/README.md
+++ b/packages/liferay-changelog-generator/README.md
@@ -13,6 +13,11 @@ Operates in two modes:
 
 The idea is that is you ever want to make edits by hand you can, and the way you preserve them over time is by running `git add --patch` to selectively apply newly generated changes while keeping previous manual edits intact.
 
+When run in a monorepo, it can work in two ways:
+
+-   Run from the root of the repo, it produces a single changelog for the entire repo. This is appropriate for projects like [liferay-js-themes-toolkit](https://github.com/liferay/liferay-js-themes-toolkit), where the packages in the repo are always released together.
+-   Run from a `packages/*` subdirectory, it produces a changelog specific to that directory. It is assumed that you have a `.yarnrc` in each package containing a `version-tag-prefix`; this enables the generator to determine when each package was released and produce an accurate changelog. This is appropriate for projects like [liferay-npm-tools](https://github.com/liferay/liferay-npm-tools), where the packages are versioned independently of one another and are not released together.
+
 ## Installation
 
 Either:
@@ -44,8 +49,8 @@ Options:
 -   [eslint-config-liferay](https://github.com/liferay/eslint-config-liferay) ([CHANGELOG](https://github.com/liferay/eslint-config-liferay/blob/master/CHANGELOG.md)).
 -   [liferay-ckeditor](https://github.com/liferay/liferay-ckeditor) ([CHANGELOG](https://github.com/liferay/liferay-ckeditor/blob/master/CHANGELOG.md)).
 -   [liferay-js-themes-toolkit](https://github.com/liferay/liferay-js-themes-toolkit) ([CHANGELOG](https://github.com/liferay/liferay-js-themes-toolkit/blob/master/CHANGELOG.md)).
+-   [liferay-npm-tools](https://github.com/liferay/liferay-npm-tools) (see per-package changelogs in [`packages/*` subdirectories](https://github.com/liferay/liferay-npm-tools/tree/master/packages)).
 
 ## Known limitations
 
 -   Doesn't currently do anything special with Conventional Commit metadata (but it [easily could](https://github.com/liferay/liferay-js-themes-toolkit/issues/258)).
--   Doesn't currently separate changes by package when used in a monorepo.

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -105,6 +105,7 @@ async function getChanges(from, to) {
 		range,
 		'--numstat',
 		'-m',
+		'--first-parent',
 		'--relative',
 		'--pretty=format:%x00%H%x00%B%x00'
 	);

--- a/packages/liferay-jest-junit-reporter/CHANGELOG.md
+++ b/packages/liferay-jest-junit-reporter/CHANGELOG.md
@@ -2,38 +2,74 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v1.1.0-beta.1...liferay-jest-junit-reporter/v1.2.0)
 
--   revert: undo reporter changes related to IFI-780 ([\#387](https://github.com/liferay/liferay-npm-tools/pull/387))
--   refactor(reporter): remove explicit devDependencies ([\#386](https://github.com/liferay/liferay-npm-tools/pull/386))
--   feat(scripts): make preflight checks respect .eslintignore (#354) ([\#357](https://github.com/liferay/liferay-npm-tools/pull/357))
--   chore: remove unnecessary line from .prettierignore ([\#356](https://github.com/liferay/liferay-npm-tools/pull/356))
--   chore: improve license consistency ([\#355](https://github.com/liferay/liferay-npm-tools/pull/355))
+### :boom: Breaking changes
+
 -   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
--   refactor: simplify mock setup ([\#299](https://github.com/liferay/liferay-npm-tools/pull/299))
+-   feat(scripts)!: update eslint-config-liferay v11.1.1 ([\#293](https://github.com/liferay/liferay-npm-tools/pull/293))
+
+### :new: Features
+
+-   feat(scripts): make preflight checks respect .eslintignore (#354) ([\#357](https://github.com/liferay/liferay-npm-tools/pull/357))
+-   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
 -   feat: add "ci" scripts to packages as a convenience ([\#298](https://github.com/liferay/liferay-npm-tools/pull/298))
 -   feat(scripts)!: update eslint-config-liferay v11.1.1 ([\#293](https://github.com/liferay/liferay-npm-tools/pull/293))
 -   feat: add reminder to publish liferay-npm-scripts ([\#276](https://github.com/liferay/liferay-npm-tools/pull/276))
+
+### :wrench: Bug fixes
+
 -   fix: make release commit messages satisfy Semantic Pull Requests bot ([\#264](https://github.com/liferay/liferay-npm-tools/pull/264))
 -   fix: correct bad homepage links in package.json files ([\#254](https://github.com/liferay/liferay-npm-tools/pull/254))
+
+### :house: Chores
+
+-   chore: remove unnecessary line from .prettierignore ([\#356](https://github.com/liferay/liferay-npm-tools/pull/356))
+-   chore: improve license consistency ([\#355](https://github.com/liferay/liferay-npm-tools/pull/355))
+
+### :woman_juggling: Refactoring
+
+-   refactor(reporter): remove explicit devDependencies ([\#386](https://github.com/liferay/liferay-npm-tools/pull/386))
+-   refactor: simplify mock setup ([\#299](https://github.com/liferay/liferay-npm-tools/pull/299))
+
+### :leftwards_arrow_with_hook: Reverts
+
+-   revert: undo reporter changes related to IFI-780 ([\#387](https://github.com/liferay/liferay-npm-tools/pull/387))
 
 ## [liferay-jest-junit-reporter/v1.1.0-beta.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v1.1.0-beta.1) (2019-08-19)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v1.0.1...liferay-jest-junit-reporter/v1.1.0-beta.1)
 
--   feat(reporter): include module name at end of classname (#136) ([\#200](https://github.com/liferay/liferay-npm-tools/pull/200))
--   fix: update/remove bad links and add missing links in package.json files ([\#199](https://github.com/liferay/liferay-npm-tools/pull/199))
+### :boom: Breaking changes
+
 -   chore!: update eslint-config-liferay to v6.0.0 ([\#195](https://github.com/liferay/liferay-npm-tools/pull/195))
+
+### :new: Features
+
+-   feat(reporter): include module name at end of classname (#136) ([\#200](https://github.com/liferay/liferay-npm-tools/pull/200))
 -   feat: add "postversion" scripts to automate publishing ([\#175](https://github.com/liferay/liferay-npm-tools/pull/175))
--   fix(reporter): correct an innocuous typo ([\#140](https://github.com/liferay/liferay-npm-tools/pull/140))
--   chore(scripts): update eslint-config-liferay dep to v4.1.0 ([\#132](https://github.com/liferay/liferay-npm-tools/pull/132))
--   refactor: rename files to match naming conventions (#107) ([\#115](https://github.com/liferay/liferay-npm-tools/pull/115))
--   chore: keep Markdown and JSON files formatted by Prettier ([\#100](https://github.com/liferay/liferay-npm-tools/pull/100))
 -   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
 -   feat: add CONTRIBUTING.md (#48) ([\#49](https://github.com/liferay/liferay-npm-tools/pull/49))
+
+### :wrench: Bug fixes
+
+-   fix: update/remove bad links and add missing links in package.json files ([\#199](https://github.com/liferay/liferay-npm-tools/pull/199))
+-   fix(reporter): correct an innocuous typo ([\#140](https://github.com/liferay/liferay-npm-tools/pull/140))
+
+### :house: Chores
+
+-   chore!: update eslint-config-liferay to v6.0.0 ([\#195](https://github.com/liferay/liferay-npm-tools/pull/195))
+-   chore(scripts): update eslint-config-liferay dep to v4.1.0 ([\#132](https://github.com/liferay/liferay-npm-tools/pull/132))
+-   chore: keep Markdown and JSON files formatted by Prettier ([\#100](https://github.com/liferay/liferay-npm-tools/pull/100))
 -   chore: separate formatting and linting scripts ([\#41](https://github.com/liferay/liferay-npm-tools/pull/41))
+
+### :woman_juggling: Refactoring
+
+-   refactor: rename files to match naming conventions (#107) ([\#115](https://github.com/liferay/liferay-npm-tools/pull/115))
 
 ## [liferay-jest-junit-reporter/v1.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v1.0.1) (2019-03-27)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v1.0.0...liferay-jest-junit-reporter/v1.0.1)
+
+### :package: Miscellaneous
 
 -   Remove Lerna, add Yarn workspaces, update Jest and Babel ([\#43](https://github.com/liferay/liferay-npm-tools/pull/43))
 -   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))

--- a/packages/liferay-jest-junit-reporter/CHANGELOG.md
+++ b/packages/liferay-jest-junit-reporter/CHANGELOG.md
@@ -1,0 +1,53 @@
+## [liferay-jest-junit-reporter/v1.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v1.2.0) (2020-02-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v1.1.0-beta.1...liferay-jest-junit-reporter/v1.2.0)
+
+-   revert: undo reporter changes related to IFI-780 ([\#387](https://github.com/liferay/liferay-npm-tools/pull/387))
+-   refactor(reporter): remove explicit devDependencies ([\#386](https://github.com/liferay/liferay-npm-tools/pull/386))
+-   feat(scripts): make preflight checks respect .eslintignore (#354) ([\#357](https://github.com/liferay/liferay-npm-tools/pull/357))
+-   chore: remove unnecessary line from .prettierignore ([\#356](https://github.com/liferay/liferay-npm-tools/pull/356))
+-   chore: improve license consistency ([\#355](https://github.com/liferay/liferay-npm-tools/pull/355))
+-   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
+-   refactor: simplify mock setup ([\#299](https://github.com/liferay/liferay-npm-tools/pull/299))
+-   feat: add "ci" scripts to packages as a convenience ([\#298](https://github.com/liferay/liferay-npm-tools/pull/298))
+-   feat(scripts)!: update eslint-config-liferay v11.1.1 ([\#293](https://github.com/liferay/liferay-npm-tools/pull/293))
+-   feat: add reminder to publish liferay-npm-scripts ([\#276](https://github.com/liferay/liferay-npm-tools/pull/276))
+-   fix: make release commit messages satisfy Semantic Pull Requests bot ([\#264](https://github.com/liferay/liferay-npm-tools/pull/264))
+-   fix: correct bad homepage links in package.json files ([\#254](https://github.com/liferay/liferay-npm-tools/pull/254))
+
+## [liferay-jest-junit-reporter/v1.1.0-beta.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v1.1.0-beta.1) (2019-08-19)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v1.0.1...liferay-jest-junit-reporter/v1.1.0-beta.1)
+
+-   feat(reporter): include module name at end of classname (#136) ([\#200](https://github.com/liferay/liferay-npm-tools/pull/200))
+-   fix: update/remove bad links and add missing links in package.json files ([\#199](https://github.com/liferay/liferay-npm-tools/pull/199))
+-   chore!: update eslint-config-liferay to v6.0.0 ([\#195](https://github.com/liferay/liferay-npm-tools/pull/195))
+-   feat: add "postversion" scripts to automate publishing ([\#175](https://github.com/liferay/liferay-npm-tools/pull/175))
+-   fix(reporter): correct an innocuous typo ([\#140](https://github.com/liferay/liferay-npm-tools/pull/140))
+-   chore(scripts): update eslint-config-liferay dep to v4.1.0 ([\#132](https://github.com/liferay/liferay-npm-tools/pull/132))
+-   refactor: rename files to match naming conventions (#107) ([\#115](https://github.com/liferay/liferay-npm-tools/pull/115))
+-   chore: keep Markdown and JSON files formatted by Prettier ([\#100](https://github.com/liferay/liferay-npm-tools/pull/100))
+-   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
+-   feat: add CONTRIBUTING.md (#48) ([\#49](https://github.com/liferay/liferay-npm-tools/pull/49))
+-   chore: separate formatting and linting scripts ([\#41](https://github.com/liferay/liferay-npm-tools/pull/41))
+
+## [liferay-jest-junit-reporter/v1.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v1.0.1) (2019-03-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v1.0.0...liferay-jest-junit-reporter/v1.0.1)
+
+-   Remove Lerna, add Yarn workspaces, update Jest and Babel ([\#43](https://github.com/liferay/liferay-npm-tools/pull/43))
+-   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
+
+## [liferay-jest-junit-reporter/v1.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v1.0.0) (2019-01-22)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v0.0.4...liferay-jest-junit-reporter/v1.0.0)
+
+## [liferay-jest-junit-reporter/v0.0.4](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v0.0.4) (2018-07-12)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v0.0.3...liferay-jest-junit-reporter/v0.0.4)
+
+## [liferay-jest-junit-reporter/v0.0.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v0.0.3) (2017-09-01)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-jest-junit-reporter/v0.0.2...liferay-jest-junit-reporter/v0.0.3)
+
+## [liferay-jest-junit-reporter/v0.0.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v0.0.2) (2017-09-01)

--- a/packages/liferay-jest-junit-reporter/CHANGELOG.md
+++ b/packages/liferay-jest-junit-reporter/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### :new: Features
 
--   feat(scripts): make preflight checks respect .eslintignore (#354) ([\#357](https://github.com/liferay/liferay-npm-tools/pull/357))
 -   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
 -   feat: add "ci" scripts to packages as a convenience ([\#298](https://github.com/liferay/liferay-npm-tools/pull/298))
 -   feat(scripts)!: update eslint-config-liferay v11.1.1 ([\#293](https://github.com/liferay/liferay-npm-tools/pull/293))
@@ -22,7 +21,6 @@
 
 ### :house: Chores
 
--   chore: remove unnecessary line from .prettierignore ([\#356](https://github.com/liferay/liferay-npm-tools/pull/356))
 -   chore: improve license consistency ([\#355](https://github.com/liferay/liferay-npm-tools/pull/355))
 
 ### :woman_juggling: Refactoring
@@ -47,7 +45,6 @@
 -   feat(reporter): include module name at end of classname (#136) ([\#200](https://github.com/liferay/liferay-npm-tools/pull/200))
 -   feat: add "postversion" scripts to automate publishing ([\#175](https://github.com/liferay/liferay-npm-tools/pull/175))
 -   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
--   feat: add CONTRIBUTING.md (#48) ([\#49](https://github.com/liferay/liferay-npm-tools/pull/49))
 
 ### :wrench: Bug fixes
 
@@ -72,7 +69,6 @@
 ### :package: Miscellaneous
 
 -   Remove Lerna, add Yarn workspaces, update Jest and Babel ([\#43](https://github.com/liferay/liferay-npm-tools/pull/43))
--   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
 
 ## [liferay-jest-junit-reporter/v1.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-jest-junit-reporter/v1.0.0) (2019-01-22)
 

--- a/packages/liferay-js-publish/CHANGELOG.md
+++ b/packages/liferay-js-publish/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-js-publish/v1.0.0...liferay-js-publish/v1.0.1)
 
+### :wrench: Bug fixes
+
 -   fix(publish): loosen upstream remote regex ([\#271](https://github.com/liferay/liferay-npm-tools/pull/271))
 
 ## [liferay-js-publish/v1.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-js-publish/v1.0.0) (2019-09-23)

--- a/packages/liferay-js-publish/CHANGELOG.md
+++ b/packages/liferay-js-publish/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [liferay-js-publish/v1.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-js-publish/v1.0.1) (2019-09-23)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-js-publish/v1.0.0...liferay-js-publish/v1.0.1)
+
+-   fix(publish): loosen upstream remote regex ([\#271](https://github.com/liferay/liferay-npm-tools/pull/271))
+
+## [liferay-js-publish/v1.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-js-publish/v1.0.0) (2019-09-23)

--- a/packages/liferay-npm-bundler-preset-liferay-dev/CHANGELOG.md
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/CHANGELOG.md
@@ -107,10 +107,6 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.10.0...liferay-npm-bundler-preset-liferay-dev/v1.11.0)
 
-### :new: Features
-
--   feat: allow for compound patterns in extensions in globs ([\#247](https://github.com/liferay/liferay-npm-tools/pull/247))
-
 ## [liferay-npm-bundler-preset-liferay-dev/v1.10.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.10.0) (2019-09-11)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.9.0...liferay-npm-bundler-preset-liferay-dev/v1.10.0)
@@ -221,10 +217,6 @@
 
 -   chore: use bundler version 2.7.1 ([\#58](https://github.com/liferay/liferay-npm-tools/pull/58))
 
-### :package: Miscellaneous
-
--   Just putting "develop" and "master" back into a fast-forwardable state
-
 ## [liferay-npm-bundler-preset-liferay-dev/v1.1.5](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.5) (2019-03-27)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.4...liferay-npm-bundler-preset-liferay-dev/v1.1.5)
@@ -240,12 +232,10 @@
 ### :package: Miscellaneous
 
 -   Remove Lerna, add Yarn workspaces, update Jest and Babel ([\#43](https://github.com/liferay/liferay-npm-tools/pull/43))
--   Fixes #25 | Update clay related dependencies to v2.9.0 ([\#26](https://github.com/liferay/liferay-npm-tools/pull/26))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.1.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.3) (2019-02-28)
 
 ### :package: Miscellaneous
 
 -   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
--   Fixes #15 - Resolves dependencies paths to support hoisted packages in workspace settings ([\#16](https://github.com/liferay/liferay-npm-tools/pull/16))
 -   Fixes #12 | Add clay-chart to npmbundler preset ([\#13](https://github.com/liferay/liferay-npm-tools/pull/13))

--- a/packages/liferay-npm-bundler-preset-liferay-dev/CHANGELOG.md
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/CHANGELOG.md
@@ -1,0 +1,176 @@
+## [liferay-npm-bundler-preset-liferay-dev/v4.2.5](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.2.5) (2020-02-14)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.2.4...liferay-npm-bundler-preset-liferay-dev/v4.2.5)
+
+## [liferay-npm-bundler-preset-liferay-dev/v4.2.4](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.2.4) (2020-02-13)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.2.3...liferay-npm-bundler-preset-liferay-dev/v4.2.4)
+
+-   chore(preset): update bundler dependencies to v2.18.1 ([\#378](https://github.com/liferay/liferay-npm-tools/pull/378))
+
+## [liferay-npm-bundler-preset-liferay-dev/v4.2.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.2.3) (2020-02-11)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.2.2...liferay-npm-bundler-preset-liferay-dev/v4.2.3)
+
+-   chore(preset): update to bundler v2.18.0 ([\#374](https://github.com/liferay/liferay-npm-tools/pull/374))
+
+## [liferay-npm-bundler-preset-liferay-dev/v4.2.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.2.2) (2020-01-15)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.2.1...liferay-npm-bundler-preset-liferay-dev/v4.2.2)
+
+-   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
+
+## [liferay-npm-bundler-preset-liferay-dev/v4.2.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.2.1) (2019-12-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.2.0...liferay-npm-bundler-preset-liferay-dev/v4.2.1)
+
+-   chore!: update eslint-config-liferay to v14.0.0 ([\#319](https://github.com/liferay/liferay-npm-tools/pull/319))
+
+## [liferay-npm-bundler-preset-liferay-dev/v4.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.2.0) (2019-12-04)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.1.0...liferay-npm-bundler-preset-liferay-dev/v4.2.0)
+
+## [liferay-npm-bundler-preset-liferay-dev/v4.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.1.0) (2019-11-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.0.0...liferay-npm-bundler-preset-liferay-dev/v4.1.0)
+
+-   feat(preset): add frontend-js-components-web to the preset ([\#305](https://github.com/liferay/liferay-npm-tools/pull/305))
+-   feat: add "ci" scripts to packages as a convenience ([\#298](https://github.com/liferay/liferay-npm-tools/pull/298))
+
+## [liferay-npm-bundler-preset-liferay-dev/v4.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.0.0) (2019-10-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v2.1.0...liferay-npm-bundler-preset-liferay-dev/v4.0.0)
+
+## [liferay-npm-bundler-preset-liferay-dev/v2.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v2.1.0) (2019-10-10)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v2.0.1...liferay-npm-bundler-preset-liferay-dev/v2.1.0)
+
+-   feat(preset-liferay-dev): updates supported @clayui imports versions to 3.0.0 ([\#289](https://github.com/liferay/liferay-npm-tools/pull/289))
+
+## [liferay-npm-bundler-preset-liferay-dev/v2.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v2.0.1) (2019-10-09)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v2.0.0...liferay-npm-bundler-preset-liferay-dev/v2.0.1)
+
+-   feat: add reminder to publish liferay-npm-scripts ([\#276](https://github.com/liferay/liferay-npm-tools/pull/276))
+
+## [liferay-npm-bundler-preset-liferay-dev/v2.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v2.0.0) (2019-09-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.12.0...liferay-npm-bundler-preset-liferay-dev/v2.0.0)
+
+-   chore(scripts): send build output to "build" instead of "classes" (#272) ([\#273](https://github.com/liferay/liferay-npm-tools/pull/273))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.12.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.12.0) (2019-09-20)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.11.1...liferay-npm-bundler-preset-liferay-dev/v1.12.0)
+
+-   feat: updates initial clay v3.0.0 imports ([\#266](https://github.com/liferay/liferay-npm-tools/pull/266))
+-   fix: make release commit messages satisfy Semantic Pull Requests bot ([\#264](https://github.com/liferay/liferay-npm-tools/pull/264))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.11.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.11.1) (2019-09-18)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.11.0...liferay-npm-bundler-preset-liferay-dev/v1.11.1)
+
+-   fix: correct bad homepage links in package.json files ([\#254](https://github.com/liferay/liferay-npm-tools/pull/254))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.11.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.11.0) (2019-09-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.10.0...liferay-npm-bundler-preset-liferay-dev/v1.11.0)
+
+-   feat: allow for compound patterns in extensions in globs ([\#247](https://github.com/liferay/liferay-npm-tools/pull/247))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.10.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.10.0) (2019-09-11)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.9.0...liferay-npm-bundler-preset-liferay-dev/v1.10.0)
+
+-   feat: Add support for bundler css-loaders ([\#241](https://github.com/liferay/liferay-npm-tools/pull/241))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.9.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.9.0) (2019-09-10)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.8.0...liferay-npm-bundler-preset-liferay-dev/v1.9.0)
+
+-   feat: updates clay v3 versions to alpha.1 ([\#237](https://github.com/liferay/liferay-npm-tools/pull/237))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.8.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.8.0) (2019-08-28)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.7.0...liferay-npm-bundler-preset-liferay-dev/v1.8.0)
+
+-   feat: updates @clayui imports to milestone.3 and adds new packages management-toolbar, slider and tabs ([\#212](https://github.com/liferay/liferay-npm-tools/pull/212))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.7.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.7.0) (2019-08-20)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.6.0...liferay-npm-bundler-preset-liferay-dev/v1.7.0)
+
+-   feat(preset): add "/" import config for frontend-js-react-web ([\#202](https://github.com/liferay/liferay-npm-tools/pull/202))
+-   fix: update/remove bad links and add missing links in package.json files ([\#199](https://github.com/liferay/liferay-npm-tools/pull/199))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.6.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.6.0) (2019-08-14)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.5.1...liferay-npm-bundler-preset-liferay-dev/v1.6.0)
+
+-   chore: update liferay-npm-bundler-preset-liferay-dev dependencies ([\#196](https://github.com/liferay/liferay-npm-tools/pull/196))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.5.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.5.1) (2019-08-08)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.5.0...liferay-npm-bundler-preset-liferay-dev/v1.5.1)
+
+-   fix: adds missing clay and frontend-js-web dependencies configuration ([\#189](https://github.com/liferay/liferay-npm-tools/pull/189))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.5.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.5.0) (2019-07-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.4.0...liferay-npm-bundler-preset-liferay-dev/v1.5.0)
+
+-   chore: update clay3 versions in config.json ([\#185](https://github.com/liferay/liferay-npm-tools/pull/185))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.4.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.4.0) (2019-07-25)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.3.0...liferay-npm-bundler-preset-liferay-dev/v1.4.0)
+
+-   chore: update dependencies ([\#182](https://github.com/liferay/liferay-npm-tools/pull/182))
+-   feat: add "postversion" scripts to automate publishing ([\#175](https://github.com/liferay/liferay-npm-tools/pull/175))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.3.0) (2019-07-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.2.0...liferay-npm-bundler-preset-liferay-dev/v1.3.0)
+
+-   chore(preset): use loose version requirements to facilitate backporting ([\#173](https://github.com/liferay/liferay-npm-tools/pull/173))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.2.0) (2019-06-24)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.7...liferay-npm-bundler-preset-liferay-dev/v1.2.0)
+
+-   feat(preset): add shared @clayui and react packages ([\#127](https://github.com/liferay/liferay-npm-tools/pull/127))
+-   chore: keep Markdown and JSON files formatted by Prettier ([\#100](https://github.com/liferay/liferay-npm-tools/pull/100))
+-   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
+-   feat: add top-level shortcut to run all tests (#67) ([\#68](https://github.com/liferay/liferay-npm-tools/pull/68))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.1.7](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.7) (2019-04-02)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.6...liferay-npm-bundler-preset-liferay-dev/v1.1.7)
+
+-   chore: adds exclusions of build dependencies ([\#60](https://github.com/liferay/liferay-npm-tools/pull/60))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.1.6](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.6) (2019-04-01)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.5...liferay-npm-bundler-preset-liferay-dev/v1.1.6)
+
+-   chore: use bundler version 2.7.1 ([\#58](https://github.com/liferay/liferay-npm-tools/pull/58))
+-   Just putting "develop" and "master" back into a fast-forwardable state
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.1.5](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.5) (2019-03-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.4...liferay-npm-bundler-preset-liferay-dev/v1.1.5)
+
+-   chore: Update dependencies on liferay-npm-build-tools packages (#42) ([\#46](https://github.com/liferay/liferay-npm-tools/pull/46))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.1.4](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.4) (2019-03-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.3...liferay-npm-bundler-preset-liferay-dev/v1.1.4)
+
+-   Remove Lerna, add Yarn workspaces, update Jest and Babel ([\#43](https://github.com/liferay/liferay-npm-tools/pull/43))
+-   Fixes #25 | Update clay related dependencies to v2.9.0 ([\#26](https://github.com/liferay/liferay-npm-tools/pull/26))
+
+## [liferay-npm-bundler-preset-liferay-dev/v1.1.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.3) (2019-02-28)
+
+-   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
+-   Fixes #15 - Resolves dependencies paths to support hoisted packages in workspace settings ([\#16](https://github.com/liferay/liferay-npm-tools/pull/16))
+-   Fixes #12 | Add clay-chart to npmbundler preset ([\#13](https://github.com/liferay/liferay-npm-tools/pull/13))

--- a/packages/liferay-npm-bundler-preset-liferay-dev/CHANGELOG.md
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/CHANGELOG.md
@@ -6,11 +6,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.2.3...liferay-npm-bundler-preset-liferay-dev/v4.2.4)
 
+### :house: Chores
+
 -   chore(preset): update bundler dependencies to v2.18.1 ([\#378](https://github.com/liferay/liferay-npm-tools/pull/378))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v4.2.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.2.3) (2020-02-11)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.2.2...liferay-npm-bundler-preset-liferay-dev/v4.2.3)
+
+### :house: Chores
 
 -   chore(preset): update to bundler v2.18.0 ([\#374](https://github.com/liferay/liferay-npm-tools/pull/374))
 
@@ -18,11 +22,23 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.2.1...liferay-npm-bundler-preset-liferay-dev/v4.2.2)
 
+### :boom: Breaking changes
+
+-   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
+
+### :new: Features
+
 -   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v4.2.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.2.1) (2019-12-17)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.2.0...liferay-npm-bundler-preset-liferay-dev/v4.2.1)
+
+### :boom: Breaking changes
+
+-   chore!: update eslint-config-liferay to v14.0.0 ([\#319](https://github.com/liferay/liferay-npm-tools/pull/319))
+
+### :house: Chores
 
 -   chore!: update eslint-config-liferay to v14.0.0 ([\#319](https://github.com/liferay/liferay-npm-tools/pull/319))
 
@@ -33,6 +49,8 @@
 ## [liferay-npm-bundler-preset-liferay-dev/v4.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v4.1.0) (2019-11-27)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v4.0.0...liferay-npm-bundler-preset-liferay-dev/v4.1.0)
+
+### :new: Features
 
 -   feat(preset): add frontend-js-components-web to the preset ([\#305](https://github.com/liferay/liferay-npm-tools/pull/305))
 -   feat: add "ci" scripts to packages as a convenience ([\#298](https://github.com/liferay/liferay-npm-tools/pull/298))
@@ -45,11 +63,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v2.0.1...liferay-npm-bundler-preset-liferay-dev/v2.1.0)
 
+### :new: Features
+
 -   feat(preset-liferay-dev): updates supported @clayui imports versions to 3.0.0 ([\#289](https://github.com/liferay/liferay-npm-tools/pull/289))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v2.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v2.0.1) (2019-10-09)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v2.0.0...liferay-npm-bundler-preset-liferay-dev/v2.0.1)
+
+### :new: Features
 
 -   feat: add reminder to publish liferay-npm-scripts ([\#276](https://github.com/liferay/liferay-npm-tools/pull/276))
 
@@ -57,18 +79,27 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.12.0...liferay-npm-bundler-preset-liferay-dev/v2.0.0)
 
+### :house: Chores
+
 -   chore(scripts): send build output to "build" instead of "classes" (#272) ([\#273](https://github.com/liferay/liferay-npm-tools/pull/273))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.12.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.12.0) (2019-09-20)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.11.1...liferay-npm-bundler-preset-liferay-dev/v1.12.0)
 
+### :new: Features
+
 -   feat: updates initial clay v3.0.0 imports ([\#266](https://github.com/liferay/liferay-npm-tools/pull/266))
+
+### :wrench: Bug fixes
+
 -   fix: make release commit messages satisfy Semantic Pull Requests bot ([\#264](https://github.com/liferay/liferay-npm-tools/pull/264))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.11.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.11.1) (2019-09-18)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.11.0...liferay-npm-bundler-preset-liferay-dev/v1.11.1)
+
+### :wrench: Bug fixes
 
 -   fix: correct bad homepage links in package.json files ([\#254](https://github.com/liferay/liferay-npm-tools/pull/254))
 
@@ -76,11 +107,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.10.0...liferay-npm-bundler-preset-liferay-dev/v1.11.0)
 
+### :new: Features
+
 -   feat: allow for compound patterns in extensions in globs ([\#247](https://github.com/liferay/liferay-npm-tools/pull/247))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.10.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.10.0) (2019-09-11)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.9.0...liferay-npm-bundler-preset-liferay-dev/v1.10.0)
+
+### :new: Features
 
 -   feat: Add support for bundler css-loaders ([\#241](https://github.com/liferay/liferay-npm-tools/pull/241))
 
@@ -88,11 +123,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.8.0...liferay-npm-bundler-preset-liferay-dev/v1.9.0)
 
+### :new: Features
+
 -   feat: updates clay v3 versions to alpha.1 ([\#237](https://github.com/liferay/liferay-npm-tools/pull/237))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.8.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.8.0) (2019-08-28)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.7.0...liferay-npm-bundler-preset-liferay-dev/v1.8.0)
+
+### :new: Features
 
 -   feat: updates @clayui imports to milestone.3 and adds new packages management-toolbar, slider and tabs ([\#212](https://github.com/liferay/liferay-npm-tools/pull/212))
 
@@ -100,12 +139,19 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.6.0...liferay-npm-bundler-preset-liferay-dev/v1.7.0)
 
+### :new: Features
+
 -   feat(preset): add "/" import config for frontend-js-react-web ([\#202](https://github.com/liferay/liferay-npm-tools/pull/202))
+
+### :wrench: Bug fixes
+
 -   fix: update/remove bad links and add missing links in package.json files ([\#199](https://github.com/liferay/liferay-npm-tools/pull/199))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.6.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.6.0) (2019-08-14)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.5.1...liferay-npm-bundler-preset-liferay-dev/v1.6.0)
+
+### :house: Chores
 
 -   chore: update liferay-npm-bundler-preset-liferay-dev dependencies ([\#196](https://github.com/liferay/liferay-npm-tools/pull/196))
 
@@ -113,11 +159,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.5.0...liferay-npm-bundler-preset-liferay-dev/v1.5.1)
 
+### :wrench: Bug fixes
+
 -   fix: adds missing clay and frontend-js-web dependencies configuration ([\#189](https://github.com/liferay/liferay-npm-tools/pull/189))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.5.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.5.0) (2019-07-26)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.4.0...liferay-npm-bundler-preset-liferay-dev/v1.5.0)
+
+### :house: Chores
 
 -   chore: update clay3 versions in config.json ([\#185](https://github.com/liferay/liferay-npm-tools/pull/185))
 
@@ -125,12 +175,19 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.3.0...liferay-npm-bundler-preset-liferay-dev/v1.4.0)
 
--   chore: update dependencies ([\#182](https://github.com/liferay/liferay-npm-tools/pull/182))
+### :new: Features
+
 -   feat: add "postversion" scripts to automate publishing ([\#175](https://github.com/liferay/liferay-npm-tools/pull/175))
+
+### :house: Chores
+
+-   chore: update dependencies ([\#182](https://github.com/liferay/liferay-npm-tools/pull/182))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.3.0) (2019-07-17)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.2.0...liferay-npm-bundler-preset-liferay-dev/v1.3.0)
+
+### :house: Chores
 
 -   chore(preset): use loose version requirements to facilitate backporting ([\#173](https://github.com/liferay/liferay-npm-tools/pull/173))
 
@@ -138,14 +195,21 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.7...liferay-npm-bundler-preset-liferay-dev/v1.2.0)
 
+### :new: Features
+
 -   feat(preset): add shared @clayui and react packages ([\#127](https://github.com/liferay/liferay-npm-tools/pull/127))
--   chore: keep Markdown and JSON files formatted by Prettier ([\#100](https://github.com/liferay/liferay-npm-tools/pull/100))
 -   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
 -   feat: add top-level shortcut to run all tests (#67) ([\#68](https://github.com/liferay/liferay-npm-tools/pull/68))
+
+### :house: Chores
+
+-   chore: keep Markdown and JSON files formatted by Prettier ([\#100](https://github.com/liferay/liferay-npm-tools/pull/100))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.1.7](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.7) (2019-04-02)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.6...liferay-npm-bundler-preset-liferay-dev/v1.1.7)
+
+### :house: Chores
 
 -   chore: adds exclusions of build dependencies ([\#60](https://github.com/liferay/liferay-npm-tools/pull/60))
 
@@ -153,12 +217,19 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.5...liferay-npm-bundler-preset-liferay-dev/v1.1.6)
 
+### :house: Chores
+
 -   chore: use bundler version 2.7.1 ([\#58](https://github.com/liferay/liferay-npm-tools/pull/58))
+
+### :package: Miscellaneous
+
 -   Just putting "develop" and "master" back into a fast-forwardable state
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.1.5](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.5) (2019-03-27)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.4...liferay-npm-bundler-preset-liferay-dev/v1.1.5)
+
+### :house: Chores
 
 -   chore: Update dependencies on liferay-npm-build-tools packages (#42) ([\#46](https://github.com/liferay/liferay-npm-tools/pull/46))
 
@@ -166,10 +237,14 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-bundler-preset-liferay-dev/v1.1.3...liferay-npm-bundler-preset-liferay-dev/v1.1.4)
 
+### :package: Miscellaneous
+
 -   Remove Lerna, add Yarn workspaces, update Jest and Babel ([\#43](https://github.com/liferay/liferay-npm-tools/pull/43))
 -   Fixes #25 | Update clay related dependencies to v2.9.0 ([\#26](https://github.com/liferay/liferay-npm-tools/pull/26))
 
 ## [liferay-npm-bundler-preset-liferay-dev/v1.1.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-bundler-preset-liferay-dev/v1.1.3) (2019-02-28)
+
+### :package: Miscellaneous
 
 -   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
 -   Fixes #15 - Resolves dependencies paths to support hoisted packages in workspace settings ([\#16](https://github.com/liferay/liferay-npm-tools/pull/16))

--- a/packages/liferay-npm-scripts/CHANGELOG.md
+++ b/packages/liferay-npm-scripts/CHANGELOG.md
@@ -307,7 +307,6 @@
 ### :new: Features
 
 -   feat: add "ci" scripts to packages as a convenience ([\#298](https://github.com/liferay/liferay-npm-tools/pull/298))
--   feat: prevent accidental use of top-level `yarn version` ([\#297](https://github.com/liferay/liferay-npm-tools/pull/297))
 
 ### :house: Chores
 
@@ -502,11 +501,6 @@
 ### :new: Features
 
 -   feat!: updates eslint-config-liferay to v9.0.0 ([\#236](https://github.com/liferay/liferay-npm-tools/pull/236))
--   feat: add liferay-changelog-generator ([\#222](https://github.com/liferay/liferay-npm-tools/pull/222))
-
-### :book: Documentation
-
--   docs: fix typo in CONTRIBUTING.md ([\#224](https://github.com/liferay/liferay-npm-tools/pull/224))
 
 ### :house: Chores
 
@@ -564,10 +558,6 @@
 ## [liferay-npm-scripts/v7.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v7.2.0) (2019-08-20)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v7.1.0...liferay-npm-scripts/v7.2.0)
-
-### :new: Features
-
--   feat(reporter): include module name at end of classname (#136) ([\#200](https://github.com/liferay/liferay-npm-tools/pull/200))
 
 ### :house: Chores
 
@@ -979,7 +969,6 @@
 
 -   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
 -   feat: look for Sass dependency in top-level node_modules (#72) ([\#73](https://github.com/liferay/liferay-npm-tools/pull/73))
--   feat: add top-level shortcut to run all tests (#67) ([\#68](https://github.com/liferay/liferay-npm-tools/pull/68))
 
 ## [liferay-npm-scripts/v1.4.13](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.13) (2019-04-05)
 
@@ -1009,10 +998,6 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.9...liferay-npm-scripts/v1.4.10)
 
-### :new: Features
-
--   feat: add CONTRIBUTING.md (#48) ([\#49](https://github.com/liferay/liferay-npm-tools/pull/49))
-
 ### :wrench: Bug fixes
 
 -   fix: jest-haste-map warnings about module naming collisions (#53) ([\#54](https://github.com/liferay/liferay-npm-tools/pull/54))
@@ -1022,10 +1007,6 @@
 
 -   chore: use bundler version 2.7.1 ([\#58](https://github.com/liferay/liferay-npm-tools/pull/58))
 -   chore: separate formatting and linting scripts ([\#41](https://github.com/liferay/liferay-npm-tools/pull/41))
-
-### :package: Miscellaneous
-
--   Just putting "develop" and "master" back into a fast-forwardable state
 
 ## [liferay-npm-scripts/v1.4.9](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.9) (2019-03-27)
 

--- a/packages/liferay-npm-scripts/CHANGELOG.md
+++ b/packages/liferay-npm-scripts/CHANGELOG.md
@@ -12,7 +12,6 @@
 -   feat(scripts): enforce one SCSS import per line ([\#395](https://github.com/liferay/liferay-npm-tools/pull/395))
 -   chore: update for compliance with current Outbound Licensing Policy ([\#394](https://github.com/liferay/liferay-npm-tools/pull/394))
 -   fix(scripts): avoid false positives involving no-unused-vars ([\#392](https://github.com/liferay/liferay-npm-tools/pull/392))
--   fix(scripts): avoid false positives involving no-unused-vars ([\#392](https://github.com/liferay/liferay-npm-tools/pull/392))
 -   feat(scripts): disallow explicit .scss extension in imports ([\#393](https://github.com/liferay/liferay-npm-tools/pull/393))
 
 ## [liferay-npm-scripts/v27.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v27.0.0) (2020-02-20)
@@ -56,7 +55,6 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v23.1.0...liferay-npm-scripts/v24.0.0)
 
--   chore(scripts)!: update to eslint-config-liferay v19.0.0 ([\#371](https://github.com/liferay/liferay-npm-tools/pull/371))
 -   chore(scripts)!: update to eslint-config-liferay v19.0.0 ([\#371](https://github.com/liferay/liferay-npm-tools/pull/371))
 -   feat(scripts): add "process" to the default list of globals ([\#370](https://github.com/liferay/liferay-npm-tools/pull/370))
 
@@ -107,7 +105,6 @@
 -   chore(scripts): update eslint-config-liferay to v17.0.0 ([\#350](https://github.com/liferay/liferay-npm-tools/pull/350))
 -   feat(scripts): add stylelint ([\#347](https://github.com/liferay/liferay-npm-tools/pull/347))
 -   feat(scripts): run preflight checks during "fix" runs too ([\#349](https://github.com/liferay/liferay-npm-tools/pull/349))
--   refactor(scripts): eliminate many yarn peer dependency warnings (#336) ([\#346](https://github.com/liferay/liferay-npm-tools/pull/346))
 -   refactor(scripts): eliminate many yarn peer dependency warnings (#336) ([\#346](https://github.com/liferay/liferay-npm-tools/pull/346))
 -   chore(scripts): clean up straggling (but inconsequential) .babelrc references ([\#345](https://github.com/liferay/liferay-npm-tools/pull/345))
 
@@ -162,7 +159,6 @@
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v15.1.0...liferay-npm-scripts/v16.0.0)
 
 -   chore!: update eslint-config-liferay to v14.0.0 ([\#319](https://github.com/liferay/liferay-npm-tools/pull/319))
--   chore!: update eslint-config-liferay to v14.0.0 ([\#319](https://github.com/liferay/liferay-npm-tools/pull/319))
 -   fix(scripts): don't use color or report results if successful (#317) ([\#318](https://github.com/liferay/liferay-npm-tools/pull/318))
 
 ## [liferay-npm-scripts/v15.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v15.1.0) (2019-12-04)
@@ -174,7 +170,6 @@
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v14.2.0...liferay-npm-scripts/v15.0.0)
 
 -   feat: lint JS inside JSP files ([\#314](https://github.com/liferay/liferay-npm-tools/pull/314))
--   refactor(scripts): rename src/format to src/jsp ([\#313](https://github.com/liferay/liferay-npm-tools/pull/313))
 -   refactor(scripts): rename src/format to src/jsp ([\#313](https://github.com/liferay/liferay-npm-tools/pull/313))
 -   docs(scripts): remove stale link from README ([\#312](https://github.com/liferay/liferay-npm-tools/pull/312))
 
@@ -224,8 +219,6 @@
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.3...liferay-npm-scripts/v10.1.4)
 
 -   fix(scripts): disables useStrict in commonjs transform by default ([\#287](https://github.com/liferay/liferay-npm-tools/pull/287))
--   fix(scripts): disables useStrict in commonjs transform by default ([\#287](https://github.com/liferay/liferay-npm-tools/pull/287))
--   refactor(scripts): use rimraf API directly (#284) ([\#288](https://github.com/liferay/liferay-npm-tools/pull/288))
 -   refactor(scripts): use rimraf API directly (#284) ([\#288](https://github.com/liferay/liferay-npm-tools/pull/288))
 -   feat(scripts): check bundled Babel config file for validity ([\#286](https://github.com/liferay/liferay-npm-tools/pull/286))
 
@@ -239,7 +232,6 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.1...liferay-npm-scripts/v10.1.2)
 
--   feat: cleans up rogue sourcemaps inside liferay-npm-bridge-generator output ([\#283](https://github.com/liferay/liferay-npm-tools/pull/283))
 -   feat: cleans up rogue sourcemaps inside liferay-npm-bridge-generator output ([\#283](https://github.com/liferay/liferay-npm-tools/pull/283))
 -   feat(scripts): support "export namespace from" in Babel ([\#281](https://github.com/liferay/liferay-npm-tools/pull/281))
 
@@ -292,11 +284,8 @@
 -   refactor: implement improvements from JSP formatting review ([\#250](https://github.com/liferay/liferay-npm-tools/pull/250))
 -   refactor: use getPaths() to eliminate repetition ([\#249](https://github.com/liferay/liferay-npm-tools/pull/249))
 -   feat: allow for compound patterns in extensions in globs ([\#247](https://github.com/liferay/liferay-npm-tools/pull/247))
--   feat: allow for compound patterns in extensions in globs ([\#247](https://github.com/liferay/liferay-npm-tools/pull/247))
 -   feat: format JS in JSP files using Prettier ([\#248](https://github.com/liferay/liferay-npm-tools/pull/248))
 -   feat: add SignalHandler for managing cleanup ([\#245](https://github.com/liferay/liferay-npm-tools/pull/245))
--   feat: add SignalHandler for managing cleanup ([\#245](https://github.com/liferay/liferay-npm-tools/pull/245))
--   fix: don't choke on stale .babelrc files (#242) ([\#243](https://github.com/liferay/liferay-npm-tools/pull/243))
 -   fix: don't choke on stale .babelrc files (#242) ([\#243](https://github.com/liferay/liferay-npm-tools/pull/243))
 -   fix: don't let signals leave stale files lying around (#242) ([\#246](https://github.com/liferay/liferay-npm-tools/pull/246))
 
@@ -316,7 +305,6 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.3.0...liferay-npm-scripts/v9.0.0)
 
--   feat!: updates eslint-config-liferay to v9.0.0 ([\#236](https://github.com/liferay/liferay-npm-tools/pull/236))
 -   feat!: updates eslint-config-liferay to v9.0.0 ([\#236](https://github.com/liferay/liferay-npm-tools/pull/236))
 -   docs: fix typo in CONTRIBUTING.md ([\#224](https://github.com/liferay/liferay-npm-tools/pull/224))
 -   chore(scripts): correct license type in liferay-npm-scripts package.json ([\#225](https://github.com/liferay/liferay-npm-tools/pull/225))
@@ -424,7 +412,6 @@
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.12.1...liferay-npm-scripts/v4.13.0)
 
 -   feat(scripts): improve Prettier summary output ([\#179](https://github.com/liferay/liferay-npm-tools/pull/179))
--   feat(scripts): improve Prettier summary output ([\#179](https://github.com/liferay/liferay-npm-tools/pull/179))
 -   test(scripts): suppress log output in formatting tests ([\#178](https://github.com/liferay/liferay-npm-tools/pull/178))
 
 ## [liferay-npm-scripts/v4.12.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.12.1) (2019-07-19)
@@ -449,8 +436,6 @@
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.9.0...liferay-npm-scripts/v4.10.0)
 
 -   chore(scripts): update to eslint-config-liferay v4.4.0 ([\#168](https://github.com/liferay/liferay-npm-tools/pull/168))
--   chore(scripts): update to eslint-config-liferay v4.4.0 ([\#168](https://github.com/liferay/liferay-npm-tools/pull/168))
--   style: use double quotes for JSX attributes ([\#166](https://github.com/liferay/liferay-npm-tools/pull/166))
 -   style: use double quotes for JSX attributes ([\#166](https://github.com/liferay/liferay-npm-tools/pull/166))
 -   fix(scripts): make async work in tests again ([\#167](https://github.com/liferay/liferay-npm-tools/pull/167))
 
@@ -459,7 +444,6 @@
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.8.0...liferay-npm-scripts/v4.9.0)
 
 -   feat(scripts): add ability to lint/format changed files only ([\#165](https://github.com/liferay/liferay-npm-tools/pull/165))
--   feat(scripts): add @testing-library dependencies ([\#164](https://github.com/liferay/liferay-npm-tools/pull/164))
 -   feat(scripts): add @testing-library dependencies ([\#164](https://github.com/liferay/liferay-npm-tools/pull/164))
 -   refactor(scripts): remove now-unnecessary ESLint workaround ([\#163](https://github.com/liferay/liferay-npm-tools/pull/163))
 
@@ -473,7 +457,6 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.6.0...liferay-npm-scripts/v4.7.0)
 
--   chore(scripts): tweak "master-private" concept of "root" ([\#157](https://github.com/liferay/liferay-npm-tools/pull/157))
 -   chore(scripts): tweak "master-private" concept of "root" ([\#157](https://github.com/liferay/liferay-npm-tools/pull/157))
 -   refactor(scripts): simplify Jest config set-up ([\#156](https://github.com/liferay/liferay-npm-tools/pull/156))
 
@@ -490,12 +473,8 @@
 
 -   feat: run CI on Windows ([\#151](https://github.com/liferay/liferay-npm-tools/pull/151))
 -   fix(scripts): make file glob expansion work on Windows ([\#150](https://github.com/liferay/liferay-npm-tools/pull/150))
--   fix(scripts): make file glob expansion work on Windows ([\#150](https://github.com/liferay/liferay-npm-tools/pull/150))
--   feat: bundle babel/preset-react with liferay-npm-scripts (#139) ([\#149](https://github.com/liferay/liferay-npm-tools/pull/149))
 -   feat: bundle babel/preset-react with liferay-npm-scripts (#139) ([\#149](https://github.com/liferay/liferay-npm-tools/pull/149))
 -   chore: update eslint-config-liferay to v4.2.0 ([\#148](https://github.com/liferay/liferay-npm-tools/pull/148))
--   chore: update eslint-config-liferay to v4.2.0 ([\#148](https://github.com/liferay/liferay-npm-tools/pull/148))
--   fix(scripts): remove sometimes ungrammatical wording ([\#147](https://github.com/liferay/liferay-npm-tools/pull/147))
 -   fix(scripts): remove sometimes ungrammatical wording ([\#147](https://github.com/liferay/liferay-npm-tools/pull/147))
 -   fix(scripts): stop ESLint's spurious "ignored by default" warnings ([\#146](https://github.com/liferay/liferay-npm-tools/pull/146))
 
@@ -546,11 +525,8 @@
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v3.1.0...liferay-npm-scripts/v3.2.0)
 
 -   feat(scripts): teach "lint" to use "node" env for config files ([\#125](https://github.com/liferay/liferay-npm-tools/pull/125))
--   feat(scripts): teach "lint" to use "node" env for config files ([\#125](https://github.com/liferay/liferay-npm-tools/pull/125))
 -   chore: update eslint-config-liferay to v4.0.0 ([\#126](https://github.com/liferay/liferay-npm-tools/pull/126))
 -   feat(scripts): add some globals to the default list ([\#123](https://github.com/liferay/liferay-npm-tools/pull/123))
--   feat(scripts): add some globals to the default list ([\#123](https://github.com/liferay/liferay-npm-tools/pull/123))
--   feat(scripts)!: drop `--no-eslintrc` from invocation ([\#124](https://github.com/liferay/liferay-npm-tools/pull/124))
 -   feat(scripts)!: drop `--no-eslintrc` from invocation ([\#124](https://github.com/liferay/liferay-npm-tools/pull/124))
 -   feat: drop "root: true" from eslint config ([\#122](https://github.com/liferay/liferay-npm-tools/pull/122))
 -   feat(scripts): make it possible to target "\*.es.js" alone ([\#121](https://github.com/liferay/liferay-npm-tools/pull/121))
@@ -588,13 +564,11 @@
 
 -   feat: replace check-source-formatting with prettier (#93) ([\#96](https://github.com/liferay/liferay-npm-tools/pull/96))
 -   refactor: teach getMergedConfig() and index to reject invalid types ([\#92](https://github.com/liferay/liferay-npm-tools/pull/92))
--   refactor: teach getMergedConfig() and index to reject invalid types ([\#92](https://github.com/liferay/liferay-npm-tools/pull/92))
 
 ## [liferay-npm-scripts/v1.8.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.8.0) (2019-05-24)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.7.2...liferay-npm-scripts/v1.8.0)
 
--   feat: set NODE_ENV only for builds (#88) ([\#91](https://github.com/liferay/liferay-npm-tools/pull/91))
 -   feat: set NODE_ENV only for builds (#88) ([\#91](https://github.com/liferay/liferay-npm-tools/pull/91))
 -   feat: enforce canonical preset and plugin names (#89) ([\#90](https://github.com/liferay/liferay-npm-tools/pull/90))
 
@@ -639,7 +613,6 @@
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.13...liferay-npm-scripts/v1.5.0)
 
 -   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
--   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
 -   feat: look for Sass dependency in top-level node_modules (#72) ([\#73](https://github.com/liferay/liferay-npm-tools/pull/73))
 -   feat: add top-level shortcut to run all tests (#67) ([\#68](https://github.com/liferay/liferay-npm-tools/pull/68))
 
@@ -666,7 +639,6 @@
 
 -   chore: use bundler version 2.7.1 ([\#58](https://github.com/liferay/liferay-npm-tools/pull/58))
 -   fix: jest-haste-map warnings about module naming collisions (#53) ([\#54](https://github.com/liferay/liferay-npm-tools/pull/54))
--   fix: jest-haste-map warnings about module naming collisions (#53) ([\#54](https://github.com/liferay/liferay-npm-tools/pull/54))
 -   fix: don't silently swallow failures in spawnSync (#38) ([\#56](https://github.com/liferay/liferay-npm-tools/pull/56))
 -   feat: add CONTRIBUTING.md (#48) ([\#49](https://github.com/liferay/liferay-npm-tools/pull/49))
 -   chore: separate formatting and linting scripts ([\#41](https://github.com/liferay/liferay-npm-tools/pull/41))
@@ -682,7 +654,6 @@
 
 -   fix: broken "eject" in liferay-npm-scripts (#44) ([\#45](https://github.com/liferay/liferay-npm-tools/pull/45))
 -   Remove Lerna, add Yarn workspaces, update Jest and Babel ([\#43](https://github.com/liferay/liferay-npm-tools/pull/43))
--   Change merge order so that local overrides have precedence ([\#39](https://github.com/liferay/liferay-npm-tools/pull/39))
 -   Change merge order so that local overrides have precedence ([\#39](https://github.com/liferay/liferay-npm-tools/pull/39))
 -   Don't use relative path for jest testResultsProcessor ([\#37](https://github.com/liferay/liferay-npm-tools/pull/37))
 
@@ -725,15 +696,12 @@
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.3.0...liferay-npm-scripts/v1.4.0)
 
 -   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
--   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
--   Fixes #15 - Resolves dependencies paths to support hoisted packages in workspace settings ([\#16](https://github.com/liferay/liferay-npm-tools/pull/16))
 -   Fixes #15 - Resolves dependencies paths to support hoisted packages in workspace settings ([\#16](https://github.com/liferay/liferay-npm-tools/pull/16))
 
 ## [liferay-npm-scripts/v1.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.3.0) (2019-02-13)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.2.0...liferay-npm-scripts/v1.3.0)
 
--   Fixes #6 - Uses deepmerge.all to merge more than one object ([\#11](https://github.com/liferay/liferay-npm-tools/pull/11))
 -   Fixes #6 - Uses deepmerge.all to merge more than one object ([\#11](https://github.com/liferay/liferay-npm-tools/pull/11))
 -   Fixes #9 - Remove npm-which package ([\#10](https://github.com/liferay/liferay-npm-tools/pull/10))
 

--- a/packages/liferay-npm-scripts/CHANGELOG.md
+++ b/packages/liferay-npm-scripts/CHANGELOG.md
@@ -1,0 +1,776 @@
+## [liferay-npm-scripts/v28.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v28.0.1) (2020-02-28)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v28.0.0...liferay-npm-scripts/v28.0.1)
+
+-   fix(scripts): avoid linting files under "tmp/" ([\#397](https://github.com/liferay/liferay-npm-tools/pull/397))
+
+## [liferay-npm-scripts/v28.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v28.0.0) (2020-02-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v27.0.0...liferay-npm-scripts/v28.0.0)
+
+-   feat(scripts)!: enforce trailing commas in JS ([\#381](https://github.com/liferay/liferay-npm-tools/pull/381))
+-   feat(scripts): enforce one SCSS import per line ([\#395](https://github.com/liferay/liferay-npm-tools/pull/395))
+-   chore: update for compliance with current Outbound Licensing Policy ([\#394](https://github.com/liferay/liferay-npm-tools/pull/394))
+-   fix(scripts): avoid false positives involving no-unused-vars ([\#392](https://github.com/liferay/liferay-npm-tools/pull/392))
+-   fix(scripts): avoid false positives involving no-unused-vars ([\#392](https://github.com/liferay/liferay-npm-tools/pull/392))
+-   feat(scripts): disallow explicit .scss extension in imports ([\#393](https://github.com/liferay/liferay-npm-tools/pull/393))
+
+## [liferay-npm-scripts/v27.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v27.0.0) (2020-02-20)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v26.0.0...liferay-npm-scripts/v27.0.0)
+
+-   feat(script)!: sort imports in SCSS files ([\#390](https://github.com/liferay/liferay-npm-tools/pull/390))
+
+## [liferay-npm-scripts/v26.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v26.0.0) (2020-02-18)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v25.1.1...liferay-npm-scripts/v26.0.0)
+
+-   chore: update dependencies ([\#385](https://github.com/liferay/liferay-npm-tools/pull/385))
+
+## [liferay-npm-scripts/v25.1.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v25.1.1) (2020-02-14)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v25.1.0...liferay-npm-scripts/v25.1.1)
+
+## [liferay-npm-scripts/v25.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v25.1.0) (2020-02-14)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v25.0.0...liferay-npm-scripts/v25.1.0)
+
+-   feat(scripts): expand default mocks provided in test environment ([\#383](https://github.com/liferay/liferay-npm-tools/pull/383))
+
+## [liferay-npm-scripts/v25.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v25.0.0) (2020-02-13)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v24.0.1...liferay-npm-scripts/v25.0.0)
+
+-   chore(scripts): update bundler dependencies to v2.18.1 ([\#379](https://github.com/liferay/liferay-npm-tools/pull/379))
+-   feat(scripts): catch banned dependencies in package.json file ([\#377](https://github.com/liferay/liferay-npm-tools/pull/377))
+-   chore(scripts): update to bundler v2.18.0 ([\#375](https://github.com/liferay/liferay-npm-tools/pull/375))
+-   docs(scripts): improve wrapper documentation ([\#373](https://github.com/liferay/liferay-npm-tools/pull/373))
+
+## [liferay-npm-scripts/v24.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v24.0.1) (2020-02-10)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v24.0.0...liferay-npm-scripts/v24.0.1)
+
+-   chore(scripts): bump eslint-config-liferay to v19.0.1 ([\#372](https://github.com/liferay/liferay-npm-tools/pull/372))
+
+## [liferay-npm-scripts/v24.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v24.0.0) (2020-02-10)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v23.1.0...liferay-npm-scripts/v24.0.0)
+
+-   chore(scripts)!: update to eslint-config-liferay v19.0.0 ([\#371](https://github.com/liferay/liferay-npm-tools/pull/371))
+-   chore(scripts)!: update to eslint-config-liferay v19.0.0 ([\#371](https://github.com/liferay/liferay-npm-tools/pull/371))
+-   feat(scripts): add "process" to the default list of globals ([\#370](https://github.com/liferay/liferay-npm-tools/pull/370))
+
+## [liferay-npm-scripts/v23.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v23.1.0) (2020-02-07)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v23.0.0...liferay-npm-scripts/v23.1.0)
+
+-   feat(scripts): expose "prettier" subcommand ([\#367](https://github.com/liferay/liferay-npm-tools/pull/367))
+
+## [liferay-npm-scripts/v23.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v23.0.0) (2020-02-05)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v22.1.0...liferay-npm-scripts/v23.0.0)
+
+-   feat!: apply custom Liferay-specific formatting in Prettier post-processing step ([\#365](https://github.com/liferay/liferay-npm-tools/pull/365))
+
+## [liferay-npm-scripts/v22.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v22.1.0) (2020-02-03)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v22.0.1...liferay-npm-scripts/v22.1.0)
+
+-   feat(scripts): expand config detection to handle more types ([\#364](https://github.com/liferay/liferay-npm-tools/pull/364))
+
+## [liferay-npm-scripts/v22.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v22.0.1) (2020-01-31)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v22.0.0...liferay-npm-scripts/v22.0.1)
+
+-   fix(scripts): treat webpack.config.js as a config file ([\#363](https://github.com/liferay/liferay-npm-tools/pull/363))
+
+## [liferay-npm-scripts/v22.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v22.0.0) (2020-01-31)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v21.0.0...liferay-npm-scripts/v22.0.0)
+
+-   chore(scripts)!: update eslint-config-liferay v18.0.0 ([\#362](https://github.com/liferay/liferay-npm-tools/pull/362))
+-   fix(scripts): make soy resolver overrides work with ".soy" as well ([\#360](https://github.com/liferay/liferay-npm-tools/pull/360))
+-   refactor(scripts): remove DDM special-casing from Jest module mapper ([\#359](https://github.com/liferay/liferay-npm-tools/pull/359))
+-   fix(scripts): tighten up Jest module name mapper generation ([\#358](https://github.com/liferay/liferay-npm-tools/pull/358))
+
+## [liferay-npm-scripts/v21.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v21.0.0) (2020-01-24)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v20.0.0...liferay-npm-scripts/v21.0.0)
+
+-   feat(scripts): make preflight checks respect .eslintignore (#354) ([\#357](https://github.com/liferay/liferay-npm-tools/pull/357))
+-   feat(scripts)!: prohibit leading/trailing blank lines in comments ([\#353](https://github.com/liferay/liferay-npm-tools/pull/353))
+
+## [liferay-npm-scripts/v20.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v20.0.0) (2020-01-22)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v19.0.2...liferay-npm-scripts/v20.0.0)
+
+-   chore(scripts): update eslint-config-liferay to v17.0.0 ([\#350](https://github.com/liferay/liferay-npm-tools/pull/350))
+-   feat(scripts): add stylelint ([\#347](https://github.com/liferay/liferay-npm-tools/pull/347))
+-   feat(scripts): run preflight checks during "fix" runs too ([\#349](https://github.com/liferay/liferay-npm-tools/pull/349))
+-   refactor(scripts): eliminate many yarn peer dependency warnings (#336) ([\#346](https://github.com/liferay/liferay-npm-tools/pull/346))
+-   refactor(scripts): eliminate many yarn peer dependency warnings (#336) ([\#346](https://github.com/liferay/liferay-npm-tools/pull/346))
+-   chore(scripts): clean up straggling (but inconsequential) .babelrc references ([\#345](https://github.com/liferay/liferay-npm-tools/pull/345))
+
+## [liferay-npm-scripts/v19.0.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v19.0.2) (2020-01-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v19.0.1...liferay-npm-scripts/v19.0.2)
+
+-   fix(scripts): teach jest wrapper to find .babelrc.js files ([\#343](https://github.com/liferay/liferay-npm-tools/pull/343))
+
+## [liferay-npm-scripts/v19.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v19.0.1) (2020-01-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v19.0.0...liferay-npm-scripts/v19.0.1)
+
+-   fix(scripts): teach ESLint that .baberc.js is a Node module ([\#342](https://github.com/liferay/liferay-npm-tools/pull/342))
+
+## [liferay-npm-scripts/v19.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v19.0.0) (2020-01-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v18.0.0...liferay-npm-scripts/v19.0.0)
+
+-   chore(scripts)!: update eslint-config-liferay to v16.0.0 ([\#341](https://github.com/liferay/liferay-npm-tools/pull/341))
+-   feat(scripts)!: enforce use of canonical config file names ([\#340](https://github.com/liferay/liferay-npm-tools/pull/340))
+-   feat(scripts)!: make Babel use preset-react by default (#303) ([\#335](https://github.com/liferay/liferay-npm-tools/pull/335))
+
+## [liferay-npm-scripts/v18.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v18.0.0) (2020-01-15)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v17.0.4...liferay-npm-scripts/v18.0.0)
+
+-   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
+
+## [liferay-npm-scripts/v17.0.4](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v17.0.4) (2020-01-13)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v17.0.3...liferay-npm-scripts/v17.0.4)
+
+## [liferay-npm-scripts/v17.0.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v17.0.3) (2020-01-10)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v17.0.2...liferay-npm-scripts/v17.0.3)
+
+## [liferay-npm-scripts/v17.0.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v17.0.2) (2020-01-08)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v17.0.1...liferay-npm-scripts/v17.0.2)
+
+## [liferay-npm-scripts/v17.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v17.0.1) (2019-12-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v17.0.0...liferay-npm-scripts/v17.0.1)
+
+## [liferay-npm-scripts/v17.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v17.0.0) (2019-12-13)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v16.0.0...liferay-npm-scripts/v17.0.0)
+
+## [liferay-npm-scripts/v16.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v16.0.0) (2019-12-10)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v15.1.0...liferay-npm-scripts/v16.0.0)
+
+-   chore!: update eslint-config-liferay to v14.0.0 ([\#319](https://github.com/liferay/liferay-npm-tools/pull/319))
+-   chore!: update eslint-config-liferay to v14.0.0 ([\#319](https://github.com/liferay/liferay-npm-tools/pull/319))
+-   fix(scripts): don't use color or report results if successful (#317) ([\#318](https://github.com/liferay/liferay-npm-tools/pull/318))
+
+## [liferay-npm-scripts/v15.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v15.1.0) (2019-12-04)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v15.0.0...liferay-npm-scripts/v15.1.0)
+
+## [liferay-npm-scripts/v15.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v15.0.0) (2019-12-03)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v14.2.0...liferay-npm-scripts/v15.0.0)
+
+-   feat: lint JS inside JSP files ([\#314](https://github.com/liferay/liferay-npm-tools/pull/314))
+-   refactor(scripts): rename src/format to src/jsp ([\#313](https://github.com/liferay/liferay-npm-tools/pull/313))
+-   refactor(scripts): rename src/format to src/jsp ([\#313](https://github.com/liferay/liferay-npm-tools/pull/313))
+-   docs(scripts): remove stale link from README ([\#312](https://github.com/liferay/liferay-npm-tools/pull/312))
+
+## [liferay-npm-scripts/v14.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v14.2.0) (2019-11-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v14.1.0...liferay-npm-scripts/v14.2.0)
+
+-   feat(scripts): teach Jest to deal with new liferay-npm-bundler loaders ([\#308](https://github.com/liferay/liferay-npm-tools/pull/308))
+
+## [liferay-npm-scripts/v14.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v14.1.0) (2019-11-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v14.0.0...liferay-npm-scripts/v14.1.0)
+
+-   chore(scripts): update preset from v4.0.0 to v4.1.0 ([\#306](https://github.com/liferay/liferay-npm-tools/pull/306))
+-   refactor: simplify mock setup ([\#299](https://github.com/liferay/liferay-npm-tools/pull/299))
+-   feat: add "ci" scripts to packages as a convenience ([\#298](https://github.com/liferay/liferay-npm-tools/pull/298))
+-   feat: prevent accidental use of top-level `yarn version` ([\#297](https://github.com/liferay/liferay-npm-tools/pull/297))
+
+## [liferay-npm-scripts/v14.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v14.0.0) (2019-10-22)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v13.0.0...liferay-npm-scripts/v14.0.0)
+
+-   chore(scripts)! update eslint-config-liferay to v13.0.0 ([\#296](https://github.com/liferay/liferay-npm-tools/pull/296))
+
+## [liferay-npm-scripts/v13.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v13.0.0) (2019-10-21)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v12.0.0...liferay-npm-scripts/v13.0.0)
+
+-   feat(scripts)!: update eslint-config-liferay to v12.0.0 ([\#295](https://github.com/liferay/liferay-npm-tools/pull/295))
+
+## [liferay-npm-scripts/v12.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v12.0.0) (2019-10-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v12.0.0-beta.1...liferay-npm-scripts/v12.0.0)
+
+-   chore: update eslint from 6.1.0 to 6.5.1 ([\#294](https://github.com/liferay/liferay-npm-tools/pull/294))
+-   feat(scripts)!: update eslint-config-liferay v11.1.1 ([\#293](https://github.com/liferay/liferay-npm-tools/pull/293))
+-   feat: activate JSP formatting as part of standard formatting runs ([\#253](https://github.com/liferay/liferay-npm-tools/pull/253))
+
+## [liferay-npm-scripts/v12.0.0-beta.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v12.0.0-beta.1) (2019-10-15)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.4...liferay-npm-scripts/v12.0.0-beta.1)
+
+-   feat(scripts): update preset to latest (v2.1.0) ([\#290](https://github.com/liferay/liferay-npm-tools/pull/290))
+
+## [liferay-npm-scripts/v10.1.4](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.1.4) (2019-10-09)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.3...liferay-npm-scripts/v10.1.4)
+
+-   fix(scripts): disables useStrict in commonjs transform by default ([\#287](https://github.com/liferay/liferay-npm-tools/pull/287))
+-   fix(scripts): disables useStrict in commonjs transform by default ([\#287](https://github.com/liferay/liferay-npm-tools/pull/287))
+-   refactor(scripts): use rimraf API directly (#284) ([\#288](https://github.com/liferay/liferay-npm-tools/pull/288))
+-   refactor(scripts): use rimraf API directly (#284) ([\#288](https://github.com/liferay/liferay-npm-tools/pull/288))
+-   feat(scripts): check bundled Babel config file for validity ([\#286](https://github.com/liferay/liferay-npm-tools/pull/286))
+
+## [liferay-npm-scripts/v10.1.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.1.3) (2019-10-08)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.2...liferay-npm-scripts/v10.1.3)
+
+-   fix(scripts): use canonical plugin name format ([\#285](https://github.com/liferay/liferay-npm-tools/pull/285))
+
+## [liferay-npm-scripts/v10.1.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.1.2) (2019-10-08)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.1...liferay-npm-scripts/v10.1.2)
+
+-   feat: cleans up rogue sourcemaps inside liferay-npm-bridge-generator output ([\#283](https://github.com/liferay/liferay-npm-tools/pull/283))
+-   feat: cleans up rogue sourcemaps inside liferay-npm-bridge-generator output ([\#283](https://github.com/liferay/liferay-npm-tools/pull/283))
+-   feat(scripts): support "export namespace from" in Babel ([\#281](https://github.com/liferay/liferay-npm-tools/pull/281))
+
+## [liferay-npm-scripts/v10.1.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.1.1) (2019-10-02)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.0...liferay-npm-scripts/v10.1.1)
+
+-   fix(scripts): make soy.js correctly expand globs on Windows ([\#280](https://github.com/liferay/liferay-npm-tools/pull/280))
+
+## [liferay-npm-scripts/v10.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.1.0) (2019-09-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.0.1...liferay-npm-scripts/v10.1.0)
+
+-   feat(scripts): substitute goog.getMsg() calls in soy files (#277) ([\#278](https://github.com/liferay/liferay-npm-tools/pull/278))
+
+## [liferay-npm-scripts/v10.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.0.1) (2019-09-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.0.0...liferay-npm-scripts/v10.0.1)
+
+-   chore(scripts): update liferay-npm-bundler-preset-liferay-dev dep ([\#275](https://github.com/liferay/liferay-npm-tools/pull/275))
+
+## [liferay-npm-scripts/v10.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.0.0) (2019-09-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.5.0...liferay-npm-scripts/v10.0.0)
+
+-   docs(scripts): fix a typo in a code comment ([\#274](https://github.com/liferay/liferay-npm-tools/pull/274))
+-   chore(scripts): send build output to "build" instead of "classes" (#272) ([\#273](https://github.com/liferay/liferay-npm-tools/pull/273))
+
+## [liferay-npm-scripts/v9.5.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.5.0) (2019-09-20)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.4.1...liferay-npm-scripts/v9.5.0)
+
+-   feat: updates preset-dev to latest ([\#267](https://github.com/liferay/liferay-npm-tools/pull/267))
+-   fix: make release commit messages satisfy Semantic Pull Requests bot ([\#264](https://github.com/liferay/liferay-npm-tools/pull/264))
+
+## [liferay-npm-scripts/v9.4.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.4.1) (2019-09-18)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.4.0...liferay-npm-scripts/v9.4.1)
+
+-   fix: correct bad homepage links in package.json files ([\#254](https://github.com/liferay/liferay-npm-tools/pull/254))
+
+## [liferay-npm-scripts/v9.4.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.4.0) (2019-09-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.3.0...liferay-npm-scripts/v9.4.0)
+
+## [liferay-npm-scripts/v9.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.3.0) (2019-09-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.2.0...liferay-npm-scripts/v9.3.0)
+
+-   refactor: implement improvements from JSP formatting review ([\#250](https://github.com/liferay/liferay-npm-tools/pull/250))
+-   refactor: use getPaths() to eliminate repetition ([\#249](https://github.com/liferay/liferay-npm-tools/pull/249))
+-   feat: allow for compound patterns in extensions in globs ([\#247](https://github.com/liferay/liferay-npm-tools/pull/247))
+-   feat: allow for compound patterns in extensions in globs ([\#247](https://github.com/liferay/liferay-npm-tools/pull/247))
+-   feat: format JS in JSP files using Prettier ([\#248](https://github.com/liferay/liferay-npm-tools/pull/248))
+-   feat: add SignalHandler for managing cleanup ([\#245](https://github.com/liferay/liferay-npm-tools/pull/245))
+-   feat: add SignalHandler for managing cleanup ([\#245](https://github.com/liferay/liferay-npm-tools/pull/245))
+-   fix: don't choke on stale .babelrc files (#242) ([\#243](https://github.com/liferay/liferay-npm-tools/pull/243))
+-   fix: don't choke on stale .babelrc files (#242) ([\#243](https://github.com/liferay/liferay-npm-tools/pull/243))
+-   fix: don't let signals leave stale files lying around (#242) ([\#246](https://github.com/liferay/liferay-npm-tools/pull/246))
+
+## [liferay-npm-scripts/v9.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.2.0) (2019-09-11)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.1.0...liferay-npm-scripts/v9.2.0)
+
+-   feat: Add support for bundler css-loaders ([\#241](https://github.com/liferay/liferay-npm-tools/pull/241))
+
+## [liferay-npm-scripts/v9.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.1.0) (2019-09-10)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.0.0...liferay-npm-scripts/v9.1.0)
+
+-   feat: updates preset-liferay-dev to v1.9.0 to update clay imports to alpha.1 ([\#238](https://github.com/liferay/liferay-npm-tools/pull/238))
+
+## [liferay-npm-scripts/v9.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.0.0) (2019-09-06)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.3.0...liferay-npm-scripts/v9.0.0)
+
+-   feat!: updates eslint-config-liferay to v9.0.0 ([\#236](https://github.com/liferay/liferay-npm-tools/pull/236))
+-   feat!: updates eslint-config-liferay to v9.0.0 ([\#236](https://github.com/liferay/liferay-npm-tools/pull/236))
+-   docs: fix typo in CONTRIBUTING.md ([\#224](https://github.com/liferay/liferay-npm-tools/pull/224))
+-   chore(scripts): correct license type in liferay-npm-scripts package.json ([\#225](https://github.com/liferay/liferay-npm-tools/pull/225))
+-   feat: add liferay-changelog-generator ([\#222](https://github.com/liferay/liferay-npm-tools/pull/222))
+-   chore: remove redundant .prettierrc ([\#223](https://github.com/liferay/liferay-npm-tools/pull/223))
+
+## [liferay-npm-scripts/v8.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v8.3.0) (2019-09-04)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.2.0...liferay-npm-scripts/v8.3.0)
+
+-   feat: updates eslint-config-liferay to 8.1.0 ([\#216](https://github.com/liferay/liferay-npm-tools/pull/216))
+-   fix: swap order of "fix" script ("format" then "lint:fix") ([\#215](https://github.com/liferay/liferay-npm-tools/pull/215))
+
+## [liferay-npm-scripts/v8.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v8.2.0) (2019-08-28)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.1.0...liferay-npm-scripts/v8.2.0)
+
+-   feat: updates liferay-npm-bundler-preset-liferay-dev to v1.8.0 which updates @clayui imports to v3.0.0-milestone.3 ([\#213](https://github.com/liferay/liferay-npm-tools/pull/213))
+
+## [liferay-npm-scripts/v8.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v8.1.0) (2019-08-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.0.1...liferay-npm-scripts/v8.1.0)
+
+-   feat: provides default basic mocks for Liferay, fetch and Headers global objects ([\#211](https://github.com/liferay/liferay-npm-tools/pull/211))
+
+## [liferay-npm-scripts/v8.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v8.0.1) (2019-08-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.0.0...liferay-npm-scripts/v8.0.1)
+
+-   fix: search up as high as liferay-portal "root" for user config ([\#210](https://github.com/liferay/liferay-npm-tools/pull/210))
+
+## [liferay-npm-scripts/v8.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v8.0.0) (2019-08-21)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v7.2.0...liferay-npm-scripts/v8.0.0)
+
+-   chore!: update to eslint-config-liferay v8.0.0 ([\#208](https://github.com/liferay/liferay-npm-tools/pull/208))
+
+## [liferay-npm-scripts/v7.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v7.2.0) (2019-08-20)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v7.1.0...liferay-npm-scripts/v7.2.0)
+
+-   chore(scripts): update liferay-npm-bundler-preset-liferay-dev dep ([\#203](https://github.com/liferay/liferay-npm-tools/pull/203))
+-   feat(reporter): include module name at end of classname (#136) ([\#200](https://github.com/liferay/liferay-npm-tools/pull/200))
+
+## [liferay-npm-scripts/v7.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v7.1.0) (2019-08-16)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v7.0.0...liferay-npm-scripts/v7.1.0)
+
+-   fix: update/remove bad links and add missing links in package.json files ([\#199](https://github.com/liferay/liferay-npm-tools/pull/199))
+-   feat: force the use of a "test" NODE_ENV when running jest ([\#198](https://github.com/liferay/liferay-npm-tools/pull/198))
+
+## [liferay-npm-scripts/v7.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v7.0.0) (2019-08-14)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v6.0.0...liferay-npm-scripts/v7.0.0)
+
+-   chore: update liferay-npm-scripts dependencies ([\#197](https://github.com/liferay/liferay-npm-tools/pull/197))
+
+## [liferay-npm-scripts/v6.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v6.0.0) (2019-08-12)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v5.0.0...liferay-npm-scripts/v6.0.0)
+
+-   chore!: update eslint-config-liferay to v6.0.0 ([\#195](https://github.com/liferay/liferay-npm-tools/pull/195))
+
+## [liferay-npm-scripts/v5.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v5.0.0) (2019-08-08)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.18.0...liferay-npm-scripts/v5.0.0)
+
+-   chore!: update eslint-config-liferay to v5.0.0 ([\#194](https://github.com/liferay/liferay-npm-tools/pull/194))
+-   chore(scripts): update liferay-npm-bundler-preset-liferay-dev dependency ([\#193](https://github.com/liferay/liferay-npm-tools/pull/193))
+-   fix: make generateSoyDependencies() work with lone dependencies ([\#192](https://github.com/liferay/liferay-npm-tools/pull/192))
+-   fix: make babel-jest dependency explicit ([\#188](https://github.com/liferay/liferay-npm-tools/pull/188))
+
+## [liferay-npm-scripts/v4.18.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.18.0) (2019-08-07)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.17.0...liferay-npm-scripts/v4.18.0)
+
+-   feat: add "storybook" command (#94) ([\#113](https://github.com/liferay/liferay-npm-tools/pull/113))
+
+## [liferay-npm-scripts/v4.17.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.17.0) (2019-08-06)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.16.0...liferay-npm-scripts/v4.17.0)
+
+-   chore: update dependencies ([\#187](https://github.com/liferay/liferay-npm-tools/pull/187))
+
+## [liferay-npm-scripts/v4.16.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.16.0) (2019-07-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.15.0...liferay-npm-scripts/v4.16.0)
+
+-   chore: update liferay-npm-bundler-preset-liferay-dev dep ([\#186](https://github.com/liferay/liferay-npm-tools/pull/186))
+
+## [liferay-npm-scripts/v4.15.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.15.0) (2019-07-25)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.14.0...liferay-npm-scripts/v4.15.0)
+
+-   chore: update liferay-npm-scripts deps ([\#184](https://github.com/liferay/liferay-npm-tools/pull/184))
+
+## [liferay-npm-scripts/v4.14.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.14.0) (2019-07-23)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.13.0...liferay-npm-scripts/v4.14.0)
+
+-   chore: Update liferay-theme-tasks to v9.3.0 (Added liferay-font-awesome support) ([\#181](https://github.com/liferay/liferay-npm-tools/pull/181))
+
+## [liferay-npm-scripts/v4.13.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.13.0) (2019-07-19)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.12.1...liferay-npm-scripts/v4.13.0)
+
+-   feat(scripts): improve Prettier summary output ([\#179](https://github.com/liferay/liferay-npm-tools/pull/179))
+-   feat(scripts): improve Prettier summary output ([\#179](https://github.com/liferay/liferay-npm-tools/pull/179))
+-   test(scripts): suppress log output in formatting tests ([\#178](https://github.com/liferay/liferay-npm-tools/pull/178))
+
+## [liferay-npm-scripts/v4.12.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.12.1) (2019-07-19)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.12.0...liferay-npm-scripts/v4.12.1)
+
+-   fix: Revert "refactor(scripts): simplify Jest config set-up" (#176) ([\#177](https://github.com/liferay/liferay-npm-tools/pull/177))
+-   feat: add "postversion" scripts to automate publishing ([\#175](https://github.com/liferay/liferay-npm-tools/pull/175))
+
+## [liferay-npm-scripts/v4.12.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.12.0) (2019-07-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.11.0...liferay-npm-scripts/v4.12.0)
+
+## [liferay-npm-scripts/v4.11.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.11.0) (2019-07-16)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.10.0...liferay-npm-scripts/v4.11.0)
+
+-   feat(scripts): add @testing-library/user-event ([\#171](https://github.com/liferay/liferay-npm-tools/pull/171))
+
+## [liferay-npm-scripts/v4.10.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.10.0) (2019-07-16)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.9.0...liferay-npm-scripts/v4.10.0)
+
+-   chore(scripts): update to eslint-config-liferay v4.4.0 ([\#168](https://github.com/liferay/liferay-npm-tools/pull/168))
+-   chore(scripts): update to eslint-config-liferay v4.4.0 ([\#168](https://github.com/liferay/liferay-npm-tools/pull/168))
+-   style: use double quotes for JSX attributes ([\#166](https://github.com/liferay/liferay-npm-tools/pull/166))
+-   style: use double quotes for JSX attributes ([\#166](https://github.com/liferay/liferay-npm-tools/pull/166))
+-   fix(scripts): make async work in tests again ([\#167](https://github.com/liferay/liferay-npm-tools/pull/167))
+
+## [liferay-npm-scripts/v4.9.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.9.0) (2019-07-15)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.8.0...liferay-npm-scripts/v4.9.0)
+
+-   feat(scripts): add ability to lint/format changed files only ([\#165](https://github.com/liferay/liferay-npm-tools/pull/165))
+-   feat(scripts): add @testing-library dependencies ([\#164](https://github.com/liferay/liferay-npm-tools/pull/164))
+-   feat(scripts): add @testing-library dependencies ([\#164](https://github.com/liferay/liferay-npm-tools/pull/164))
+-   refactor(scripts): remove now-unnecessary ESLint workaround ([\#163](https://github.com/liferay/liferay-npm-tools/pull/163))
+
+## [liferay-npm-scripts/v4.8.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.8.0) (2019-07-11)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.7.0...liferay-npm-scripts/v4.8.0)
+
+-   feat(scripts): enable tests to have cross-project imports ([\#160](https://github.com/liferay/liferay-npm-tools/pull/160))
+
+## [liferay-npm-scripts/v4.7.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.7.0) (2019-07-10)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.6.0...liferay-npm-scripts/v4.7.0)
+
+-   chore(scripts): tweak "master-private" concept of "root" ([\#157](https://github.com/liferay/liferay-npm-tools/pull/157))
+-   chore(scripts): tweak "master-private" concept of "root" ([\#157](https://github.com/liferay/liferay-npm-tools/pull/157))
+-   refactor(scripts): simplify Jest config set-up ([\#156](https://github.com/liferay/liferay-npm-tools/pull/156))
+
+## [liferay-npm-scripts/v4.6.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.6.0) (2019-07-09)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.5.0...liferay-npm-scripts/v4.6.0)
+
+-   feat: teach findRoot() to work in master-private branch ([\#154](https://github.com/liferay/liferay-npm-tools/pull/154))
+-   chore: update to eslint-config-liferay v4.3.0 ([\#153](https://github.com/liferay/liferay-npm-tools/pull/153))
+
+## [liferay-npm-scripts/v4.5.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.5.0) (2019-07-08)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.4.0...liferay-npm-scripts/v4.5.0)
+
+-   feat: run CI on Windows ([\#151](https://github.com/liferay/liferay-npm-tools/pull/151))
+-   fix(scripts): make file glob expansion work on Windows ([\#150](https://github.com/liferay/liferay-npm-tools/pull/150))
+-   fix(scripts): make file glob expansion work on Windows ([\#150](https://github.com/liferay/liferay-npm-tools/pull/150))
+-   feat: bundle babel/preset-react with liferay-npm-scripts (#139) ([\#149](https://github.com/liferay/liferay-npm-tools/pull/149))
+-   feat: bundle babel/preset-react with liferay-npm-scripts (#139) ([\#149](https://github.com/liferay/liferay-npm-tools/pull/149))
+-   chore: update eslint-config-liferay to v4.2.0 ([\#148](https://github.com/liferay/liferay-npm-tools/pull/148))
+-   chore: update eslint-config-liferay to v4.2.0 ([\#148](https://github.com/liferay/liferay-npm-tools/pull/148))
+-   fix(scripts): remove sometimes ungrammatical wording ([\#147](https://github.com/liferay/liferay-npm-tools/pull/147))
+-   fix(scripts): remove sometimes ungrammatical wording ([\#147](https://github.com/liferay/liferay-npm-tools/pull/147))
+-   fix(scripts): stop ESLint's spurious "ignored by default" warnings ([\#146](https://github.com/liferay/liferay-npm-tools/pull/146))
+
+## [liferay-npm-scripts/v4.4.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.4.0) (2019-07-05)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.3.0...liferay-npm-scripts/v4.4.0)
+
+-   feat(scripts): configure ESLint to treat jest like node ([\#144](https://github.com/liferay/liferay-npm-tools/pull/144))
+
+## [liferay-npm-scripts/v4.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.3.0) (2019-07-03)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.2.1...liferay-npm-scripts/v4.3.0)
+
+-   feat: handling globbing internally for ESLint ([\#142](https://github.com/liferay/liferay-npm-tools/pull/142))
+-   feat: handling globbing internally for Prettier ([\#141](https://github.com/liferay/liferay-npm-tools/pull/141))
+-   feat: support async/await in jest tests (#105) ([\#138](https://github.com/liferay/liferay-npm-tools/pull/138))
+
+## [liferay-npm-scripts/v4.2.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.2.1) (2019-06-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.2.0...liferay-npm-scripts/v4.2.1)
+
+-   chore(scripts): update eslint-config-liferay dep to v4.1.1 ([\#134](https://github.com/liferay/liferay-npm-tools/pull/134))
+
+## [liferay-npm-scripts/v4.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.2.0) (2019-06-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.1.0...liferay-npm-scripts/v4.2.0)
+
+-   chore(scripts): update eslint-config-liferay dep to v4.1.0 ([\#132](https://github.com/liferay/liferay-npm-tools/pull/132))
+
+## [liferay-npm-scripts/v4.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.1.0) (2019-06-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.0.0...liferay-npm-scripts/v4.1.0)
+
+-   feat(scripts): tweak lint config for use in IDEs ([\#130](https://github.com/liferay/liferay-npm-tools/pull/130))
+
+## [liferay-npm-scripts/v4.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.0.0) (2019-06-25)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v3.3.0...liferay-npm-scripts/v4.0.0)
+
+-   feat(scripts): make "check" and "fix" do linting and formatting ([\#129](https://github.com/liferay/liferay-npm-tools/pull/129))
+
+## [liferay-npm-scripts/v3.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v3.3.0) (2019-06-24)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v3.2.0...liferay-npm-scripts/v3.3.0)
+
+## [liferay-npm-scripts/v3.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v3.2.0) (2019-06-20)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v3.1.0...liferay-npm-scripts/v3.2.0)
+
+-   feat(scripts): teach "lint" to use "node" env for config files ([\#125](https://github.com/liferay/liferay-npm-tools/pull/125))
+-   feat(scripts): teach "lint" to use "node" env for config files ([\#125](https://github.com/liferay/liferay-npm-tools/pull/125))
+-   chore: update eslint-config-liferay to v4.0.0 ([\#126](https://github.com/liferay/liferay-npm-tools/pull/126))
+-   feat(scripts): add some globals to the default list ([\#123](https://github.com/liferay/liferay-npm-tools/pull/123))
+-   feat(scripts): add some globals to the default list ([\#123](https://github.com/liferay/liferay-npm-tools/pull/123))
+-   feat(scripts)!: drop `--no-eslintrc` from invocation ([\#124](https://github.com/liferay/liferay-npm-tools/pull/124))
+-   feat(scripts)!: drop `--no-eslintrc` from invocation ([\#124](https://github.com/liferay/liferay-npm-tools/pull/124))
+-   feat: drop "root: true" from eslint config ([\#122](https://github.com/liferay/liferay-npm-tools/pull/122))
+-   feat(scripts): make it possible to target "\*.es.js" alone ([\#121](https://github.com/liferay/liferay-npm-tools/pull/121))
+
+## [liferay-npm-scripts/v3.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v3.1.0) (2019-06-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v3.0.0...liferay-npm-scripts/v3.1.0)
+
+-   feat(scripts): equip ESLint to handle new ES features + JSX (#118) ([\#119](https://github.com/liferay/liferay-npm-tools/pull/119))
+
+## [liferay-npm-scripts/v3.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v3.0.0) (2019-06-12)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v2.2.0...liferay-npm-scripts/v3.0.0)
+
+-   feat: add subcommands for running ESLint (#109) ([\#112](https://github.com/liferay/liferay-npm-tools/pull/112))
+-   chore: remove sort-keys dependency ([\#116](https://github.com/liferay/liferay-npm-tools/pull/116))
+-   refactor: rename files to match naming conventions (#107) ([\#115](https://github.com/liferay/liferay-npm-tools/pull/115))
+-   refactor(scripts)!: rename "lint"/"format" to "check"/"fix" (#110) ([\#111](https://github.com/liferay/liferay-npm-tools/pull/111))
+
+## [liferay-npm-scripts/v2.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v2.2.0) (2019-06-04)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v2.1.0...liferay-npm-scripts/v2.2.0)
+
+-   feat: expand lint/format globs to cover "test" (#95) ([\#103](https://github.com/liferay/liferay-npm-tools/pull/103))
+
+## [liferay-npm-scripts/v2.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v2.1.0) (2019-06-03)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v2.0.0...liferay-npm-scripts/v2.1.0)
+
+-   feat: provide a way to skip linting/formatting entirely ([\#101](https://github.com/liferay/liferay-npm-tools/pull/101))
+
+## [liferay-npm-scripts/v2.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v2.0.0) (2019-06-03)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.8.0...liferay-npm-scripts/v2.0.0)
+
+-   feat: replace check-source-formatting with prettier (#93) ([\#96](https://github.com/liferay/liferay-npm-tools/pull/96))
+-   refactor: teach getMergedConfig() and index to reject invalid types ([\#92](https://github.com/liferay/liferay-npm-tools/pull/92))
+-   refactor: teach getMergedConfig() and index to reject invalid types ([\#92](https://github.com/liferay/liferay-npm-tools/pull/92))
+
+## [liferay-npm-scripts/v1.8.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.8.0) (2019-05-24)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.7.2...liferay-npm-scripts/v1.8.0)
+
+-   feat: set NODE_ENV only for builds (#88) ([\#91](https://github.com/liferay/liferay-npm-tools/pull/91))
+-   feat: set NODE_ENV only for builds (#88) ([\#91](https://github.com/liferay/liferay-npm-tools/pull/91))
+-   feat: enforce canonical preset and plugin names (#89) ([\#90](https://github.com/liferay/liferay-npm-tools/pull/90))
+
+## [liferay-npm-scripts/v1.7.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.7.2) (2019-05-21)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.7.1...liferay-npm-scripts/v1.7.2)
+
+-   fix: run weback during builds using shared utility ([\#87](https://github.com/liferay/liferay-npm-tools/pull/87))
+
+## [liferay-npm-scripts/v1.7.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.7.1) (2019-05-20)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.7.0...liferay-npm-scripts/v1.7.1)
+
+-   Add clay loading indicator dependency ([\#86](https://github.com/liferay/liferay-npm-tools/pull/86))
+
+## [liferay-npm-scripts/v1.7.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.7.0) (2019-05-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.6.0...liferay-npm-scripts/v1.7.0)
+
+-   fix: recover original .npmbundlerrc after failures (#71) ([\#85](https://github.com/liferay/liferay-npm-tools/pull/85))
+-   feat: add Babel merge strategy to get-merged-config.js ([\#84](https://github.com/liferay/liferay-npm-tools/pull/84))
+-   feat: always clean up temporary Babel config files, and make webpack builds use them as well ([\#82](https://github.com/liferay/liferay-npm-tools/pull/82))
+-   feat: add "preset" functionality for npm-scripts config ([\#76](https://github.com/liferay/liferay-npm-tools/pull/76))
+-   feat: provide standard version of babel-loader ([\#81](https://github.com/liferay/liferay-npm-tools/pull/81))
+-   feat: add class-properties and object-rest-spread support ([\#80](https://github.com/liferay/liferay-npm-tools/pull/80))
+
+## [liferay-npm-scripts/v1.6.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.6.0) (2019-05-06)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.5.1...liferay-npm-scripts/v1.6.0)
+
+-   feat: add "wepback" subcommand to liferay-npm-scripts ([\#79](https://github.com/liferay/liferay-npm-tools/pull/79))
+-   Apply minor clean-up ([\#78](https://github.com/liferay/liferay-npm-tools/pull/78))
+
+## [liferay-npm-scripts/v1.5.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.5.1) (2019-04-12)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.5.0...liferay-npm-scripts/v1.5.1)
+
+-   chore: update liferay-theme-tasks to v9.1.1 ([\#75](https://github.com/liferay/liferay-npm-tools/pull/75))
+
+## [liferay-npm-scripts/v1.5.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.5.0) (2019-04-11)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.13...liferay-npm-scripts/v1.5.0)
+
+-   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
+-   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
+-   feat: look for Sass dependency in top-level node_modules (#72) ([\#73](https://github.com/liferay/liferay-npm-tools/pull/73))
+-   feat: add top-level shortcut to run all tests (#67) ([\#68](https://github.com/liferay/liferay-npm-tools/pull/68))
+
+## [liferay-npm-scripts/v1.4.13](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.13) (2019-04-05)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.12...liferay-npm-scripts/v1.4.13)
+
+-   doc: explain "theme", "theme build" in scripts README (#64) ([\#66](https://github.com/liferay/liferay-npm-tools/pull/66))
+-   feat: add "theme" subcommand (#64) ([\#65](https://github.com/liferay/liferay-npm-tools/pull/65))
+
+## [liferay-npm-scripts/v1.4.12](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.12) (2019-04-03)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.11...liferay-npm-scripts/v1.4.12)
+
+-   fix: improve executable selection on Windows (#62) ([\#63](https://github.com/liferay/liferay-npm-tools/pull/63))
+
+## [liferay-npm-scripts/v1.4.11](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.11) (2019-04-02)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.10...liferay-npm-scripts/v1.4.11)
+
+## [liferay-npm-scripts/v1.4.10](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.10) (2019-04-01)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.9...liferay-npm-scripts/v1.4.10)
+
+-   chore: use bundler version 2.7.1 ([\#58](https://github.com/liferay/liferay-npm-tools/pull/58))
+-   fix: jest-haste-map warnings about module naming collisions (#53) ([\#54](https://github.com/liferay/liferay-npm-tools/pull/54))
+-   fix: jest-haste-map warnings about module naming collisions (#53) ([\#54](https://github.com/liferay/liferay-npm-tools/pull/54))
+-   fix: don't silently swallow failures in spawnSync (#38) ([\#56](https://github.com/liferay/liferay-npm-tools/pull/56))
+-   feat: add CONTRIBUTING.md (#48) ([\#49](https://github.com/liferay/liferay-npm-tools/pull/49))
+-   chore: separate formatting and linting scripts ([\#41](https://github.com/liferay/liferay-npm-tools/pull/41))
+-   Just putting "develop" and "master" back into a fast-forwardable state
+
+## [liferay-npm-scripts/v1.4.9](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.9) (2019-03-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.8...liferay-npm-scripts/v1.4.9)
+
+## [liferay-npm-scripts/v1.4.8](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.8) (2019-03-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.7...liferay-npm-scripts/v1.4.8)
+
+-   fix: broken "eject" in liferay-npm-scripts (#44) ([\#45](https://github.com/liferay/liferay-npm-tools/pull/45))
+-   Remove Lerna, add Yarn workspaces, update Jest and Babel ([\#43](https://github.com/liferay/liferay-npm-tools/pull/43))
+-   Change merge order so that local overrides have precedence ([\#39](https://github.com/liferay/liferay-npm-tools/pull/39))
+-   Change merge order so that local overrides have precedence ([\#39](https://github.com/liferay/liferay-npm-tools/pull/39))
+-   Don't use relative path for jest testResultsProcessor ([\#37](https://github.com/liferay/liferay-npm-tools/pull/37))
+
+## [liferay-npm-scripts/v1.4.7](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.7) (2019-03-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.6...liferay-npm-scripts/v1.4.7)
+
+## [liferay-npm-scripts/v1.4.6](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.6) (2019-03-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.5...liferay-npm-scripts/v1.4.6)
+
+## [liferay-npm-scripts/v1.4.5](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.5) (2019-03-26)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.4...liferay-npm-scripts/v1.4.5)
+
+## [liferay-npm-scripts/v1.4.4](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.4) (2019-03-25)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.3...liferay-npm-scripts/v1.4.4)
+
+## [liferay-npm-scripts/v1.4.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.3) (2019-03-12)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.2...liferay-npm-scripts/v1.4.3)
+
+-   Fixes #30 - Prepends current PATH so local binaries have precendence in a workspace environment ([\#31](https://github.com/liferay/liferay-npm-tools/pull/31))
+
+## [liferay-npm-scripts/v1.4.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.2) (2019-02-28)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.1...liferay-npm-scripts/v1.4.2)
+
+-   Fixes #23 - Filters oneself dependency to avoid duplicating templates ([\#24](https://github.com/liferay/liferay-npm-tools/pull/24))
+
+## [liferay-npm-scripts/v1.4.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.1) (2019-02-28)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.0...liferay-npm-scripts/v1.4.1)
+
+-   Fixes #21 - Scopes soy glob to src folder only ([\#22](https://github.com/liferay/liferay-npm-tools/pull/22))
+
+## [liferay-npm-scripts/v1.4.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.0) (2019-02-27)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.3.0...liferay-npm-scripts/v1.4.0)
+
+-   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
+-   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
+-   Fixes #15 - Resolves dependencies paths to support hoisted packages in workspace settings ([\#16](https://github.com/liferay/liferay-npm-tools/pull/16))
+-   Fixes #15 - Resolves dependencies paths to support hoisted packages in workspace settings ([\#16](https://github.com/liferay/liferay-npm-tools/pull/16))
+
+## [liferay-npm-scripts/v1.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.3.0) (2019-02-13)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.2.0...liferay-npm-scripts/v1.3.0)
+
+-   Fixes #6 - Uses deepmerge.all to merge more than one object ([\#11](https://github.com/liferay/liferay-npm-tools/pull/11))
+-   Fixes #6 - Uses deepmerge.all to merge more than one object ([\#11](https://github.com/liferay/liferay-npm-tools/pull/11))
+-   Fixes #9 - Remove npm-which package ([\#10](https://github.com/liferay/liferay-npm-tools/pull/10))
+
+## [liferay-npm-scripts/v1.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.2.0) (2019-01-24)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.1.0...liferay-npm-scripts/v1.2.0)
+
+## [liferay-npm-scripts/v1.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.1.0) (2019-01-22)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.0.0...liferay-npm-scripts/v1.1.0)
+
+## [liferay-npm-scripts/v1.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.0.0) (2019-01-08)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v0.0.8...liferay-npm-scripts/v1.0.0)
+
+## [liferay-npm-scripts/v0.0.8](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v0.0.8) (2018-12-21)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v0.0.7...liferay-npm-scripts/v0.0.8)
+
+## [liferay-npm-scripts/v0.0.7](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v0.0.7) (2018-12-18)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v0.0.6...liferay-npm-scripts/v0.0.7)
+
+## [liferay-npm-scripts/v0.0.6](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v0.0.6) (2018-12-18)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v0.0.5...liferay-npm-scripts/v0.0.6)
+
+## [liferay-npm-scripts/v0.0.5](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v0.0.5) (2018-12-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v0.0.4...liferay-npm-scripts/v0.0.5)
+
+## [liferay-npm-scripts/v0.0.4](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v0.0.4) (2018-12-17)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v0.0.3...liferay-npm-scripts/v0.0.4)
+
+## [liferay-npm-scripts/v0.0.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v0.0.3) (2018-12-14)
+
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v0.0.2...liferay-npm-scripts/v0.0.3)
+
+## [liferay-npm-scripts/v0.0.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v0.0.2) (2018-12-13)

--- a/packages/liferay-npm-scripts/CHANGELOG.md
+++ b/packages/liferay-npm-scripts/CHANGELOG.md
@@ -2,27 +2,49 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v28.0.0...liferay-npm-scripts/v28.0.1)
 
+### :wrench: Bug fixes
+
 -   fix(scripts): avoid linting files under "tmp/" ([\#397](https://github.com/liferay/liferay-npm-tools/pull/397))
 
 ## [liferay-npm-scripts/v28.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v28.0.0) (2020-02-26)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v27.0.0...liferay-npm-scripts/v28.0.0)
 
+### :boom: Breaking changes
+
+-   feat(scripts)!: enforce trailing commas in JS ([\#381](https://github.com/liferay/liferay-npm-tools/pull/381))
+
+### :new: Features
+
 -   feat(scripts)!: enforce trailing commas in JS ([\#381](https://github.com/liferay/liferay-npm-tools/pull/381))
 -   feat(scripts): enforce one SCSS import per line ([\#395](https://github.com/liferay/liferay-npm-tools/pull/395))
--   chore: update for compliance with current Outbound Licensing Policy ([\#394](https://github.com/liferay/liferay-npm-tools/pull/394))
--   fix(scripts): avoid false positives involving no-unused-vars ([\#392](https://github.com/liferay/liferay-npm-tools/pull/392))
 -   feat(scripts): disallow explicit .scss extension in imports ([\#393](https://github.com/liferay/liferay-npm-tools/pull/393))
+
+### :wrench: Bug fixes
+
+-   fix(scripts): avoid false positives involving no-unused-vars ([\#392](https://github.com/liferay/liferay-npm-tools/pull/392))
+
+### :house: Chores
+
+-   chore: update for compliance with current Outbound Licensing Policy ([\#394](https://github.com/liferay/liferay-npm-tools/pull/394))
 
 ## [liferay-npm-scripts/v27.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v27.0.0) (2020-02-20)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v26.0.0...liferay-npm-scripts/v27.0.0)
+
+### :boom: Breaking changes
+
+-   feat(script)!: sort imports in SCSS files ([\#390](https://github.com/liferay/liferay-npm-tools/pull/390))
+
+### :new: Features
 
 -   feat(script)!: sort imports in SCSS files ([\#390](https://github.com/liferay/liferay-npm-tools/pull/390))
 
 ## [liferay-npm-scripts/v26.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v26.0.0) (2020-02-18)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v25.1.1...liferay-npm-scripts/v26.0.0)
+
+### :house: Chores
 
 -   chore: update dependencies ([\#385](https://github.com/liferay/liferay-npm-tools/pull/385))
 
@@ -34,20 +56,32 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v25.0.0...liferay-npm-scripts/v25.1.0)
 
+### :new: Features
+
 -   feat(scripts): expand default mocks provided in test environment ([\#383](https://github.com/liferay/liferay-npm-tools/pull/383))
 
 ## [liferay-npm-scripts/v25.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v25.0.0) (2020-02-13)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v24.0.1...liferay-npm-scripts/v25.0.0)
 
--   chore(scripts): update bundler dependencies to v2.18.1 ([\#379](https://github.com/liferay/liferay-npm-tools/pull/379))
+### :new: Features
+
 -   feat(scripts): catch banned dependencies in package.json file ([\#377](https://github.com/liferay/liferay-npm-tools/pull/377))
--   chore(scripts): update to bundler v2.18.0 ([\#375](https://github.com/liferay/liferay-npm-tools/pull/375))
+
+### :book: Documentation
+
 -   docs(scripts): improve wrapper documentation ([\#373](https://github.com/liferay/liferay-npm-tools/pull/373))
+
+### :house: Chores
+
+-   chore(scripts): update bundler dependencies to v2.18.1 ([\#379](https://github.com/liferay/liferay-npm-tools/pull/379))
+-   chore(scripts): update to bundler v2.18.0 ([\#375](https://github.com/liferay/liferay-npm-tools/pull/375))
 
 ## [liferay-npm-scripts/v24.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v24.0.1) (2020-02-10)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v24.0.0...liferay-npm-scripts/v24.0.1)
+
+### :house: Chores
 
 -   chore(scripts): bump eslint-config-liferay to v19.0.1 ([\#372](https://github.com/liferay/liferay-npm-tools/pull/372))
 
@@ -55,12 +89,23 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v23.1.0...liferay-npm-scripts/v24.0.0)
 
+### :boom: Breaking changes
+
 -   chore(scripts)!: update to eslint-config-liferay v19.0.0 ([\#371](https://github.com/liferay/liferay-npm-tools/pull/371))
+
+### :new: Features
+
 -   feat(scripts): add "process" to the default list of globals ([\#370](https://github.com/liferay/liferay-npm-tools/pull/370))
+
+### :house: Chores
+
+-   chore(scripts)!: update to eslint-config-liferay v19.0.0 ([\#371](https://github.com/liferay/liferay-npm-tools/pull/371))
 
 ## [liferay-npm-scripts/v23.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v23.1.0) (2020-02-07)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v23.0.0...liferay-npm-scripts/v23.1.0)
+
+### :new: Features
 
 -   feat(scripts): expose "prettier" subcommand ([\#367](https://github.com/liferay/liferay-npm-tools/pull/367))
 
@@ -68,11 +113,19 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v22.1.0...liferay-npm-scripts/v23.0.0)
 
+### :boom: Breaking changes
+
+-   feat!: apply custom Liferay-specific formatting in Prettier post-processing step ([\#365](https://github.com/liferay/liferay-npm-tools/pull/365))
+
+### :new: Features
+
 -   feat!: apply custom Liferay-specific formatting in Prettier post-processing step ([\#365](https://github.com/liferay/liferay-npm-tools/pull/365))
 
 ## [liferay-npm-scripts/v22.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v22.1.0) (2020-02-03)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v22.0.1...liferay-npm-scripts/v22.1.0)
+
+### :new: Features
 
 -   feat(scripts): expand config detection to handle more types ([\#364](https://github.com/liferay/liferay-npm-tools/pull/364))
 
@@ -80,20 +133,40 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v22.0.0...liferay-npm-scripts/v22.0.1)
 
+### :wrench: Bug fixes
+
 -   fix(scripts): treat webpack.config.js as a config file ([\#363](https://github.com/liferay/liferay-npm-tools/pull/363))
 
 ## [liferay-npm-scripts/v22.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v22.0.0) (2020-01-31)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v21.0.0...liferay-npm-scripts/v22.0.0)
 
+### :boom: Breaking changes
+
 -   chore(scripts)!: update eslint-config-liferay v18.0.0 ([\#362](https://github.com/liferay/liferay-npm-tools/pull/362))
+
+### :wrench: Bug fixes
+
 -   fix(scripts): make soy resolver overrides work with ".soy" as well ([\#360](https://github.com/liferay/liferay-npm-tools/pull/360))
--   refactor(scripts): remove DDM special-casing from Jest module mapper ([\#359](https://github.com/liferay/liferay-npm-tools/pull/359))
 -   fix(scripts): tighten up Jest module name mapper generation ([\#358](https://github.com/liferay/liferay-npm-tools/pull/358))
+
+### :house: Chores
+
+-   chore(scripts)!: update eslint-config-liferay v18.0.0 ([\#362](https://github.com/liferay/liferay-npm-tools/pull/362))
+
+### :woman_juggling: Refactoring
+
+-   refactor(scripts): remove DDM special-casing from Jest module mapper ([\#359](https://github.com/liferay/liferay-npm-tools/pull/359))
 
 ## [liferay-npm-scripts/v21.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v21.0.0) (2020-01-24)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v20.0.0...liferay-npm-scripts/v21.0.0)
+
+### :boom: Breaking changes
+
+-   feat(scripts)!: prohibit leading/trailing blank lines in comments ([\#353](https://github.com/liferay/liferay-npm-tools/pull/353))
+
+### :new: Features
 
 -   feat(scripts): make preflight checks respect .eslintignore (#354) ([\#357](https://github.com/liferay/liferay-npm-tools/pull/357))
 -   feat(scripts)!: prohibit leading/trailing blank lines in comments ([\#353](https://github.com/liferay/liferay-npm-tools/pull/353))
@@ -102,15 +175,25 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v19.0.2...liferay-npm-scripts/v20.0.0)
 
--   chore(scripts): update eslint-config-liferay to v17.0.0 ([\#350](https://github.com/liferay/liferay-npm-tools/pull/350))
+### :new: Features
+
 -   feat(scripts): add stylelint ([\#347](https://github.com/liferay/liferay-npm-tools/pull/347))
 -   feat(scripts): run preflight checks during "fix" runs too ([\#349](https://github.com/liferay/liferay-npm-tools/pull/349))
--   refactor(scripts): eliminate many yarn peer dependency warnings (#336) ([\#346](https://github.com/liferay/liferay-npm-tools/pull/346))
+
+### :house: Chores
+
+-   chore(scripts): update eslint-config-liferay to v17.0.0 ([\#350](https://github.com/liferay/liferay-npm-tools/pull/350))
 -   chore(scripts): clean up straggling (but inconsequential) .babelrc references ([\#345](https://github.com/liferay/liferay-npm-tools/pull/345))
+
+### :woman_juggling: Refactoring
+
+-   refactor(scripts): eliminate many yarn peer dependency warnings (#336) ([\#346](https://github.com/liferay/liferay-npm-tools/pull/346))
 
 ## [liferay-npm-scripts/v19.0.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v19.0.2) (2020-01-17)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v19.0.1...liferay-npm-scripts/v19.0.2)
+
+### :wrench: Bug fixes
 
 -   fix(scripts): teach jest wrapper to find .babelrc.js files ([\#343](https://github.com/liferay/liferay-npm-tools/pull/343))
 
@@ -118,19 +201,38 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v19.0.0...liferay-npm-scripts/v19.0.1)
 
+### :wrench: Bug fixes
+
 -   fix(scripts): teach ESLint that .baberc.js is a Node module ([\#342](https://github.com/liferay/liferay-npm-tools/pull/342))
 
 ## [liferay-npm-scripts/v19.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v19.0.0) (2020-01-17)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v18.0.0...liferay-npm-scripts/v19.0.0)
 
+### :boom: Breaking changes
+
 -   chore(scripts)!: update eslint-config-liferay to v16.0.0 ([\#341](https://github.com/liferay/liferay-npm-tools/pull/341))
 -   feat(scripts)!: enforce use of canonical config file names ([\#340](https://github.com/liferay/liferay-npm-tools/pull/340))
 -   feat(scripts)!: make Babel use preset-react by default (#303) ([\#335](https://github.com/liferay/liferay-npm-tools/pull/335))
 
+### :new: Features
+
+-   feat(scripts)!: enforce use of canonical config file names ([\#340](https://github.com/liferay/liferay-npm-tools/pull/340))
+-   feat(scripts)!: make Babel use preset-react by default (#303) ([\#335](https://github.com/liferay/liferay-npm-tools/pull/335))
+
+### :house: Chores
+
+-   chore(scripts)!: update eslint-config-liferay to v16.0.0 ([\#341](https://github.com/liferay/liferay-npm-tools/pull/341))
+
 ## [liferay-npm-scripts/v18.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v18.0.0) (2020-01-15)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v17.0.4...liferay-npm-scripts/v18.0.0)
+
+### :boom: Breaking changes
+
+-   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
+
+### :new: Features
 
 -   feat!: remove propTypes in production builds ([\#333](https://github.com/liferay/liferay-npm-tools/pull/333))
 
@@ -158,8 +260,17 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v15.1.0...liferay-npm-scripts/v16.0.0)
 
+### :boom: Breaking changes
+
 -   chore!: update eslint-config-liferay to v14.0.0 ([\#319](https://github.com/liferay/liferay-npm-tools/pull/319))
+
+### :wrench: Bug fixes
+
 -   fix(scripts): don't use color or report results if successful (#317) ([\#318](https://github.com/liferay/liferay-npm-tools/pull/318))
+
+### :house: Chores
+
+-   chore!: update eslint-config-liferay to v14.0.0 ([\#319](https://github.com/liferay/liferay-npm-tools/pull/319))
 
 ## [liferay-npm-scripts/v15.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v15.1.0) (2019-12-04)
 
@@ -169,13 +280,23 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v14.2.0...liferay-npm-scripts/v15.0.0)
 
+### :new: Features
+
 -   feat: lint JS inside JSP files ([\#314](https://github.com/liferay/liferay-npm-tools/pull/314))
--   refactor(scripts): rename src/format to src/jsp ([\#313](https://github.com/liferay/liferay-npm-tools/pull/313))
+
+### :book: Documentation
+
 -   docs(scripts): remove stale link from README ([\#312](https://github.com/liferay/liferay-npm-tools/pull/312))
+
+### :woman_juggling: Refactoring
+
+-   refactor(scripts): rename src/format to src/jsp ([\#313](https://github.com/liferay/liferay-npm-tools/pull/313))
 
 ## [liferay-npm-scripts/v14.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v14.2.0) (2019-11-27)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v14.1.0...liferay-npm-scripts/v14.2.0)
+
+### :new: Features
 
 -   feat(scripts): teach Jest to deal with new liferay-npm-bundler loaders ([\#308](https://github.com/liferay/liferay-npm-tools/pull/308))
 
@@ -183,14 +304,24 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v14.0.0...liferay-npm-scripts/v14.1.0)
 
--   chore(scripts): update preset from v4.0.0 to v4.1.0 ([\#306](https://github.com/liferay/liferay-npm-tools/pull/306))
--   refactor: simplify mock setup ([\#299](https://github.com/liferay/liferay-npm-tools/pull/299))
+### :new: Features
+
 -   feat: add "ci" scripts to packages as a convenience ([\#298](https://github.com/liferay/liferay-npm-tools/pull/298))
 -   feat: prevent accidental use of top-level `yarn version` ([\#297](https://github.com/liferay/liferay-npm-tools/pull/297))
+
+### :house: Chores
+
+-   chore(scripts): update preset from v4.0.0 to v4.1.0 ([\#306](https://github.com/liferay/liferay-npm-tools/pull/306))
+
+### :woman_juggling: Refactoring
+
+-   refactor: simplify mock setup ([\#299](https://github.com/liferay/liferay-npm-tools/pull/299))
 
 ## [liferay-npm-scripts/v14.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v14.0.0) (2019-10-22)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v13.0.0...liferay-npm-scripts/v14.0.0)
+
+### :package: Miscellaneous
 
 -   chore(scripts)! update eslint-config-liferay to v13.0.0 ([\#296](https://github.com/liferay/liferay-npm-tools/pull/296))
 
@@ -198,19 +329,36 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v12.0.0...liferay-npm-scripts/v13.0.0)
 
+### :boom: Breaking changes
+
+-   feat(scripts)!: update eslint-config-liferay to v12.0.0 ([\#295](https://github.com/liferay/liferay-npm-tools/pull/295))
+
+### :new: Features
+
 -   feat(scripts)!: update eslint-config-liferay to v12.0.0 ([\#295](https://github.com/liferay/liferay-npm-tools/pull/295))
 
 ## [liferay-npm-scripts/v12.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v12.0.0) (2019-10-17)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v12.0.0-beta.1...liferay-npm-scripts/v12.0.0)
 
--   chore: update eslint from 6.1.0 to 6.5.1 ([\#294](https://github.com/liferay/liferay-npm-tools/pull/294))
+### :boom: Breaking changes
+
+-   feat(scripts)!: update eslint-config-liferay v11.1.1 ([\#293](https://github.com/liferay/liferay-npm-tools/pull/293))
+
+### :new: Features
+
 -   feat(scripts)!: update eslint-config-liferay v11.1.1 ([\#293](https://github.com/liferay/liferay-npm-tools/pull/293))
 -   feat: activate JSP formatting as part of standard formatting runs ([\#253](https://github.com/liferay/liferay-npm-tools/pull/253))
+
+### :house: Chores
+
+-   chore: update eslint from 6.1.0 to 6.5.1 ([\#294](https://github.com/liferay/liferay-npm-tools/pull/294))
 
 ## [liferay-npm-scripts/v12.0.0-beta.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v12.0.0-beta.1) (2019-10-15)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.4...liferay-npm-scripts/v12.0.0-beta.1)
+
+### :new: Features
 
 -   feat(scripts): update preset to latest (v2.1.0) ([\#290](https://github.com/liferay/liferay-npm-tools/pull/290))
 
@@ -218,19 +366,31 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.3...liferay-npm-scripts/v10.1.4)
 
--   fix(scripts): disables useStrict in commonjs transform by default ([\#287](https://github.com/liferay/liferay-npm-tools/pull/287))
--   refactor(scripts): use rimraf API directly (#284) ([\#288](https://github.com/liferay/liferay-npm-tools/pull/288))
+### :new: Features
+
 -   feat(scripts): check bundled Babel config file for validity ([\#286](https://github.com/liferay/liferay-npm-tools/pull/286))
+
+### :wrench: Bug fixes
+
+-   fix(scripts): disables useStrict in commonjs transform by default ([\#287](https://github.com/liferay/liferay-npm-tools/pull/287))
+
+### :woman_juggling: Refactoring
+
+-   refactor(scripts): use rimraf API directly (#284) ([\#288](https://github.com/liferay/liferay-npm-tools/pull/288))
 
 ## [liferay-npm-scripts/v10.1.3](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.1.3) (2019-10-08)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.2...liferay-npm-scripts/v10.1.3)
+
+### :wrench: Bug fixes
 
 -   fix(scripts): use canonical plugin name format ([\#285](https://github.com/liferay/liferay-npm-tools/pull/285))
 
 ## [liferay-npm-scripts/v10.1.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.1.2) (2019-10-08)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.1...liferay-npm-scripts/v10.1.2)
+
+### :new: Features
 
 -   feat: cleans up rogue sourcemaps inside liferay-npm-bridge-generator output ([\#283](https://github.com/liferay/liferay-npm-tools/pull/283))
 -   feat(scripts): support "export namespace from" in Babel ([\#281](https://github.com/liferay/liferay-npm-tools/pull/281))
@@ -239,11 +399,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.1.0...liferay-npm-scripts/v10.1.1)
 
+### :wrench: Bug fixes
+
 -   fix(scripts): make soy.js correctly expand globs on Windows ([\#280](https://github.com/liferay/liferay-npm-tools/pull/280))
 
 ## [liferay-npm-scripts/v10.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.1.0) (2019-09-27)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.0.1...liferay-npm-scripts/v10.1.0)
+
+### :new: Features
 
 -   feat(scripts): substitute goog.getMsg() calls in soy files (#277) ([\#278](https://github.com/liferay/liferay-npm-tools/pull/278))
 
@@ -251,25 +415,39 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v10.0.0...liferay-npm-scripts/v10.0.1)
 
+### :house: Chores
+
 -   chore(scripts): update liferay-npm-bundler-preset-liferay-dev dep ([\#275](https://github.com/liferay/liferay-npm-tools/pull/275))
 
 ## [liferay-npm-scripts/v10.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v10.0.0) (2019-09-26)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.5.0...liferay-npm-scripts/v10.0.0)
 
+### :book: Documentation
+
 -   docs(scripts): fix a typo in a code comment ([\#274](https://github.com/liferay/liferay-npm-tools/pull/274))
+
+### :house: Chores
+
 -   chore(scripts): send build output to "build" instead of "classes" (#272) ([\#273](https://github.com/liferay/liferay-npm-tools/pull/273))
 
 ## [liferay-npm-scripts/v9.5.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.5.0) (2019-09-20)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.4.1...liferay-npm-scripts/v9.5.0)
 
+### :new: Features
+
 -   feat: updates preset-dev to latest ([\#267](https://github.com/liferay/liferay-npm-tools/pull/267))
+
+### :wrench: Bug fixes
+
 -   fix: make release commit messages satisfy Semantic Pull Requests bot ([\#264](https://github.com/liferay/liferay-npm-tools/pull/264))
 
 ## [liferay-npm-scripts/v9.4.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.4.1) (2019-09-18)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.4.0...liferay-npm-scripts/v9.4.1)
+
+### :wrench: Bug fixes
 
 -   fix: correct bad homepage links in package.json files ([\#254](https://github.com/liferay/liferay-npm-tools/pull/254))
 
@@ -281,17 +459,27 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.2.0...liferay-npm-scripts/v9.3.0)
 
--   refactor: implement improvements from JSP formatting review ([\#250](https://github.com/liferay/liferay-npm-tools/pull/250))
--   refactor: use getPaths() to eliminate repetition ([\#249](https://github.com/liferay/liferay-npm-tools/pull/249))
+### :new: Features
+
 -   feat: allow for compound patterns in extensions in globs ([\#247](https://github.com/liferay/liferay-npm-tools/pull/247))
 -   feat: format JS in JSP files using Prettier ([\#248](https://github.com/liferay/liferay-npm-tools/pull/248))
 -   feat: add SignalHandler for managing cleanup ([\#245](https://github.com/liferay/liferay-npm-tools/pull/245))
+
+### :wrench: Bug fixes
+
 -   fix: don't choke on stale .babelrc files (#242) ([\#243](https://github.com/liferay/liferay-npm-tools/pull/243))
 -   fix: don't let signals leave stale files lying around (#242) ([\#246](https://github.com/liferay/liferay-npm-tools/pull/246))
+
+### :woman_juggling: Refactoring
+
+-   refactor: implement improvements from JSP formatting review ([\#250](https://github.com/liferay/liferay-npm-tools/pull/250))
+-   refactor: use getPaths() to eliminate repetition ([\#249](https://github.com/liferay/liferay-npm-tools/pull/249))
 
 ## [liferay-npm-scripts/v9.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.2.0) (2019-09-11)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.1.0...liferay-npm-scripts/v9.2.0)
+
+### :new: Features
 
 -   feat: Add support for bundler css-loaders ([\#241](https://github.com/liferay/liferay-npm-tools/pull/241))
 
@@ -299,28 +487,49 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v9.0.0...liferay-npm-scripts/v9.1.0)
 
+### :new: Features
+
 -   feat: updates preset-liferay-dev to v1.9.0 to update clay imports to alpha.1 ([\#238](https://github.com/liferay/liferay-npm-tools/pull/238))
 
 ## [liferay-npm-scripts/v9.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v9.0.0) (2019-09-06)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.3.0...liferay-npm-scripts/v9.0.0)
 
+### :boom: Breaking changes
+
 -   feat!: updates eslint-config-liferay to v9.0.0 ([\#236](https://github.com/liferay/liferay-npm-tools/pull/236))
--   docs: fix typo in CONTRIBUTING.md ([\#224](https://github.com/liferay/liferay-npm-tools/pull/224))
--   chore(scripts): correct license type in liferay-npm-scripts package.json ([\#225](https://github.com/liferay/liferay-npm-tools/pull/225))
+
+### :new: Features
+
+-   feat!: updates eslint-config-liferay to v9.0.0 ([\#236](https://github.com/liferay/liferay-npm-tools/pull/236))
 -   feat: add liferay-changelog-generator ([\#222](https://github.com/liferay/liferay-npm-tools/pull/222))
+
+### :book: Documentation
+
+-   docs: fix typo in CONTRIBUTING.md ([\#224](https://github.com/liferay/liferay-npm-tools/pull/224))
+
+### :house: Chores
+
+-   chore(scripts): correct license type in liferay-npm-scripts package.json ([\#225](https://github.com/liferay/liferay-npm-tools/pull/225))
 -   chore: remove redundant .prettierrc ([\#223](https://github.com/liferay/liferay-npm-tools/pull/223))
 
 ## [liferay-npm-scripts/v8.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v8.3.0) (2019-09-04)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.2.0...liferay-npm-scripts/v8.3.0)
 
+### :new: Features
+
 -   feat: updates eslint-config-liferay to 8.1.0 ([\#216](https://github.com/liferay/liferay-npm-tools/pull/216))
+
+### :wrench: Bug fixes
+
 -   fix: swap order of "fix" script ("format" then "lint:fix") ([\#215](https://github.com/liferay/liferay-npm-tools/pull/215))
 
 ## [liferay-npm-scripts/v8.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v8.2.0) (2019-08-28)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.1.0...liferay-npm-scripts/v8.2.0)
+
+### :new: Features
 
 -   feat: updates liferay-npm-bundler-preset-liferay-dev to v1.8.0 which updates @clayui imports to v3.0.0-milestone.3 ([\#213](https://github.com/liferay/liferay-npm-tools/pull/213))
 
@@ -328,11 +537,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.0.1...liferay-npm-scripts/v8.1.0)
 
+### :new: Features
+
 -   feat: provides default basic mocks for Liferay, fetch and Headers global objects ([\#211](https://github.com/liferay/liferay-npm-tools/pull/211))
 
 ## [liferay-npm-scripts/v8.0.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v8.0.1) (2019-08-26)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v8.0.0...liferay-npm-scripts/v8.0.1)
+
+### :wrench: Bug fixes
 
 -   fix: search up as high as liferay-portal "root" for user config ([\#210](https://github.com/liferay/liferay-npm-tools/pull/210))
 
@@ -340,25 +553,43 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v7.2.0...liferay-npm-scripts/v8.0.0)
 
+### :boom: Breaking changes
+
+-   chore!: update to eslint-config-liferay v8.0.0 ([\#208](https://github.com/liferay/liferay-npm-tools/pull/208))
+
+### :house: Chores
+
 -   chore!: update to eslint-config-liferay v8.0.0 ([\#208](https://github.com/liferay/liferay-npm-tools/pull/208))
 
 ## [liferay-npm-scripts/v7.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v7.2.0) (2019-08-20)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v7.1.0...liferay-npm-scripts/v7.2.0)
 
--   chore(scripts): update liferay-npm-bundler-preset-liferay-dev dep ([\#203](https://github.com/liferay/liferay-npm-tools/pull/203))
+### :new: Features
+
 -   feat(reporter): include module name at end of classname (#136) ([\#200](https://github.com/liferay/liferay-npm-tools/pull/200))
+
+### :house: Chores
+
+-   chore(scripts): update liferay-npm-bundler-preset-liferay-dev dep ([\#203](https://github.com/liferay/liferay-npm-tools/pull/203))
 
 ## [liferay-npm-scripts/v7.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v7.1.0) (2019-08-16)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v7.0.0...liferay-npm-scripts/v7.1.0)
 
--   fix: update/remove bad links and add missing links in package.json files ([\#199](https://github.com/liferay/liferay-npm-tools/pull/199))
+### :new: Features
+
 -   feat: force the use of a "test" NODE_ENV when running jest ([\#198](https://github.com/liferay/liferay-npm-tools/pull/198))
+
+### :wrench: Bug fixes
+
+-   fix: update/remove bad links and add missing links in package.json files ([\#199](https://github.com/liferay/liferay-npm-tools/pull/199))
 
 ## [liferay-npm-scripts/v7.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v7.0.0) (2019-08-14)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v6.0.0...liferay-npm-scripts/v7.0.0)
+
+### :house: Chores
 
 -   chore: update liferay-npm-scripts dependencies ([\#197](https://github.com/liferay/liferay-npm-tools/pull/197))
 
@@ -366,20 +597,37 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v5.0.0...liferay-npm-scripts/v6.0.0)
 
+### :boom: Breaking changes
+
+-   chore!: update eslint-config-liferay to v6.0.0 ([\#195](https://github.com/liferay/liferay-npm-tools/pull/195))
+
+### :house: Chores
+
 -   chore!: update eslint-config-liferay to v6.0.0 ([\#195](https://github.com/liferay/liferay-npm-tools/pull/195))
 
 ## [liferay-npm-scripts/v5.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v5.0.0) (2019-08-08)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.18.0...liferay-npm-scripts/v5.0.0)
 
+### :boom: Breaking changes
+
 -   chore!: update eslint-config-liferay to v5.0.0 ([\#194](https://github.com/liferay/liferay-npm-tools/pull/194))
--   chore(scripts): update liferay-npm-bundler-preset-liferay-dev dependency ([\#193](https://github.com/liferay/liferay-npm-tools/pull/193))
+
+### :wrench: Bug fixes
+
 -   fix: make generateSoyDependencies() work with lone dependencies ([\#192](https://github.com/liferay/liferay-npm-tools/pull/192))
 -   fix: make babel-jest dependency explicit ([\#188](https://github.com/liferay/liferay-npm-tools/pull/188))
+
+### :house: Chores
+
+-   chore!: update eslint-config-liferay to v5.0.0 ([\#194](https://github.com/liferay/liferay-npm-tools/pull/194))
+-   chore(scripts): update liferay-npm-bundler-preset-liferay-dev dependency ([\#193](https://github.com/liferay/liferay-npm-tools/pull/193))
 
 ## [liferay-npm-scripts/v4.18.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.18.0) (2019-08-07)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.17.0...liferay-npm-scripts/v4.18.0)
+
+### :new: Features
 
 -   feat: add "storybook" command (#94) ([\#113](https://github.com/liferay/liferay-npm-tools/pull/113))
 
@@ -387,11 +635,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.16.0...liferay-npm-scripts/v4.17.0)
 
+### :house: Chores
+
 -   chore: update dependencies ([\#187](https://github.com/liferay/liferay-npm-tools/pull/187))
 
 ## [liferay-npm-scripts/v4.16.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.16.0) (2019-07-26)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.15.0...liferay-npm-scripts/v4.16.0)
+
+### :house: Chores
 
 -   chore: update liferay-npm-bundler-preset-liferay-dev dep ([\#186](https://github.com/liferay/liferay-npm-tools/pull/186))
 
@@ -399,11 +651,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.14.0...liferay-npm-scripts/v4.15.0)
 
+### :house: Chores
+
 -   chore: update liferay-npm-scripts deps ([\#184](https://github.com/liferay/liferay-npm-tools/pull/184))
 
 ## [liferay-npm-scripts/v4.14.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.14.0) (2019-07-23)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.13.0...liferay-npm-scripts/v4.14.0)
+
+### :house: Chores
 
 -   chore: Update liferay-theme-tasks to v9.3.0 (Added liferay-font-awesome support) ([\#181](https://github.com/liferay/liferay-npm-tools/pull/181))
 
@@ -411,15 +667,25 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.12.1...liferay-npm-scripts/v4.13.0)
 
+### :new: Features
+
 -   feat(scripts): improve Prettier summary output ([\#179](https://github.com/liferay/liferay-npm-tools/pull/179))
+
+### :eyeglasses: Tests
+
 -   test(scripts): suppress log output in formatting tests ([\#178](https://github.com/liferay/liferay-npm-tools/pull/178))
 
 ## [liferay-npm-scripts/v4.12.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.12.1) (2019-07-19)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.12.0...liferay-npm-scripts/v4.12.1)
 
--   fix: Revert "refactor(scripts): simplify Jest config set-up" (#176) ([\#177](https://github.com/liferay/liferay-npm-tools/pull/177))
+### :new: Features
+
 -   feat: add "postversion" scripts to automate publishing ([\#175](https://github.com/liferay/liferay-npm-tools/pull/175))
+
+### :wrench: Bug fixes
+
+-   fix: Revert "refactor(scripts): simplify Jest config set-up" (#176) ([\#177](https://github.com/liferay/liferay-npm-tools/pull/177))
 
 ## [liferay-npm-scripts/v4.12.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.12.0) (2019-07-17)
 
@@ -429,27 +695,44 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.10.0...liferay-npm-scripts/v4.11.0)
 
+### :new: Features
+
 -   feat(scripts): add @testing-library/user-event ([\#171](https://github.com/liferay/liferay-npm-tools/pull/171))
 
 ## [liferay-npm-scripts/v4.10.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.10.0) (2019-07-16)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.9.0...liferay-npm-scripts/v4.10.0)
 
--   chore(scripts): update to eslint-config-liferay v4.4.0 ([\#168](https://github.com/liferay/liferay-npm-tools/pull/168))
--   style: use double quotes for JSX attributes ([\#166](https://github.com/liferay/liferay-npm-tools/pull/166))
+### :wrench: Bug fixes
+
 -   fix(scripts): make async work in tests again ([\#167](https://github.com/liferay/liferay-npm-tools/pull/167))
+
+### :house: Chores
+
+-   chore(scripts): update to eslint-config-liferay v4.4.0 ([\#168](https://github.com/liferay/liferay-npm-tools/pull/168))
+
+### :nail_care: Style
+
+-   style: use double quotes for JSX attributes ([\#166](https://github.com/liferay/liferay-npm-tools/pull/166))
 
 ## [liferay-npm-scripts/v4.9.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.9.0) (2019-07-15)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.8.0...liferay-npm-scripts/v4.9.0)
 
+### :new: Features
+
 -   feat(scripts): add ability to lint/format changed files only ([\#165](https://github.com/liferay/liferay-npm-tools/pull/165))
 -   feat(scripts): add @testing-library dependencies ([\#164](https://github.com/liferay/liferay-npm-tools/pull/164))
+
+### :woman_juggling: Refactoring
+
 -   refactor(scripts): remove now-unnecessary ESLint workaround ([\#163](https://github.com/liferay/liferay-npm-tools/pull/163))
 
 ## [liferay-npm-scripts/v4.8.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.8.0) (2019-07-11)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.7.0...liferay-npm-scripts/v4.8.0)
+
+### :new: Features
 
 -   feat(scripts): enable tests to have cross-project imports ([\#160](https://github.com/liferay/liferay-npm-tools/pull/160))
 
@@ -457,36 +740,58 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.6.0...liferay-npm-scripts/v4.7.0)
 
+### :house: Chores
+
 -   chore(scripts): tweak "master-private" concept of "root" ([\#157](https://github.com/liferay/liferay-npm-tools/pull/157))
+
+### :woman_juggling: Refactoring
+
 -   refactor(scripts): simplify Jest config set-up ([\#156](https://github.com/liferay/liferay-npm-tools/pull/156))
 
 ## [liferay-npm-scripts/v4.6.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.6.0) (2019-07-09)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.5.0...liferay-npm-scripts/v4.6.0)
 
+### :new: Features
+
 -   feat: teach findRoot() to work in master-private branch ([\#154](https://github.com/liferay/liferay-npm-tools/pull/154))
+
+### :house: Chores
+
 -   chore: update to eslint-config-liferay v4.3.0 ([\#153](https://github.com/liferay/liferay-npm-tools/pull/153))
 
 ## [liferay-npm-scripts/v4.5.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.5.0) (2019-07-08)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.4.0...liferay-npm-scripts/v4.5.0)
 
+### :new: Features
+
 -   feat: run CI on Windows ([\#151](https://github.com/liferay/liferay-npm-tools/pull/151))
--   fix(scripts): make file glob expansion work on Windows ([\#150](https://github.com/liferay/liferay-npm-tools/pull/150))
 -   feat: bundle babel/preset-react with liferay-npm-scripts (#139) ([\#149](https://github.com/liferay/liferay-npm-tools/pull/149))
--   chore: update eslint-config-liferay to v4.2.0 ([\#148](https://github.com/liferay/liferay-npm-tools/pull/148))
+
+### :wrench: Bug fixes
+
+-   fix(scripts): make file glob expansion work on Windows ([\#150](https://github.com/liferay/liferay-npm-tools/pull/150))
 -   fix(scripts): remove sometimes ungrammatical wording ([\#147](https://github.com/liferay/liferay-npm-tools/pull/147))
 -   fix(scripts): stop ESLint's spurious "ignored by default" warnings ([\#146](https://github.com/liferay/liferay-npm-tools/pull/146))
+
+### :house: Chores
+
+-   chore: update eslint-config-liferay to v4.2.0 ([\#148](https://github.com/liferay/liferay-npm-tools/pull/148))
 
 ## [liferay-npm-scripts/v4.4.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.4.0) (2019-07-05)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.3.0...liferay-npm-scripts/v4.4.0)
+
+### :new: Features
 
 -   feat(scripts): configure ESLint to treat jest like node ([\#144](https://github.com/liferay/liferay-npm-tools/pull/144))
 
 ## [liferay-npm-scripts/v4.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.3.0) (2019-07-03)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.2.1...liferay-npm-scripts/v4.3.0)
+
+### :new: Features
 
 -   feat: handling globbing internally for ESLint ([\#142](https://github.com/liferay/liferay-npm-tools/pull/142))
 -   feat: handling globbing internally for Prettier ([\#141](https://github.com/liferay/liferay-npm-tools/pull/141))
@@ -496,11 +801,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.2.0...liferay-npm-scripts/v4.2.1)
 
+### :house: Chores
+
 -   chore(scripts): update eslint-config-liferay dep to v4.1.1 ([\#134](https://github.com/liferay/liferay-npm-tools/pull/134))
 
 ## [liferay-npm-scripts/v4.2.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.2.0) (2019-06-27)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.1.0...liferay-npm-scripts/v4.2.0)
+
+### :house: Chores
 
 -   chore(scripts): update eslint-config-liferay dep to v4.1.0 ([\#132](https://github.com/liferay/liferay-npm-tools/pull/132))
 
@@ -508,11 +817,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v4.0.0...liferay-npm-scripts/v4.1.0)
 
+### :new: Features
+
 -   feat(scripts): tweak lint config for use in IDEs ([\#130](https://github.com/liferay/liferay-npm-tools/pull/130))
 
 ## [liferay-npm-scripts/v4.0.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v4.0.0) (2019-06-25)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v3.3.0...liferay-npm-scripts/v4.0.0)
+
+### :new: Features
 
 -   feat(scripts): make "check" and "fix" do linting and formatting ([\#129](https://github.com/liferay/liferay-npm-tools/pull/129))
 
@@ -524,16 +837,27 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v3.1.0...liferay-npm-scripts/v3.2.0)
 
+### :boom: Breaking changes
+
+-   feat(scripts)!: drop `--no-eslintrc` from invocation ([\#124](https://github.com/liferay/liferay-npm-tools/pull/124))
+
+### :new: Features
+
 -   feat(scripts): teach "lint" to use "node" env for config files ([\#125](https://github.com/liferay/liferay-npm-tools/pull/125))
--   chore: update eslint-config-liferay to v4.0.0 ([\#126](https://github.com/liferay/liferay-npm-tools/pull/126))
 -   feat(scripts): add some globals to the default list ([\#123](https://github.com/liferay/liferay-npm-tools/pull/123))
 -   feat(scripts)!: drop `--no-eslintrc` from invocation ([\#124](https://github.com/liferay/liferay-npm-tools/pull/124))
 -   feat: drop "root: true" from eslint config ([\#122](https://github.com/liferay/liferay-npm-tools/pull/122))
 -   feat(scripts): make it possible to target "\*.es.js" alone ([\#121](https://github.com/liferay/liferay-npm-tools/pull/121))
 
+### :house: Chores
+
+-   chore: update eslint-config-liferay to v4.0.0 ([\#126](https://github.com/liferay/liferay-npm-tools/pull/126))
+
 ## [liferay-npm-scripts/v3.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v3.1.0) (2019-06-17)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v3.0.0...liferay-npm-scripts/v3.1.0)
+
+### :new: Features
 
 -   feat(scripts): equip ESLint to handle new ES features + JSX (#118) ([\#119](https://github.com/liferay/liferay-npm-tools/pull/119))
 
@@ -541,8 +865,20 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v2.2.0...liferay-npm-scripts/v3.0.0)
 
+### :boom: Breaking changes
+
+-   refactor(scripts)!: rename "lint"/"format" to "check"/"fix" (#110) ([\#111](https://github.com/liferay/liferay-npm-tools/pull/111))
+
+### :new: Features
+
 -   feat: add subcommands for running ESLint (#109) ([\#112](https://github.com/liferay/liferay-npm-tools/pull/112))
+
+### :house: Chores
+
 -   chore: remove sort-keys dependency ([\#116](https://github.com/liferay/liferay-npm-tools/pull/116))
+
+### :woman_juggling: Refactoring
+
 -   refactor: rename files to match naming conventions (#107) ([\#115](https://github.com/liferay/liferay-npm-tools/pull/115))
 -   refactor(scripts)!: rename "lint"/"format" to "check"/"fix" (#110) ([\#111](https://github.com/liferay/liferay-npm-tools/pull/111))
 
@@ -550,11 +886,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v2.1.0...liferay-npm-scripts/v2.2.0)
 
+### :new: Features
+
 -   feat: expand lint/format globs to cover "test" (#95) ([\#103](https://github.com/liferay/liferay-npm-tools/pull/103))
 
 ## [liferay-npm-scripts/v2.1.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v2.1.0) (2019-06-03)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v2.0.0...liferay-npm-scripts/v2.1.0)
+
+### :new: Features
 
 -   feat: provide a way to skip linting/formatting entirely ([\#101](https://github.com/liferay/liferay-npm-tools/pull/101))
 
@@ -562,12 +902,19 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.8.0...liferay-npm-scripts/v2.0.0)
 
+### :new: Features
+
 -   feat: replace check-source-formatting with prettier (#93) ([\#96](https://github.com/liferay/liferay-npm-tools/pull/96))
+
+### :woman_juggling: Refactoring
+
 -   refactor: teach getMergedConfig() and index to reject invalid types ([\#92](https://github.com/liferay/liferay-npm-tools/pull/92))
 
 ## [liferay-npm-scripts/v1.8.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.8.0) (2019-05-24)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.7.2...liferay-npm-scripts/v1.8.0)
+
+### :new: Features
 
 -   feat: set NODE_ENV only for builds (#88) ([\#91](https://github.com/liferay/liferay-npm-tools/pull/91))
 -   feat: enforce canonical preset and plugin names (#89) ([\#90](https://github.com/liferay/liferay-npm-tools/pull/90))
@@ -576,11 +923,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.7.1...liferay-npm-scripts/v1.7.2)
 
+### :wrench: Bug fixes
+
 -   fix: run weback during builds using shared utility ([\#87](https://github.com/liferay/liferay-npm-tools/pull/87))
 
 ## [liferay-npm-scripts/v1.7.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.7.1) (2019-05-20)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.7.0...liferay-npm-scripts/v1.7.1)
+
+### :package: Miscellaneous
 
 -   Add clay loading indicator dependency ([\#86](https://github.com/liferay/liferay-npm-tools/pull/86))
 
@@ -588,29 +939,43 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.6.0...liferay-npm-scripts/v1.7.0)
 
--   fix: recover original .npmbundlerrc after failures (#71) ([\#85](https://github.com/liferay/liferay-npm-tools/pull/85))
+### :new: Features
+
 -   feat: add Babel merge strategy to get-merged-config.js ([\#84](https://github.com/liferay/liferay-npm-tools/pull/84))
 -   feat: always clean up temporary Babel config files, and make webpack builds use them as well ([\#82](https://github.com/liferay/liferay-npm-tools/pull/82))
 -   feat: add "preset" functionality for npm-scripts config ([\#76](https://github.com/liferay/liferay-npm-tools/pull/76))
 -   feat: provide standard version of babel-loader ([\#81](https://github.com/liferay/liferay-npm-tools/pull/81))
 -   feat: add class-properties and object-rest-spread support ([\#80](https://github.com/liferay/liferay-npm-tools/pull/80))
 
+### :wrench: Bug fixes
+
+-   fix: recover original .npmbundlerrc after failures (#71) ([\#85](https://github.com/liferay/liferay-npm-tools/pull/85))
+
 ## [liferay-npm-scripts/v1.6.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.6.0) (2019-05-06)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.5.1...liferay-npm-scripts/v1.6.0)
 
+### :new: Features
+
 -   feat: add "wepback" subcommand to liferay-npm-scripts ([\#79](https://github.com/liferay/liferay-npm-tools/pull/79))
+
+### :package: Miscellaneous
+
 -   Apply minor clean-up ([\#78](https://github.com/liferay/liferay-npm-tools/pull/78))
 
 ## [liferay-npm-scripts/v1.5.1](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.5.1) (2019-04-12)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.5.0...liferay-npm-scripts/v1.5.1)
 
+### :house: Chores
+
 -   chore: update liferay-theme-tasks to v9.1.1 ([\#75](https://github.com/liferay/liferay-npm-tools/pull/75))
 
 ## [liferay-npm-scripts/v1.5.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.5.0) (2019-04-11)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.13...liferay-npm-scripts/v1.5.0)
+
+### :new: Features
 
 -   feat: simplify release process (#50) ([\#74](https://github.com/liferay/liferay-npm-tools/pull/74))
 -   feat: look for Sass dependency in top-level node_modules (#72) ([\#73](https://github.com/liferay/liferay-npm-tools/pull/73))
@@ -620,12 +985,19 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.12...liferay-npm-scripts/v1.4.13)
 
--   doc: explain "theme", "theme build" in scripts README (#64) ([\#66](https://github.com/liferay/liferay-npm-tools/pull/66))
+### :new: Features
+
 -   feat: add "theme" subcommand (#64) ([\#65](https://github.com/liferay/liferay-npm-tools/pull/65))
+
+### :book: Documentation
+
+-   doc: explain "theme", "theme build" in scripts README (#64) ([\#66](https://github.com/liferay/liferay-npm-tools/pull/66))
 
 ## [liferay-npm-scripts/v1.4.12](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.12) (2019-04-03)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.11...liferay-npm-scripts/v1.4.12)
+
+### :wrench: Bug fixes
 
 -   fix: improve executable selection on Windows (#62) ([\#63](https://github.com/liferay/liferay-npm-tools/pull/63))
 
@@ -637,11 +1009,22 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.9...liferay-npm-scripts/v1.4.10)
 
--   chore: use bundler version 2.7.1 ([\#58](https://github.com/liferay/liferay-npm-tools/pull/58))
+### :new: Features
+
+-   feat: add CONTRIBUTING.md (#48) ([\#49](https://github.com/liferay/liferay-npm-tools/pull/49))
+
+### :wrench: Bug fixes
+
 -   fix: jest-haste-map warnings about module naming collisions (#53) ([\#54](https://github.com/liferay/liferay-npm-tools/pull/54))
 -   fix: don't silently swallow failures in spawnSync (#38) ([\#56](https://github.com/liferay/liferay-npm-tools/pull/56))
--   feat: add CONTRIBUTING.md (#48) ([\#49](https://github.com/liferay/liferay-npm-tools/pull/49))
+
+### :house: Chores
+
+-   chore: use bundler version 2.7.1 ([\#58](https://github.com/liferay/liferay-npm-tools/pull/58))
 -   chore: separate formatting and linting scripts ([\#41](https://github.com/liferay/liferay-npm-tools/pull/41))
+
+### :package: Miscellaneous
+
 -   Just putting "develop" and "master" back into a fast-forwardable state
 
 ## [liferay-npm-scripts/v1.4.9](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.9) (2019-03-27)
@@ -652,7 +1035,12 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.7...liferay-npm-scripts/v1.4.8)
 
+### :wrench: Bug fixes
+
 -   fix: broken "eject" in liferay-npm-scripts (#44) ([\#45](https://github.com/liferay/liferay-npm-tools/pull/45))
+
+### :package: Miscellaneous
+
 -   Remove Lerna, add Yarn workspaces, update Jest and Babel ([\#43](https://github.com/liferay/liferay-npm-tools/pull/43))
 -   Change merge order so that local overrides have precedence ([\#39](https://github.com/liferay/liferay-npm-tools/pull/39))
 -   Don't use relative path for jest testResultsProcessor ([\#37](https://github.com/liferay/liferay-npm-tools/pull/37))
@@ -677,11 +1065,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.2...liferay-npm-scripts/v1.4.3)
 
+### :package: Miscellaneous
+
 -   Fixes #30 - Prepends current PATH so local binaries have precendence in a workspace environment ([\#31](https://github.com/liferay/liferay-npm-tools/pull/31))
 
 ## [liferay-npm-scripts/v1.4.2](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.2) (2019-02-28)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.1...liferay-npm-scripts/v1.4.2)
+
+### :package: Miscellaneous
 
 -   Fixes #23 - Filters oneself dependency to avoid duplicating templates ([\#24](https://github.com/liferay/liferay-npm-tools/pull/24))
 
@@ -689,11 +1081,15 @@
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.4.0...liferay-npm-scripts/v1.4.1)
 
+### :package: Miscellaneous
+
 -   Fixes #21 - Scopes soy glob to src folder only ([\#22](https://github.com/liferay/liferay-npm-tools/pull/22))
 
 ## [liferay-npm-scripts/v1.4.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.4.0) (2019-02-27)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.3.0...liferay-npm-scripts/v1.4.0)
+
+### :package: Miscellaneous
 
 -   Fixes #17 - Updates lock files ([\#20](https://github.com/liferay/liferay-npm-tools/pull/20))
 -   Fixes #15 - Resolves dependencies paths to support hoisted packages in workspace settings ([\#16](https://github.com/liferay/liferay-npm-tools/pull/16))
@@ -701,6 +1097,8 @@
 ## [liferay-npm-scripts/v1.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v1.3.0) (2019-02-13)
 
 [Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v1.2.0...liferay-npm-scripts/v1.3.0)
+
+### :package: Miscellaneous
 
 -   Fixes #6 - Uses deepmerge.all to merge more than one object ([\#11](https://github.com/liferay/liferay-npm-tools/pull/11))
 -   Fixes #9 - Remove npm-which package ([\#10](https://github.com/liferay/liferay-npm-tools/pull/10))


### PR DESCRIPTION
As an example of what these look like, this commit includes changelogs for the packages in this repo (except for liferay-js-insights, which has apparently never been published), made using:

    (cd packages/liferay-changelog-generator && bin/liferay-changelog-generator.js --version=liferay-changelog-generator/v1.2.0 --to=liferay-changelog-generator/v1.2.0 --no-update-tags --regenerate)
    (cd packages/liferay-jest-junit-reporter && ../liferay-changelog-generator/bin/liferay-changelog-generator.js --version=liferay-jest-junit-reporter/v1.2.0 --to=liferay-jest-junit-reporter/v1.2.0 --no-update-tags --regenerate)
    (cd packages/liferay-js-publish && ../liferay-changelog-generator/bin/liferay-changelog-generator.js --version=liferay-js-publish/v1.0.1 --to=liferay-js-publish/v1.0.1 --no-update-tags --regenerate)
    (cd packages/liferay-npm-bundler-preset-liferay-dev && ../liferay-changelog-generator/bin/liferay-changelog-generator.js --version=liferay-npm-bundler-preset-liferay-dev/v4.2.5 --to=liferay-npm-bundler-preset-liferay-dev/v4.2.5 --no-update-tags --regenerate)
    (cd packages/liferay-npm-scripts && ../liferay-changelog-generator/bin/liferay-changelog-generator.js --version=liferay-npm-scripts/v28.0.1 --to=liferay-npm-scripts/v28.0.1 --no-update-tags --regenerate)

That is a bit of a handful obviously, but subsequent updates should be easy. For example, for the next release of liferay-changelog-generator, we'll just have to run:

    bin/liferay-changelog-generator.js --version=liferay-changelog-generator/v1.3.0

(In other projects, we'd use `npx liferay-changelog-generator` instead of `bin/liferay-changelog-generator.js`.)

Closes: https://github.com/liferay/liferay-npm-tools/issues/226