### PR TITLE
feat(scripts): don't filter files when liferay-npm-scripts updates

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/src/utils/filterChangedFiles.js
@@ -45,6 +45,10 @@ function filterChangedFiles(files) {
 			'modules/private/package.json'
 		);
 	} catch (error) {
+		// An exit status of 1 means we detected the change we were looking for:
+		//
+		// https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---quiet
+		// https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---exit-code
 		if (error.toString().includes('exited with status 1.')) {
 			return files;
 		}

--- a/packages/liferay-npm-scripts/src/utils/run.js
+++ b/packages/liferay-npm-scripts/src/utils/run.js
@@ -11,7 +11,18 @@ const {spawn} = require('cross-spawn');
 function run(executable, ...args) {
 	const command = [executable, ...args].join(' ');
 
-	const {error, signal, status, stdout} = spawn.sync(executable, args);
+	const {error, signal, status, stderr, stdout} = spawn.sync(
+		executable,
+		args
+	);
+
+	if (error || signal || status) {
+		if (process.env.CI && process.env.TRAVIS) {
+			process.stderr.write('command:\n\n' + command + '\n\n');
+			process.stderr.write('stdout:\n\n' + stdout + '\n\n');
+			process.stderr.write('stderr:\n\n' + stderr + '\n\n');
+		}
+	}
 
 	if (error) {
 		throw error;

--- a/packages/liferay-npm-scripts/src/utils/run.js
+++ b/packages/liferay-npm-scripts/src/utils/run.js
@@ -9,7 +9,7 @@ const {spawn} = require('cross-spawn');
  * Convenience helper for running commands.
  */
 function run(executable, ...args) {
-	const command = `${executable} ${args.join(' ')}`;
+	const command = [executable, ...args].join(' ');
 
 	const {error, signal, status, stdout} = spawn.sync(executable, args);
 
@@ -19,13 +19,13 @@ function run(executable, ...args) {
 
 	if (signal) {
 		throw new Error(
-			`run(): command \`${command}\` exited due to signal ${signal}`
+			`run(): command \`${command}\` exited due to signal ${signal}.`
 		);
 	}
 
 	if (status) {
 		throw new Error(
-			`run(): command \`${command}\` exited with status ${status}`
+			`run(): command \`${command}\` exited with status ${status}.`
 		);
 	}
 

--- a/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
@@ -53,6 +53,8 @@ describe('filterChangedFiles()', () => {
 		process.chdir(repo);
 
 		git('init');
+		git('config', 'user.email', 'ci@example.net');
+		git('config', 'user.name', 'Continuous Integration');
 
 		fs.mkdirSync(join('modules', 'private'), {recursive: true});
 

--- a/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
@@ -64,7 +64,7 @@ describe('filterChangedFiles()', () => {
 		fs.writeFileSync(privatePkg, 'liferay-npm-scripts: 1\n', 'utf8');
 
 		git('add', 'a', 'modules');
-		git('commit', '-m', 'a', 'a', 'modules');
+		git('commit', '-m', 'a', '--', 'a', 'modules');
 		git('tag', 'a');
 		git('commit', '-m', 'b', '--allow-empty');
 		git('tag', 'b');
@@ -75,17 +75,17 @@ describe('filterChangedFiles()', () => {
 			flag: 'a',
 		});
 
-		git('commit', '-m', 'c', 'a');
+		git('commit', '-m', 'c', '--', 'a');
 		git('tag', 'c');
 
 		fs.writeFileSync(pkg, 'extra: 1\n', {encoding: 'utf8', flag: 'a'});
 
-		git('commit', '-m', 'd', pkg);
+		git('commit', '-m', 'd', '--', pkg);
 		git('tag', 'd');
 
 		fs.writeFileSync(pkg, 'liferay-npm-scripts: 2\nextra: 1\n', 'utf8');
 
-		git('commit', '-m', 'e', pkg);
+		git('commit', '-m', 'e', '--', pkg);
 		git('tag', 'e');
 		git('commit', '-m', 'f', '--allow-empty');
 		git('tag', 'f');
@@ -94,13 +94,13 @@ describe('filterChangedFiles()', () => {
 		fs.writeFileSync(pkg, 'liferay-npm-scripts: 2\n', 'utf8');
 		fs.writeFileSync(privatePkg, 'liferay-npm-scripts: 2\n', 'utf8');
 
-		git('commit', '-m', 'g', 'modules');
+		git('commit', '-m', 'g', '--', 'modules');
 		git('tag', 'g');
 		git('checkout', '-b', 'topic-2');
 
 		fs.writeFileSync('a', 'more stuff\n', {encoding: 'utf8', flag: 'a'});
 
-		git('commit', '-m', 'h', 'a');
+		git('commit', '-m', 'h', '--', 'a');
 		git('tag', 'h');
 
 		fs.writeFileSync(privatePkg, 'extra: 1\n', {
@@ -108,7 +108,7 @@ describe('filterChangedFiles()', () => {
 			flag: 'a',
 		});
 
-		git('commit', '-m', 'i', privatePkg);
+		git('commit', '-m', 'i', '--', privatePkg);
 		git('tag', 'i');
 
 		fs.writeFileSync(
@@ -117,7 +117,7 @@ describe('filterChangedFiles()', () => {
 			'utf8'
 		);
 
-		git('commit', '-m', 'j', privatePkg);
+		git('commit', '-m', 'j', '--', privatePkg);
 		git('tag', 'j');
 		git('commit', '-m', 'k', '--allow-empty');
 		git('tag', 'k');

--- a/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
@@ -64,7 +64,7 @@ describe('filterChangedFiles()', () => {
 		fs.writeFileSync(privatePkg, 'liferay-npm-scripts: 1\n', 'utf8');
 
 		git('add', 'a', 'modules');
-		git('commit', '-m', 'a', '--', 'a', 'modules');
+		git('commit', '-m', 'a', 'a', 'modules');
 		git('tag', 'a');
 		git('commit', '-m', 'b', '--allow-empty');
 		git('tag', 'b');
@@ -75,17 +75,17 @@ describe('filterChangedFiles()', () => {
 			flag: 'a',
 		});
 
-		git('commit', '-m', 'c', '--', 'a');
+		git('commit', '-m', 'c', 'a');
 		git('tag', 'c');
 
 		fs.writeFileSync(pkg, 'extra: 1\n', {encoding: 'utf8', flag: 'a'});
 
-		git('commit', '-m', 'd', '--', pkg);
+		git('commit', '-m', 'd', pkg);
 		git('tag', 'd');
 
 		fs.writeFileSync(pkg, 'liferay-npm-scripts: 2\nextra: 1\n', 'utf8');
 
-		git('commit', '-m', 'e', '--', pkg);
+		git('commit', '-m', 'e', pkg);
 		git('tag', 'e');
 		git('commit', '-m', 'f', '--allow-empty');
 		git('tag', 'f');
@@ -94,13 +94,13 @@ describe('filterChangedFiles()', () => {
 		fs.writeFileSync(pkg, 'liferay-npm-scripts: 2\n', 'utf8');
 		fs.writeFileSync(privatePkg, 'liferay-npm-scripts: 2\n', 'utf8');
 
-		git('commit', '-m', 'g', '--', 'modules');
+		git('commit', '-m', 'g', 'modules');
 		git('tag', 'g');
 		git('checkout', '-b', 'topic-2');
 
 		fs.writeFileSync('a', 'more stuff\n', {encoding: 'utf8', flag: 'a'});
 
-		git('commit', '-m', 'h', '--', 'a');
+		git('commit', '-m', 'h', 'a');
 		git('tag', 'h');
 
 		fs.writeFileSync(privatePkg, 'extra: 1\n', {
@@ -108,7 +108,7 @@ describe('filterChangedFiles()', () => {
 			flag: 'a',
 		});
 
-		git('commit', '-m', 'i', '--', privatePkg);
+		git('commit', '-m', 'i', privatePkg);
 		git('tag', 'i');
 
 		fs.writeFileSync(
@@ -117,7 +117,7 @@ describe('filterChangedFiles()', () => {
 			'utf8'
 		);
 
-		git('commit', '-m', 'j', '--', privatePkg);
+		git('commit', '-m', 'j', privatePkg);
 		git('tag', 'j');
 		git('commit', '-m', 'k', '--allow-empty');
 		git('tag', 'k');

--- a/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
@@ -6,12 +6,14 @@
 const {randomBytes} = require('crypto');
 const fs = require('fs');
 const os = require('os');
-const {join} = require('path');
+const path = require('path');
 
 const filterChangedFiles = require('../../src/utils/filterChangedFiles');
 const git = require('../../src/utils/git');
 
 const TMP_DIR = os.tmpdir();
+
+const join = path.posix.join;
 
 describe('filterChangedFiles()', () => {
 	let branch;

--- a/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {randomBytes} = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const {join} = require('path');
+
+const filterChangedFiles = require('../../src/utils/filterChangedFiles');
+const git = require('../../src/utils/git');
+
+const TMP_DIR = os.tmpdir();
+
+describe('filterChangedFiles()', () => {
+	let branch;
+	let cwd;
+	let files;
+	let pkg;
+	let privatePkg;
+
+	beforeAll(() => {
+		cwd = process.cwd();
+		branch = process.env.LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME;
+
+		// Set up a Git repo with the following history:
+		//
+		//      * (master, HEAD) l
+		//      | * (topic-2) k (touches nothing)
+		//      | * j (updates liferay-npm-scripts in private)
+		//      | * i (touches private package.json but no update)
+		//      | * h (touches a source file)
+		//      |/
+		//      * g (updates scripts in both places)
+		//      | * (topic-1) f (touches nothing)
+		//      | * e (updates liferay-npm-scripts at top-level)
+		//      | * d (touches top-level package.json but no update)
+		//      | * c (touches a source file)
+		//      |/
+		//      * b (touches nothing)
+		//      * a (root commit)
+		//
+		const repo = join(
+			TMP_DIR,
+			`liferay-npm-scripts-${randomBytes(16).toString('hex')}`
+		);
+
+		fs.mkdirSync(repo);
+
+		process.chdir(repo);
+
+		git('init');
+
+		fs.mkdirSync(join('modules', 'private'), {recursive: true});
+
+		pkg = join('modules', 'package.json');
+		privatePkg = join('modules', 'private', 'package.json');
+
+		fs.writeFileSync('a', 'stuff\n', 'utf8');
+		fs.writeFileSync(pkg, 'liferay-npm-scripts: 1\n', 'utf8');
+		fs.writeFileSync(privatePkg, 'liferay-npm-scripts: 1\n', 'utf8');
+
+		git('add', 'a', 'modules');
+		git('commit', '-m', 'a', '--', 'a', 'modules');
+		git('tag', 'a');
+		git('commit', '-m', 'b', '--allow-empty');
+		git('tag', 'b');
+		git('checkout', '-b', 'topic-1');
+
+		fs.writeFileSync('a', 'different stuff\n', {
+			encoding: 'utf8',
+			flag: 'a',
+		});
+
+		git('commit', '-m', 'c', '--', 'a');
+		git('tag', 'c');
+
+		fs.writeFileSync(pkg, 'extra: 1\n', {encoding: 'utf8', flag: 'a'});
+
+		git('commit', '-m', 'd', '--', pkg);
+		git('tag', 'd');
+
+		fs.writeFileSync(pkg, 'liferay-npm-scripts: 2\nextra: 1\n', 'utf8');
+
+		git('commit', '-m', 'e', '--', pkg);
+		git('tag', 'e');
+		git('commit', '-m', 'f', '--allow-empty');
+		git('tag', 'f');
+		git('checkout', 'master');
+
+		fs.writeFileSync(pkg, 'liferay-npm-scripts: 2\n', 'utf8');
+		fs.writeFileSync(privatePkg, 'liferay-npm-scripts: 2\n', 'utf8');
+
+		git('commit', '-m', 'g', '--', 'modules');
+		git('tag', 'g');
+		git('checkout', '-b', 'topic-2');
+
+		fs.writeFileSync('a', 'more stuff\n', {encoding: 'utf8', flag: 'a'});
+
+		git('commit', '-m', 'h', '--', 'a');
+		git('tag', 'h');
+
+		fs.writeFileSync(privatePkg, 'extra: 1\n', {
+			encoding: 'utf8',
+			flag: 'a',
+		});
+
+		git('commit', '-m', 'i', '--', privatePkg);
+		git('tag', 'i');
+
+		fs.writeFileSync(
+			privatePkg,
+			'liferay-npm-scripts: 3\nextra: 1\n',
+			'utf8'
+		);
+
+		git('commit', '-m', 'j', '--', privatePkg);
+		git('tag', 'j');
+		git('commit', '-m', 'k', '--allow-empty');
+		git('tag', 'k');
+		git('checkout', 'master');
+		git('commit', '-m', 'l', '--allow-empty');
+		git('tag', 'l');
+
+		files = git('ls-tree', '--name-only', '-r', 'HEAD').split('\n');
+	});
+
+	afterAll(() => {
+		process.chdir(cwd);
+		process.env.LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME = branch;
+	});
+
+	it('has a test repo that it can use (sanity check)', () => {
+		expect(files.length).toBe(3);
+	});
+
+	describe('when LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME is not set', () => {
+		it('returns all files', () => {
+			expect(filterChangedFiles(files)).toEqual(files);
+		});
+	});
+
+	describe('when LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME is set', () => {
+		beforeEach(() => {
+			process.env.LIFERAY_NPM_SCRIPTS_WORKING_BRANCH_NAME = 'master';
+		});
+
+		it('returns only changed files, unless it detects a liferay-npm-scripts update', () => {
+			// Top-level.
+			git('checkout', '--detach', 'c');
+			expect(filterChangedFiles(files)).toEqual(['a']);
+
+			git('checkout', '--detach', 'd');
+			expect(filterChangedFiles(files)).toEqual(['a', pkg]);
+
+			git('checkout', '--detach', 'e');
+			expect(filterChangedFiles(files)).toEqual(files);
+
+			// Private.
+			git('checkout', '--detach', 'h');
+			expect(filterChangedFiles(files)).toEqual(['a']);
+
+			git('checkout', '--detach', 'i');
+			expect(filterChangedFiles(files)).toEqual(['a', privatePkg]);
+
+			git('checkout', '--detach', 'j');
+			expect(filterChangedFiles(files)).toEqual(files);
+		});
+	});
+});

--- a/packages/liferay-npm-scripts/test/utils/run.js
+++ b/packages/liferay-npm-scripts/test/utils/run.js
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const run = require('../../src/utils/run');
+
+describe('run()', () => {
+	it('runs a command and returns its output', () => {
+		expect(run('echo', 'hello')).toBe('hello');
+	});
+
+	it('reports the exit status of failed commands', () => {
+		// NOTE: we want the error message format to be stable, because
+		// `filterChangedFiles()` depends on it.
+		expect(() => run('false')).toThrow(
+			'run(): command `false` exited with status 1.'
+		);
+	});
+});


### PR DESCRIPTION
Originally sent as: https://github.com/liferay/liferay-npm-tools/pull/435

But for some reason, CI isn't picking up new commits on that one. Trying a new PR here.

---

As described in #416:

> We saw SF fail in this PR:
>
> https://github.com/liferay/liferay-portal-ee/pull/18535
>
> because when we did this backport:
>
> https://github.com/liferay/liferay-portal-ee/pull/18336
>
> of liferay-npm-scripts to the 7.2.x branch, new formatting rules came into effect but we didn't run the checks over the entire repo (in CI, we only run on changed/new files).
>
> The idea, then, is to run more broadly on branches that change the liferay-npm-scripts version (because any updates to eslint-config-liferay — or stylelint, or prettier — end up coming in via a new version of liferay-npm-scripts).
>
> A full-repo formatting check takes about 2m. The top-level package.json doesn't change all that often, so this won't happen often. For example, looking at the history:
>
> https://github.com/liferay/liferay-portal/commits/master/modules/package.json
>
> right now, I see only 8 changes in the last 30 days, and 30 changes over the last 3 months).
>
> If we want to reduce the likelihood of doing a full run unnecessarily, we could also look at the actual diff and detect whether the version of liferay-npm-scripts actually changed.

In the end that's exactly what I did: we look at the diff to see if it includes added/removed (ie. changed) lines containing the string "liferay-npm-scripts" in either "modules/package.json" or "modules/private/package.json".

Closes: https://github.com/liferay/liferay-npm-tools/issues/416