### PR TITLE
feat(changelog): use version-tag-prefix automatically

### DIFF
--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -383,39 +383,39 @@ function option(name) {
 
 const V_PREFIX_REGEX = /^v\d/;
 
-	//  Regex to take a version number and extract:
-	//
-	//  1. Package name prefix (if present).
-	//  2. "v" (if present).
-	//  3. Valid semver version.
-	//
-	//  Examples
-	//
-	//      package-name/v1.2.3-alpha.1+build.10
-	//      =>  name: "package-name/"
-	//          v: "v"
-	//          semver version: "1.2.3-alpha.1+build.10"
-	//
-	//      package-name/1.2.3-alpha.1+build.10
-	//      =>  name: "package-name/"
-	//          v: undefined
-	//          semver version: "1.2.3-alpha.1+build.10"
-	//
-	//      v1.2.3-alpha.1+build.10
-	//      =>  name: "",
-	//          v: "v"
-	//          semver version: "1.2.3-alpha.1+build.10"
-	//
-	//      1.2.3-alpha.1+build.10
-	//      =>  name: "",
-	//          v: undefined,
-	//          semver version: "1.2.3-alpha.1+build.10"
-	//
-	// If semver version is not valid, behavior is undefined. :troll:
-	//
-	// See: https://semver.org/
-	//
-	const VERSION_REGEX = /^(.*?)(\bv)?(\d+\.\d+\.\d+(?:-[0-9a-z-]+(?:\.[0-9a-z-]+)*)?(?:\+[0-9a-z-]+(?:\.[0-9a-z-]+)*)?)$/i;
+//  Regex to take a version number and extract:
+//
+//  1. Package name prefix (if present).
+//  2. "v" (if present).
+//  3. Valid semver version.
+//
+//  Examples
+//
+//      package-name/v1.2.3-alpha.1+build.10
+//      =>  name: "package-name/"
+//          v: "v"
+//          semver version: "1.2.3-alpha.1+build.10"
+//
+//      package-name/1.2.3-alpha.1+build.10
+//      =>  name: "package-name/"
+//          v: undefined
+//          semver version: "1.2.3-alpha.1+build.10"
+//
+//      v1.2.3-alpha.1+build.10
+//      =>  name: "",
+//          v: "v"
+//          semver version: "1.2.3-alpha.1+build.10"
+//
+//      1.2.3-alpha.1+build.10
+//      =>  name: "",
+//          v: undefined,
+//          semver version: "1.2.3-alpha.1+build.10"
+//
+// If semver version is not valid, behavior is undefined. :troll:
+//
+// See: https://semver.org/
+//
+const VERSION_REGEX = /^(.*?)(\bv)?(\d+\.\d+\.\d+(?:-[0-9a-z-]+(?:\.[0-9a-z-]+)*)?(?:\+[0-9a-z-]+(?:\.[0-9a-z-]+)*)?)$/i;
 
 /**
  * Make sure `version` starts with the appropriate prefix:

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -452,6 +452,7 @@ async function normalizeVersion(version, {force}, versionTagPrefix) {
 	if (!match) {
 		if (force) {
 			warn(`Version "${version}" does not match expected pattern`);
+
 			return version;
 		} else {
 			warn(

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -195,66 +195,6 @@ function escape(string) {
 		.replace(/>/g, '&gt;');
 }
 
-/**
- * Returns a tag pattern that can be passed to `git describe` to select the
- * appropriate tag.
- *
- * If we're being run from a "packages/$PACKAGE" subdirectory in a
- * monorepo and a ".yarnrc" file exists, we use its "version-tag-prefix" to
- * construct a suitable pattern (eg. "some-package/v*").
- *
- * If we can't get a "version-tag-prefix", or if we're being run from the repo
- * root, we use a fallback pattern of "*", which will match any tag.
- *
- * It none of the above apply (eg. because we're not being run from the repo
- * root), an error is thrown.
- */
-async function getTagPattern() {
-	const root = (await git('rev-parse', '--show-toplevel')).trim();
-
-	const cwd = process.cwd();
-
-	const basename = path.basename(cwd);
-
-	const project = path.join(root, 'packages', basename);
-
-	if (cwd === project) {
-		try {
-			const contents = await readFileAsync(
-				path.join(cwd, '.yarnrc'),
-				'utf8'
-			);
-
-			let prefix;
-
-			contents.split(/\r\n|\r|\n/).find(line => {
-				const match = line.match(/^\s*version-tag-prefix\s+"([^"]+)"/);
-
-				if (match) {
-					prefix = match[1];
-
-					return true;
-				}
-			});
-
-			if (prefix) {
-				return `${prefix}*`;
-			}
-		} catch (_error) {
-			// No readable .yarnrc.
-		}
-	} else if (cwd !== root) {
-		throw new Error(
-			`Expected to run from repo root (${path.relative(
-				cwd,
-				root
-			)}) or "packages/*" but was run from ${cwd}`
-		);
-	}
-
-	return '*';
-}
-
 function linkToComparison(from, to, remote) {
 	if (remote && from) {
 		return `[Full changelog](${remote}/compare/${from}...${to})`;
@@ -441,47 +381,121 @@ function option(name) {
 	}
 }
 
-const NUMBER_PREFIX_REGEX = /^\d/;
 const V_PREFIX_REGEX = /^v\d/;
 
+	//  Regex to take a version number and extract:
+	//
+	//  1. Package name prefix (if present).
+	//  2. "v" (if present).
+	//  3. Valid semver version.
+	//
+	//  Examples
+	//
+	//      package-name/v1.2.3-alpha.1+build.10
+	//      =>  name: "package-name/"
+	//          v: "v"
+	//          semver version: "1.2.3-alpha.1+build.10"
+	//
+	//      package-name/1.2.3-alpha.1+build.10
+	//      =>  name: "package-name/"
+	//          v: undefined
+	//          semver version: "1.2.3-alpha.1+build.10"
+	//
+	//      v1.2.3-alpha.1+build.10
+	//      =>  name: "",
+	//          v: "v"
+	//          semver version: "1.2.3-alpha.1+build.10"
+	//
+	//      1.2.3-alpha.1+build.10
+	//      =>  name: "",
+	//          v: undefined,
+	//          semver version: "1.2.3-alpha.1+build.10"
+	//
+	// If semver version is not valid, behavior is undefined. :troll:
+	//
+	// See: https://semver.org/
+	//
+	const VERSION_REGEX = /^(.*?)(\bv)?(\d+\.\d+\.\d+(?:-[0-9a-z-]+(?:\.[0-9a-z-]+)*)?(?:\+[0-9a-z-]+(?:\.[0-9a-z-]+)*)?)$/i;
+
 /**
- * Make sure `version` starts with "v", if that's the convention in this
- * project, and vice versa: remove an unwanted prefix, if that is not the
- * convention.
+ * Make sure `version` starts with the appropriate prefix:
+ *
+ * - "some-tag-prefix/v" read from a `.yarnrc` file (if present); or:
+ * - "v", if that's the convention in the current project; or vice versa:
+ * - not "v" (ie. remove an unwanted prefix), if that is not the
+ *   convention.
  */
-async function normalizeVersion(version, {force}) {
-	const tags = (await git('tag', '-l')).trim().split('\n');
+async function normalizeVersion(version, {force}, versionTagPrefix) {
+	let prefix = '';
 
-	// Calculate a "coefficient" that reflects the likelihood that this repo
-	// uses a "v" prefix by convention.
-	const coefficient = tags.reduce((current, tag) => {
-		return current + (V_PREFIX_REGEX.test(tag) ? 1 : -1);
-	}, 0);
+	if (versionTagPrefix) {
+		// We know the desired prefix (from the .yarnrc).
+		prefix = versionTagPrefix;
+	} else {
+		// Try to guess the right prefix ("v" or nothing) based on existing
+		// tags.
+		const tags = (await git('tag', '-l')).trim().split('\n');
 
-	const hasPrefix = V_PREFIX_REGEX.test(version);
-	const hasNumber = NUMBER_PREFIX_REGEX.test(version);
+		// Calculate a "coefficient" that reflects the likelihood that
+		// this repo uses a "v" prefix by convention.
+		const coefficient = tags.reduce((current, tag) => {
+			return current + (V_PREFIX_REGEX.test(tag) ? 1 : -1);
+		}, 0);
 
-	if (coefficient > 0 && !hasPrefix) {
-		if (force || !hasNumber) {
-			warn(`Version "${version}" is missing expected "v" prefix`);
+		if (coefficient > 0) {
+			prefix = 'v';
+		}
+	}
+
+	const match = version.match(VERSION_REGEX);
+
+	if (!match) {
+		if (force) {
+			warn(`Version "${version}" does not match expected pattern`);
+			return version;
 		} else {
 			warn(
-				`Adding expected "v" prefix to version "${version}"`,
-				'use --force to disable this coercion'
+				`Version "${version}" does not match expected pattern`,
+				'run again with --force to proceed anyway'
 			);
 
-			return `v${version}`;
+			throw new Error('Unexpected version format');
 		}
-	} else if (coefficient < 0 && hasPrefix) {
-		if (force) {
-			warn(`Version "${version}" has unexpected "v" prefix`);
-		} else if (version.length > 1) {
-			warn(
-				`Removing unexpected "v" prefix from "${version}"`,
-				'use --force to disable this coercion'
-			);
+	}
 
-			return version.slice(1);
+	const name = match[1];
+	const v = match[2] || '';
+	const semver = match[3];
+
+	if (prefix) {
+		if (prefix !== name + v) {
+			if (force) {
+				warn(
+					`Version "${version}" is missing expected "${prefix}" prefix`
+				);
+			} else {
+				warn(
+					`Replacing unexpected "${name}${v}" prefix with expected "${prefix}" prefix in version "${version}"`,
+					'use --force to disable this coercion'
+				);
+
+				return `${prefix}${semver}`;
+			}
+		}
+	} else {
+		if (name || v) {
+			if (force) {
+				warn(
+					`Version "${version}" has unexpected "${name}${v}" prefix`
+				);
+			} else {
+				warn(
+					`Removing unexpected "${name}${v}" prefix from "${version}"`,
+					'use --force to disable this coercion'
+				);
+
+				return semver;
+			}
 		}
 	}
 
@@ -598,6 +612,66 @@ async function generate({date, from, remote, to, version}) {
 	);
 }
 
+/**
+ * Returns a tag prefix that can be used to construct or find a version tag.
+ *
+ * -   If we're being run from a "packages/$PACKAGE" subdirectory in a
+ *     monorepo and a ".yarnrc" file exists, we return its "version-tag-prefix".
+ *
+ *     For example, given a prefix of "my-package/v", then we can find matching
+ *     tags using `git-describe`--match='my-package/v*'".
+ *
+ * -   If we can't get a "version-tag-prefix", or if we're being run from the repo
+ *     root, we use a fallback prefix of "".
+ *
+ *     With the fallback prefix of "", we can find matching tags using
+ *     `git-describe --match='*'`.
+ *
+ * It none of the above apply (eg. because we're not being run from the repo
+ * root), an error is thrown.
+ */
+async function getVersionTagPrefix() {
+	const root = (await git('rev-parse', '--show-toplevel')).trim();
+
+	const cwd = process.cwd();
+
+	const basename = path.basename(cwd);
+
+	const project = path.join(root, 'packages', basename);
+
+	let prefix;
+
+	if (cwd === project) {
+		try {
+			const contents = await readFileAsync(
+				path.join(cwd, '.yarnrc'),
+				'utf8'
+			);
+
+			contents.split(/\r\n|\r|\n/).find(line => {
+				const match = line.match(/^\s*version-tag-prefix\s+"([^"]+)"/);
+
+				if (match) {
+					prefix = match[1];
+
+					return true;
+				}
+			});
+		} catch (_error) {
+			// No readable .yarnrc.
+		}
+	} else if (cwd !== root) {
+		throw new Error(
+			`Expected to run from repo root (${path.relative(
+				cwd,
+				root
+			)}) or "packages/*" but was run from ${cwd}`
+		);
+	}
+
+	return prefix || '';
+}
+
 async function main(_node, _script, ...args) {
 	const options = parseArgs(args);
 	if (!options) {
@@ -622,9 +696,15 @@ async function main(_node, _script, ...args) {
 		}
 	}
 
-	const tagPattern = await getTagPattern();
+	const versionTagPrefix = await getVersionTagPrefix();
 
-	const version = await normalizeVersion(options.version, options);
+	const tagPattern = `${versionTagPrefix}*`;
+
+	const version = await normalizeVersion(
+		options.version,
+		options,
+		versionTagPrefix
+	);
 
 	const remote = await getRemote(options);
 	let from = await getPreviousReleasedVersion(to, tagPattern);


### PR DESCRIPTION
The idea of this change is to make it easier to generate changelogs in a monorepo with per-package changelogs. At the moment, you have to provide the `--version` flag in the format that corresponds to the version that you are going to release (eg. `--version=liferay-npm-scripts/v28.0.2`).

But we can make that easier for the user by accepting a shorter format (eg. `v28.0.2` or even `28.0.2`), and then automagically doing the right thing by reading the `version-tag-prefix` from the `.yarnrc`.

Test plan: I tried this in a bunch of scenarios to show that it behaves reasonably.

For starters, in this repo, with:

```
../liferay-changelog-generator/bin/liferay-changelog-generator.js --version=$VERSION
```

Valid: `liferay-npm-scripts/v100.10.10+x-1`

    Wrote ./CHANGELOG.md 59835 bytes ✨

Invalid semver: `liferay-npm-scripts/v100`

    warning: Version "liferay-npm-scripts/v100" does not match expected pattern
    run again with --force to proceed anyway
    Error: Unexpected version format

Valid semver, missing "v": `liferay-npm-scripts/100.10.10`

    warning: Replacing unexpected "liferay-npm-scripts/" prefix with expected "liferay-npm-scripts/v" prefix in version "liferay-npm-scripts/100.10.10"
    use --force to disable this coercion
    Wrote ./CHANGELOG.md 59823 bytes ✨

Misspelled package name: `liferay-npm-scriptz/100.10.10`

    warning: Replacing unexpcted "liferay-npm-scriptz/" prefix with expected "liferay-npm-scripts/v" prefix in version "liferay-npm-scriptz/100.10.10"
    use --force to disable this coercion
    Wrote ./CHANGELOG.md 59823 bytes ✨

For comparison, with `--force` and that same bad name:

    warning: Version "liferay-npm-scriptz/100.10.10" is missing expected "liferay-npm-scripts/v" prefix
    Wrote ./CHANGELOG.md 59820 bytes ✨

Missing package name: `100.10.10`

    warning: Replacing unexpected "" prefix with expected "liferay-npm-scripts/v" prefix in version "100.10.10"
    use --force to disable this coercion
    Wrote ./CHANGELOG.md 59823 bytes ✨

Missing package name, but with "v": `v100.10.10`

    warning: Replacing unexpected "v" prefix with expected "liferay-npm-scripts/v" prefix in version "v100.10.10"
    use --force to disable this coercion
    Wrote ./CHANGELOG.md 59823 bytes ✨

Now, remove the `.yarnrc` and try again:

`v100.10.10`:

    warning: Removing unexpected "v" prefix from "v100.10.10"
    use --force to disable this coercion
    Wrote ./CHANGELOG.md 59760 bytes ✨

`100.10.10`:

    Wrote ./CHANGELOG.md 59760 bytes ✨

`pkg/v100.10.10`:

    warning: Removing unexpected "pkg/v" prefix from "pkg/v100.10.10"
    use --force to disable this coercion
    Wrote ./CHANGELOG.md 59760 bytes ✨

Without the `.yarnrc`, note how we strip off the "v", because none of the tags in the repo start with "v", so we assume it is not wanted.

Now in a non-monorepo (eg. alloy-editor):

Testing with:

```
../liferay-npm-tools/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js --version=100.10.10
```

    warning: Replacing unexpected "" prefix with expected "v" prefix in version "100.10.10"
    use --force to disable this coercion
    Wrote ./CHANGELOG.md 114051 bytes ✨

Note how in alloy-editor where all the tags start with "v", it correctly infers that then "v" should apply.

Obvious disclaimer: if you feed totally random garbage into this, you'll get unpredictable results, but that was always the case, and you should always check the generated changelog before committing it.

Closes: https://github.com/liferay/liferay-npm-tools/issues/408