### PR TITLE
docs(scripts): document how "build" preset values are used

### DIFF
--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -15,9 +15,24 @@ const CHECK_AND_FIX_GLOBS = [
 
 module.exports = {
 	build: {
+		// Passed to:
+		// - `metalsoy` executable (via `generateSoyDependencies()`).
 		dependencies: [...clay, ...liferay, ...metal],
+
+		// Passed to:
+		// - `babel` executable (via `runBabel()`).
+		// - `jest` executable (via resolver.js).
+		// - `metalsoy` executable (via `buildSoy()`).
 		input: 'src/main/resources/META-INF/resources',
+
+		// Passed to:
+		// - `babel` executable (via `runBabel()`).
+		// - `jest` executable (via resolver.js).
+		// - `translateSoy()`.
 		output: 'build/node/packageRunBuild/resources',
+
+		// Used in various places to keep intermediate artefacts out of Gradle's
+		// way (see `buildSoy()`, `withTempFile()`, etc).
 		temp: 'build/npmscripts',
 	},
 	check: CHECK_AND_FIX_GLOBS,


### PR DESCRIPTION
I was asking about this in Slack because I initially thought these were all getting passed to `liferay-npm-bundler`, but `liferay-npm-bundler` doesn't even have most of these properties (only `output`).

So, did a bit of digging to see how each value is used and am documenting it for posterity. There is a risk that this might drift out of sync with the implementation if it changes, but I think it's better to have (possibly) slightly stale documentation than nothing at all.