### PR TITLE
docs: update release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ yarn ci
 cd packages/liferay-npm-scripts
 
 # Update the changelog:
-../liferay-changelog-generator --version=liferay-npm-scripts/v29.0.1
+npx liferay-changelog-generator --version=liferay-npm-scripts/v29.0.1
 
 # Review and stage the generated changes:
 git add -p
@@ -105,7 +105,7 @@ yarn ci
 cd packages/liferay-npm-scripts
 
 # Update the changelog.
-../liferay-changelog-generator --version=$PACKAGE_NAME/v9.5.0-beta.1
+npx liferay-changelog-generator --version=$PACKAGE_NAME/v9.5.0-beta.1
 
 # Bump to the prerelease version number
 yarn version --new-version 9.5.0-beta.1


### PR DESCRIPTION
I just noticed while preparing the release of liferay-npm-scripts v28.0.2 that I hadn't included the full path to the generator in the instructions; ie.

    ../liferay-changelog-generator/bin/liferay-changelog-generator.js

Let's just simplify the instructions and tell people to use `npx` because that is much easier. We can assume that if you are working on the changelog generator itself and you want to use an unreleased version of the generator then you probably know when not to use `npx` and provide a full path instead.