### PR TITLE
chore(scripts)!: update eslint-config-liferay to v20.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "6.8.0",
-		"eslint-config-liferay": "19.0.1",
+		"eslint-config-liferay": "20.0.0",
 		"prettier": "1.19.1"
 	},
 	"jest": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "6.8.0",
-		"eslint-config-liferay": "20.0.0",
+		"eslint-config-liferay": "20.0.1",
 		"prettier": "1.19.1"
 	},
 	"jest": {

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -42,7 +42,7 @@
 		"css-loader": "^3.0.0",
 		"deepmerge": "^4.0.0",
 		"eslint": "6.8.0",
-		"eslint-config-liferay": "20.0.0",
+		"eslint-config-liferay": "20.0.1",
 		"fs-extra": "^8.1.0",
 		"globby": "11.0.0",
 		"http-proxy-middleware": "0.21.0",

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -42,7 +42,7 @@
 		"css-loader": "^3.0.0",
 		"deepmerge": "^4.0.0",
 		"eslint": "6.8.0",
-		"eslint-config-liferay": "19.0.1",
+		"eslint-config-liferay": "20.0.0",
 		"fs-extra": "^8.1.0",
 		"globby": "11.0.0",
 		"http-proxy-middleware": "0.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5458,10 +5458,10 @@ escodegen@^1.11.0, escodegen@^1.11.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@19.0.1:
-  version "19.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-19.0.1.tgz#51d2dc1a83a01ba663f8057eaf48079f2012254d"
-  integrity sha512-EMufAFBmhzcPPzTgQR3poiiJCtnBuGboMaUprpRW403kSXgsDKEeWnLGQt9lepuXBDFvhXGY3jGIoo6Tmlj3AA==
+eslint-config-liferay@20.0.0:
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-20.0.0.tgz#5c041d5f3a938925a7029d98940a922ba120fda8"
+  integrity sha512-HZXCbu72Cf5Xwb9TZ3+NquKSWPCTsp1B0F2O4LNIT7rpD5Px4K2rNc90Cvf8RqtZb0x3XOnYUhcTu7Uv11DLhA==
   dependencies:
     eslint-config-prettier "^6.5.0"
     eslint-plugin-no-for-of-loops "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5458,10 +5458,10 @@ escodegen@^1.11.0, escodegen@^1.11.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@20.0.0:
-  version "20.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-20.0.0.tgz#5c041d5f3a938925a7029d98940a922ba120fda8"
-  integrity sha512-HZXCbu72Cf5Xwb9TZ3+NquKSWPCTsp1B0F2O4LNIT7rpD5Px4K2rNc90Cvf8RqtZb0x3XOnYUhcTu7Uv11DLhA==
+eslint-config-liferay@20.0.1:
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-20.0.1.tgz#966b1c538d9af8a63685efadd8d9a81c1d7321f1"
+  integrity sha512-9SSavMhQhgaN4NUzEkoD4GGMdAeIBW+YonnRhIqosfa/rwed1twKWeR55s8yR0p2MOUsORl87bhb9UkD2UVKBg==
   dependencies:
     eslint-config-prettier "^6.5.0"
     eslint-plugin-no-for-of-loops "^1.0.0"


### PR DESCRIPTION
- [v20.0.0 release notes](https://github.com/liferay/eslint-config-liferay/releases/tag/v20.0.0).
- [v20.0.1 release notes](https://github.com/liferay/eslint-config-liferay/releases/tag/v20.0.1).

Breaking because it [includes a new lint](https://github.com/liferay/eslint-config-liferay/pull/165) (or, not so much a new lint as a additional places where the "liferay/import-extensions" lint rule now applies).