### PR TITLE
fix(scripts): make check/fix globs apply consistently at project level

### DIFF
--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -7,16 +7,10 @@ const clay = require('./dependencies/clay');
 const liferay = require('./dependencies/liferay');
 const metal = require('./dependencies/metal');
 
-const JS_GLOBS = ['/{src,test}/**/*.js'];
-const JSON_GLOBS = ['/*.json'];
-const JSP_GLOBS = ['/src/**/*.{jsp,jspf}'];
-const SCSS_GLOBS = ['/{src,test}/**/*.scss'];
-
 const CHECK_AND_FIX_GLOBS = [
-	...JS_GLOBS,
-	...JSON_GLOBS,
-	...JSP_GLOBS,
-	...SCSS_GLOBS,
+	'/*.{js,json}',
+	'/{src,test}/**/*.{js,scss}',
+	'/src/**/*.{jsp,jspf}',
 ];
 
 module.exports = {


### PR DESCRIPTION
@julien reported that [this PR](https://github.com/brianchandotcom/liferay-portal/pull/85713) was failing SF checks in CI but not locally.

The cause was that [we had conservative default globs defined at the project level](https://github.com/liferay/liferay-npm-tools/blob/29545e04a57b35b17903aa638c7db2be129995ae/packages/liferay-npm-scripts/src/presets/standard/index.js#L10), so if you run `yarn format` locally from a project, as Julien was, it won't actually look at any JS files outside of "src/" or "test/" — this has been the case [since the beginnings of the preset](https://github.com/liferay/liferay-npm-tools/blob/dc58feb8260e3d71b1546782672d5acc08fd6197/packages/liferay-npm-scripts-preset-standard/index.js#L19) (in fact, back then, it was even more conservative, because it only looked at "src/", not "test/").

Compare that with [the top-level globs in liferay-portal](https://github.com/liferay/liferay-portal/blob/a70a80655148ff04e8f939bbdc1fa7b46e74e102/modules/npmscripts.config.js#L17) which will catch dotfiles like `.eslintrc.js`. So CI was failing because it runs project-wide checks.

I think we can make the globs more aggressive in the preset at this point to avoid this kind of confusion. The current behavior is inconsistent enough that I think we can justify calling it a bug.

Closes: https://github.com/liferay/liferay-npm-tools/issues/405