### PR TITLE
feat(changelog): extract "feat", "fix" information from PR titles

### DIFF
--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -222,6 +222,15 @@ const types = {
 	/* eslint-enable sort-keys */
 };
 
+/**
+ * Aliases mapping common mistakes to legit Conventional Commits types.
+ */
+const aliases = {
+	bug: 'fix',
+	doc: 'docs',
+	feature: 'feat',
+};
+
 const TYPE_REGEXP = /^\s*(\w+)(\([^)]+\))?(!)?:\s+.+/;
 
 const BREAKING_TRAILER_REGEXP = /^BREAKING[ -]CHANGE:/m;
@@ -232,10 +241,9 @@ async function formatChanges(changes, remote) {
 	changes.forEach(({description, number}) => {
 		const match = description.match(TYPE_REGEXP);
 
-		const section =
-			match && sections.has(match[1])
-				? sections.get(match[1])
-				: sections.get('misc');
+		const type = aliases[match && match[1]] || (match && match[1]);
+
+		const section = sections.get(type) || sections.get('misc');
 
 		const link = linkToPullRequest(number, remote);
 

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -201,18 +201,18 @@ function linkToVersion(version, remote) {
  */
 const types = {
 	/* eslint-disable sort-keys */
-	feat: 'Features',
-	fix: 'Bug fixes',
-	perf: 'Peformance',
-	docs: 'Documentation',
-	chore: 'Chores',
-	refactor: 'Refactoring',
-	style: 'Style',
-	test: 'Tests',
-	revert: 'Reverts',
+	feat: ':new: Features',
+	fix: ':wrench: Bug fixes',
+	perf: ':racing_car: Peformance',
+	docs: ':book: Documentation',
+	chore: ':house: Chores',
+	refactor: ':woman_juggling: Refactoring',
+	style: ':nail_care: Style',
+	test: ':eyeglasses: Tests',
+	revert: ':leftwards_arrow_with_hook: Reverts',
 
 	// Not in the Conventional Commits spec; this is our catch-all:
-	misc: 'Miscellaneous',
+	misc: ':package: Miscellaneous',
 	/* eslint-enable sort-keys */
 };
 


### PR DESCRIPTION
Test plan: Regenerate the changelog for liferay-npm-scripts with `../liferay-changelog-generator/bin/liferay-changelog-generator.js --version=liferay-npm-scripts/v28.0.1 --to=liferay-npm-scripts/v28.0.1 --no-update-tags --regenerate`:

https://gist.github.com/wincent/436d53be8351f587f42735d307a48f46

(Note that that requires you to be rebased on top of https://github.com/liferay/liferay-npm-tools/pull/398).

Closes: https://github.com/liferay/liferay-npm-tools/issues/227