### PR TITLE
feat(changelog): add --dry-run switch

### DIFF
--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -505,6 +505,7 @@ async function normalizeVersion(version, {force}, versionTagPrefix) {
 
 function parseArgs(args) {
 	const options = {
+		dryRun: false,
 		outfile: './CHANGELOG.md',
 		to: 'HEAD',
 		updateTags: true,
@@ -512,6 +513,13 @@ function parseArgs(args) {
 
 	let match;
 	args.forEach(arg => {
+		match = arg.match(option('dry-run|d'));
+		if (match) {
+			options.dryRun = true;
+
+			return;
+		}
+
 		match = arg.match(option('force|f'));
 		if (match) {
 			options.force = true;
@@ -745,7 +753,11 @@ async function main(_node, _script, ...args) {
 			from = previousVersion;
 		}
 
-		await writeFileAsync(outfile, contents);
+		if (options.dryRun) {
+			process.stdout.write(contents + '\n');
+		} else {
+			await writeFileAsync(outfile, contents);
+		}
 		written = contents.length;
 	} else {
 		let previousContents = '';
@@ -774,11 +786,21 @@ async function main(_node, _script, ...args) {
 		const newContents = [contents, previousContents]
 			.filter(Boolean)
 			.join('\n');
-		await writeFileAsync(outfile, newContents);
+
+		if (options.dryRun) {
+			process.stdout.write(contents + '\n');
+		} else {
+			await writeFileAsync(outfile, newContents);
+		}
+
 		written = newContents.length;
 	}
 
-	info(`Wrote ${outfile} ${written} bytes ✨`);
+	if (options.dryRun) {
+		info(`[--dry-run] Would write ${outfile} ${written} bytes ✨`);
+	} else {
+		info(`Wrote ${outfile} ${written} bytes ✨`);
+	}
 }
 
 module.exports = main;


### PR DESCRIPTION
Prints what would be generated to stdout.

Just a little itch I wanted to scratch. Makes it easier to test changes to the changelog generator.

Test plan:

See changes on stdout:

```
bin/liferay-changelog-generator.js --version=1.4.0 --dry-run
```

Prove that changes can be redirected to a file (ie. changes go to stdout, other messages go to stderr):

```
bin/liferay-changelog-generator.js --version=1.4.0 --dry-run > /tmp/ex
```

Test with `--regenerate` and see a bunch more output:

```
bin/liferay-changelog-generator.js --version=1.4.0 --dry-run --regenerate
```

Show that without `--dry-run`, changelog gets written:

```
bin/liferay-changelog-generator.js --version=1.4.0
```

Show that `-d` is the same as `--dry-run`:

```
bin/liferay-changelog-generator.js --version=1.4.0 -d
```

<img width="1185" alt="liferay-npm-tools___bin_liferay-changelog-generator_js" src="https://user-images.githubusercontent.com/7074/78383742-2e198980-75d9-11ea-8478-362ce315a9d4.png">
