### PR TITLE
fix(changelog): don't propagate bad whitespace from PR titles

### DIFF
--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -135,7 +135,10 @@ async function getChanges(from, to) {
 				const number = metadata ? metadata[1] : NaN;
 
 				if (description) {
-					changes.set(hash, {description, number});
+					changes.set(hash, {
+						description: description.trim(),
+						number,
+					});
 				}
 			}
 		} else {


### PR DESCRIPTION
Hard to see this in the GitHub UI, but in running the generator over various repos, I found a few odd merge commits that had bad leading whitespace; eg:

https://github.com/liferay/eslint-config-liferay/commit/12a3fbd7426e49d0e86456fb8cbf9bb319bb4b91

(Note the space before the "feat:")

Trim such whitespace off in the output, to avoid creating a disagreement with Prettier (which will insist that the whitespace be stripped).

Test plan: Regen the eslint-config-liferay changelog and see that it no longer contains the unwanted whitespace:

    ../liferay-npm-tools/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js \
      --from=v1.0.1 \
      --to=v19.0.2 \
      --version=v19.0.2 \
      --regenerate