### PR TITLE
fix: Make moduleNameMapper work in presence of different module structures

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -77,13 +77,14 @@ function getJestModuleNameMapper() {
 
 					if (main) {
 						const entry = path.join(project, ...SRC_PATH, main);
-						const resources = path.relative(
-							cwd,
-							path.join(project, ...SRC_PATH)
-						);
 
 						if (fs.existsSync(entry)) {
 							const basename = path.basename(project);
+
+							const resources = path.relative(
+								cwd,
+								path.join(project, ...SRC_PATH)
+							);
 
 							mappings[
 								`^${basename}$`

--- a/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -74,19 +74,24 @@ function getJestModuleNameMapper() {
 					const {main} = JSON.parse(
 						fs.readFileSync(packageJson, 'utf8')
 					);
-					if (main) {
-						const file = path.join(project, ...SRC_PATH, main);
 
-						if (fs.existsSync(file)) {
-							const relative = path.relative(cwd, file);
-							const dirname = path.dirname(relative);
+					if (main) {
+						const entry = path.join(project, ...SRC_PATH, main);
+						const resources = path.relative(
+							cwd,
+							path.join(project, ...SRC_PATH)
+						);
+
+						if (fs.existsSync(entry)) {
 							const basename = path.basename(project);
 
-							mappings[`^${basename}$`] = `<rootDir>${relative}`;
+							mappings[
+								`^${basename}$`
+							] = `<rootDir>${path.relative(cwd, entry)}`;
 
 							mappings[
 								`^${basename}/(.*)`
-							] = `<rootDir>${dirname}/$1`;
+							] = `<rootDir>${resources}/$1`;
 						}
 					}
 				}


### PR DESCRIPTION
Problem reported [in Slack](https://liferay.slack.com/archives/CNBG06JS3/p1585226190005800), analyzed in [LPS-110957](https://issues.liferay.com/browse/LPS-110957), and workaround supplied in [this pull](https://github.com/marcosapmf/liferay-portal/pull/7).

Quoting some of the context:

> As we noted in the Slack thread, the import path starts with: "/js/components/..."
>
> The autogenerated moduleNameMapper has this config in it:
>
> ```
>     "^dynamic-data-mapping-form-builder/(.*)": "<rootDir>../dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/$1",
>     "^dynamic-data-mapping-form-field-type$": "<rootDir>../dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/index.js",
> ```
>
> So it basically appends "/js/components/..." etc to the module path which itself ends with "/js", causing a bad path to be yielded with a double "/js/js/" in it.
>
> Root cause is we have inconsistent module structure where some projects put their "main" entry point in "resources/js/" and others directly under "resources/". I'll try to provide a robust solution in liferay-npm-scripts, but for now the immediate workaround is to overwrite `moduleNameMapper` locally.
>
> I think we can discard the alternate fix of making all modules have the exact same structure — that would be too much churn (and risk) for small payoff.
>
> Actual commit to look at is [the last one](https://github.com/marcosapmf/liferay-portal/commit/52ae0903b971f97afb6b9c9f86f2d49c240d6c01), not the preceding 2,447 commits 😂.

Test plan: Ran tests in liferay-portal in the affected module. An `import` of something from `dynamic-data-mapping-form-builder` into the `dynamic-data-mapping-form-web` tests now works.

Mappings before and after this change:

```diff
diff --git a/before b/after
index cb2abbd..225d303 100644
--- a/before
+++ b/after
@@ -1,28 +1,28 @@
 {
   "^app-builder-web$": "<rootDir>../../app-builder/app-builder-web/src/main/resources/META-INF/resources/js/index.es.js",
-  "^app-builder-web/(.*)": "<rootDir>../../app-builder/app-builder-web/src/main/resources/META-INF/resources/js/$1",
+  "^app-builder-web/(.*)": "<rootDir>../../app-builder/app-builder-web/src/main/resources/META-INF/resources/$1",
   "^asset-taglib$": "<rootDir>../../asset/asset-taglib/src/main/resources/META-INF/resources/index.es.js",
   "^asset-taglib/(.*)": "<rootDir>../../asset/asset-taglib/src/main/resources/META-INF/resources/$1",
   "^data-engine-rest-impl$": "<rootDir>../../data-engine/data-engine-rest-impl/src/main/resources/META-INF/resources/index.es.js",
   "^data-engine-rest-impl/(.*)": "<rootDir>../../data-engine/data-engine-rest-impl/src/main/resources/META-INF/resources/$1",
   "^data-engine-taglib$": "<rootDir>../../data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/index.es.js",
-  "^data-engine-taglib/(.*)": "<rootDir>../../data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/$1",
+  "^data-engine-taglib/(.*)": "<rootDir>../../data-engine/data-engine-taglib/src/main/resources/META-INF/resources/$1",
   "^dynamic-data-mapping-form-builder$": "<rootDir>../dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/index.es.js",
-  "^dynamic-data-mapping-form-builder/(.*)": "<rootDir>../dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/$1",
+  "^dynamic-data-mapping-form-builder/(.*)": "<rootDir>../dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/$1",
   "^dynamic-data-mapping-form-field-type$": "<rootDir>../dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/index.js",
   "^dynamic-data-mapping-form-field-type/(.*)": "<rootDir>../dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/$1",
   "^dynamic-data-mapping-form-renderer$": "<rootDir>../dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/index.js",
   "^dynamic-data-mapping-form-renderer/(.*)": "<rootDir>../dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/$1",
   "^dynamic-data-mapping-form-web$": "<rootDir>src/main/resources/META-INF/resources/admin/js/main.es.js",
-  "^dynamic-data-mapping-form-web/(.*)": "<rootDir>src/main/resources/META-INF/resources/admin/js/$1",
+  "^dynamic-data-mapping-form-web/(.*)": "<rootDir>src/main/resources/META-INF/resources/$1",
   "^frontend-editor-ckeditor-web$": "<rootDir>../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.js",
   "^frontend-editor-ckeditor-web/(.*)": "<rootDir>../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/$1",
   "^frontend-js-components-web$": "<rootDir>../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.js",
   "^frontend-js-components-web/(.*)": "<rootDir>../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/$1",
   "^frontend-js-react-web$": "<rootDir>../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.es.js",
-  "^frontend-js-react-web/(.*)": "<rootDir>../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/$1",
+  "^frontend-js-react-web/(.*)": "<rootDir>../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/$1",
   "^frontend-js-web$": "<rootDir>../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js",
   "^frontend-js-web/(.*)": "<rootDir>../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/$1",
   "^item-selector-taglib$": "<rootDir>../../item-selector/item-selector-taglib/src/main/resources/META-INF/resources/index.es.js",
   "^item-selector-taglib/(.*)": "<rootDir>../../item-selector/item-selector-taglib/src/main/resources/META-INF/resources/$1"
-}
\ No newline at end of file
+}
```

Closes: https://github.com/liferay/liferay-npm-tools/issues/424