### PR TITLE
feat(preset): use css-loader for ".css" files

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -269,7 +269,15 @@
 	"output": "build/node/packageRunBuild/resources",
 	"rules": [
 		{
-			"test": "\\.s?css$",
+			"test": "\\.css$",
+			"use": [
+				{
+					"loader": "css-loader"
+				}
+			]
+		},
+		{
+			"test": "\\.scss$",
 			"exclude": "node_modules",
 			"use": [
 				{

--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -269,7 +269,7 @@
 	"output": "build/node/packageRunBuild/resources",
 	"rules": [
 		{
-			"test": "\\.scss$",
+			"test": "\\.s?css$",
 			"exclude": "node_modules",
 			"use": [
 				{

--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -270,11 +270,7 @@
 	"rules": [
 		{
 			"test": "\\.css$",
-			"use": [
-				{
-					"loader": "css-loader"
-				}
-			]
+			"use": ["css-loader"]
 		},
 		{
 			"test": "\\.scss$",


### PR DESCRIPTION
In addition to the existing support for ".scss" files.

Closes: https://github.com/liferay/liferay-npm-tools/issues/411