### PR TITLE
chore!: update Prettier to v2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"devDependencies": {
 		"eslint": "6.8.0",
 		"eslint-config-liferay": "20.0.1",
-		"prettier": "1.19.1"
+		"prettier": "2.0.5"
 	},
 	"jest": {
 		"setupFilesAfterEnv": [

--- a/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js
+++ b/packages/liferay-changelog-generator/bin/liferay-changelog-generator.js
@@ -7,7 +7,7 @@
 
 const main = require('../src');
 
-main(...process.argv).catch(err => {
+main(...process.argv).catch((err) => {
 	process.stderr.write(`${err}\n`);
 	process.exit(1);
 });

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -266,7 +266,7 @@ const TYPE_REGEXP = /^\s*(\w+)(\([^)]+\))?(!)?:\s+.+/;
 const BREAKING_TRAILER_REGEXP = /^BREAKING[ -]CHANGE:/m;
 
 async function formatChanges(changes, remote) {
-	const sections = new Map(Object.keys(types).map(type => [type, []]));
+	const sections = new Map(Object.keys(types).map((type) => [type, []]));
 
 	changes.forEach(({description, number}) => {
 		const match = description.match(TYPE_REGEXP);
@@ -317,7 +317,7 @@ async function formatChanges(changes, remote) {
  *
  */
 function printBanner(message) {
-	const lines = message.split('\n').map(line => line.trim());
+	const lines = message.split('\n').map((line) => line.trim());
 
 	const width = lines.reduce((max, line) => {
 		return Math.max(max, line.length);
@@ -335,7 +335,7 @@ function printBanner(message) {
 
 	TEMPLATE.forEach(([left, middle, right]) => {
 		if (middle === '*') {
-			lines.forEach(line => {
+			lines.forEach((line) => {
 				banner +=
 					left +
 					line +
@@ -512,7 +512,7 @@ function parseArgs(args) {
 	};
 
 	let match;
-	args.forEach(arg => {
+	args.forEach((arg) => {
 		match = arg.match(option('dry-run|d'));
 		if (match) {
 			options.dryRun = true;
@@ -599,10 +599,7 @@ function parseArgs(args) {
 function formatDate(date) {
 	const year = date.getFullYear();
 	const month = (date.getMonth() + 1).toString().padStart(2, '0');
-	const day = date
-		.getDate()
-		.toString()
-		.padStart(2, '0');
+	const day = date.getDate().toString().padStart(2, '0');
 
 	return `${year}-${month}-${day}`;
 }
@@ -657,7 +654,7 @@ async function getVersionTagPrefix() {
 				'utf8'
 			);
 
-			contents.split(/\r\n|\r|\n/).find(line => {
+			contents.split(/\r\n|\r|\n/).find((line) => {
 				const match = line.match(/^\s*version-tag-prefix\s+"([^"]+)"/);
 
 				if (match) {

--- a/packages/liferay-jest-junit-reporter/src/index.js
+++ b/packages/liferay-jest-junit-reporter/src/index.js
@@ -20,7 +20,7 @@ function formatDirectoryPath(dirPath) {
 	return dirPath.replace(APPS_DIR, '').replace(/\//g, '.');
 }
 
-module.exports = report => {
+module.exports = (report) => {
 	const generalMetrics = {
 		_attr: {
 			errors: 0,
@@ -41,7 +41,7 @@ module.exports = report => {
 			(results, suite) =>
 				suite.testResults.length
 					? results.concat(
-							suite.testResults.map(test => ({
+							suite.testResults.map((test) => ({
 								...test,
 								testFilePath: suite.testFilePath,
 							}))
@@ -49,7 +49,7 @@ module.exports = report => {
 					: results,
 			[]
 		)
-		.map(testCase => {
+		.map((testCase) => {
 			const results = [
 				{
 					_attr: {
@@ -64,10 +64,10 @@ module.exports = report => {
 
 			if (testCase.failureMessages && testCase.failureMessages.length) {
 				const failureMessageArr = testCase.failureMessages.map(
-					failureMessage =>
+					(failureMessage) =>
 						failureMessage
 							.split(NEW_LINE)
-							.map(message =>
+							.map((message) =>
 								stripAnsi(message).replace(APPS_DIR, '')
 							)
 				);
@@ -80,7 +80,7 @@ module.exports = report => {
 							},
 						},
 						failureMessageArr
-							.map(failureMessage =>
+							.map((failureMessage) =>
 								failureMessage.join(NEW_LINE)
 							)
 							.join(NEW_LINE),

--- a/packages/liferay-js-insights/index.js
+++ b/packages/liferay-js-insights/index.js
@@ -89,8 +89,10 @@ async function getModuleMeta(modulePath) {
 		const meta = await getModuleMeta(modulePath);
 
 		await Promise.all(
-			requestedInsights.map(insight => INSIGHTS[insight]({ast, content}))
-		).then(values => {
+			requestedInsights.map((insight) =>
+				INSIGHTS[insight]({ast, content})
+			)
+		).then((values) => {
 			const moduleInfo = {meta};
 
 			requestedInsights.forEach((insight, index) => {

--- a/packages/liferay-js-insights/insights/dependencies.js
+++ b/packages/liferay-js-insights/insights/dependencies.js
@@ -8,30 +8,30 @@ const {default: traverse} = require('@babel/traverse');
 const SOURCE_GROUPS = [
 	{
 		name: 'clay3',
-		test: source => source.startsWith('@clayui'),
+		test: (source) => source.startsWith('@clayui'),
 	},
 	{
 		name: 'react',
-		test: source =>
+		test: (source) =>
 			source.startsWith('react') ||
 			source.startsWith('prop-types') ||
 			source.startsWith('classnames'),
 	},
 	{
 		name: 'js',
-		test: source => source.startsWith('frontend-js-web'),
+		test: (source) => source.startsWith('frontend-js-web'),
 	},
 	{
 		name: 'metal',
-		test: source => source.startsWith('metal-') || source === 'metal',
+		test: (source) => source.startsWith('metal-') || source === 'metal',
 	},
 	{
 		name: 'clay2',
-		test: source => source.startsWith('clay-') || source === 'clay',
+		test: (source) => source.startsWith('clay-') || source === 'clay',
 	},
 	{
 		name: 'others',
-		test: source => true, // eslint-disable-line
+		test: (source) => true, // eslint-disable-line
 	},
 ];
 
@@ -46,7 +46,7 @@ const SOURCE_GROUPS = [
  *  - others
  *  - react
  */
-module.exports = async function({ast}) {
+module.exports = async function ({ast}) {
 	const dependencies = SOURCE_GROUPS.reduce((deps, group) => {
 		deps[group.name] = [];
 
@@ -55,15 +55,15 @@ module.exports = async function({ast}) {
 
 	traverse(ast, {
 		ImportDeclaration({node}) {
-			const {name} = SOURCE_GROUPS.find(group =>
+			const {name} = SOURCE_GROUPS.find((group) =>
 				group.test(node.source.value)
 			);
 
 			dependencies[name] = [
 				...dependencies[name],
 				node.specifiers
-					.filter(specifier => specifier.local.name)
-					.map(specifier => specifier.local.name),
+					.filter((specifier) => specifier.local.name)
+					.map((specifier) => specifier.local.name),
 			].reduce((memo, it) => memo.concat(it), []); // Not using flatMap to support Node.js 10;;;
 		},
 	});

--- a/packages/liferay-js-insights/insights/loc.js
+++ b/packages/liferay-js-insights/insights/loc.js
@@ -25,7 +25,7 @@ function extractWhitespaceLOC(content) {
 /**
  * Returns information about the number of lines in the module and their nature: code, comment, total and whitespace
  */
-module.exports = async function({ast, content}) {
+module.exports = async function ({ast, content}) {
 	const comment = extractCommentLOC(ast);
 	const total = ast.loc.end.line;
 	const whitespace = extractWhitespaceLOC(content);

--- a/packages/liferay-js-insights/reporters/airtable.js
+++ b/packages/liferay-js-insights/reporters/airtable.js
@@ -37,7 +37,7 @@ const progress = new cliProgress.MultiBar(
  *
  * 		- The Table name should be provided as `--output`. If none is passed, it defaults to `master`.
  */
-module.exports = async function(modulesInfo, config) {
+module.exports = async function (modulesInfo, config) {
 	const {airtableApiKey, airtableBaseKey, output} = {
 		airtableApiKey: process.env.LFR_DEPS_AIRTABLE_API_KEY,
 		airtableBaseKey: process.env.LFR_DEPS_AIRTABLE_BASE_KEY,
@@ -52,16 +52,18 @@ module.exports = async function(modulesInfo, config) {
 
 	while (synced < modulesInfo.length) {
 		// Airtable API only allows creating up to 10 records per request. It also expects a flat Map<string, object> `fields` parameter
-		const chunk = modulesInfo.slice(synced, synced + 10).map(moduleInfo => {
-			return {
-				fields: {
-					app: moduleInfo.meta.app,
-					module: moduleInfo.meta.name,
-					url: moduleInfo.meta.url,
-					...moduleInfo.dependencies,
-				},
-			};
-		});
+		const chunk = modulesInfo
+			.slice(synced, synced + 10)
+			.map((moduleInfo) => {
+				return {
+					fields: {
+						app: moduleInfo.meta.app,
+						module: moduleInfo.meta.name,
+						url: moduleInfo.meta.url,
+						...moduleInfo.dependencies,
+					},
+				};
+			});
 
 		try {
 			await base(output).create(chunk, {

--- a/packages/liferay-js-insights/reporters/json.js
+++ b/packages/liferay-js-insights/reporters/json.js
@@ -17,8 +17,8 @@ function prepareModule(dependencies) {
 	};
 
 	Object.keys(dependencies)
-		.filter(key => dependencies[key] && dependencies[key].length)
-		.forEach(key => {
+		.filter((key) => dependencies[key] && dependencies[key].length)
+		.forEach((key) => {
 			simpleModule.dependencies[key] = dependencies[key];
 		});
 
@@ -31,9 +31,9 @@ function prepareModule(dependencies) {
  *
  * Modules will be grouped within their application and the report will only show the groups that are actually depended upon rather than all of them. For example, if a module does not have any dependency on Clay3, the `clay3` field won't show up in the report.
  */
-module.exports = async function(modulesInfo, {output}) {
+module.exports = async function (modulesInfo, {output}) {
 	const modulesJSON = modulesInfo
-		.filter(moduleInfo => moduleInfo.dependencies)
+		.filter((moduleInfo) => moduleInfo.dependencies)
 		.reduce((acc, {dependencies, meta}) => {
 			const moduleData = {
 				name: meta.name,

--- a/packages/liferay-js-insights/reporters/table.js
+++ b/packages/liferay-js-insights/reporters/table.js
@@ -17,7 +17,7 @@ const idx = (p, o) => p.reduce((xs, x) => (xs && xs[x] ? xs[x] : null), o);
 /**
  * Prints the modules's insights report as a table in the terminal.
  */
-module.exports = async function(modulesInfo, config) {
+module.exports = async function (modulesInfo, config) {
 	const {output} = {
 		...DEFAULT_CONFIG,
 		...config,
@@ -32,10 +32,10 @@ module.exports = async function(modulesInfo, config) {
 	const table = new Table({colWidths, head});
 
 	modulesInfo
-		.map(moduleInfo =>
-			head.map(field => idx(field.split('.'), moduleInfo) || '')
+		.map((moduleInfo) =>
+			head.map((field) => idx(field.split('.'), moduleInfo) || '')
 		)
-		.forEach(moduleInfo => table.push(moduleInfo));
+		.forEach((moduleInfo) => table.push(moduleInfo));
 
 	// eslint-disable-next-line no-console
 	console.log(table.toString());

--- a/packages/liferay-js-publish/src/index.js
+++ b/packages/liferay-js-publish/src/index.js
@@ -119,10 +119,10 @@ function confirm(prompt, answer = 'y', matcher = YES_REGEX) {
 		});
 	}
 
-	const promise = new Promise(resolve => {
+	const promise = new Promise((resolve) => {
 		const question = answer === 'y' ? `${prompt} [y/n] ` : `${prompt} `;
 		readline.question(question, resolve);
-	}).then(result => {
+	}).then((result) => {
 		if (answer === 'y') {
 			if (!result.match(matcher)) {
 				throw new Error('User aborted');
@@ -143,7 +143,7 @@ function getRemote() {
 	const remotes = git('remote', '-v').split('\n');
 
 	const upstreams = remotes
-		.map(remote => {
+		.map((remote) => {
 			const [name, url] = remote.split(/\s+/);
 
 			return [name, url];
@@ -207,7 +207,7 @@ async function runYarnPublish(pkg) {
 let exitStatus = 0;
 
 main()
-	.catch(error => {
+	.catch((error) => {
 		printBanner(
 			'Failed to automatically publish package! ❌',
 			error.message,

--- a/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
+++ b/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
@@ -12,7 +12,7 @@ async function main() {
 	await require('../src/index')();
 }
 
-main().catch(error => {
+main().catch((error) => {
 	if (error instanceof SpawnError) {
 		// For this common error case (spawned tools exiting with an error)
 		// we avoid printing a stack trace.

--- a/packages/liferay-npm-scripts/contrib/prettier/prettier.js
+++ b/packages/liferay-npm-scripts/contrib/prettier/prettier.js
@@ -17,7 +17,7 @@ let outputChannel;
 // pain.
 //
 // eslint-disable-next-line no-unused-vars
-const debug = line => {
+const debug = (line) => {
 	try {
 		if (!outputChannel) {
 			const {window} = require('vscode');

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -58,7 +58,7 @@
 		"liferay-theme-tasks": "10.0.2",
 		"metal-tools-soy": "4.3.2",
 		"minimist": "^1.2.0",
-		"prettier": "1.19.1",
+		"prettier": "2.0.5",
 		"react": "*",
 		"react-dom": "*",
 		"regenerator-runtime": "0.13.3",

--- a/packages/liferay-npm-scripts/src/index.js
+++ b/packages/liferay-npm-scripts/src/index.js
@@ -5,7 +5,7 @@
 
 const minimist = require('minimist');
 
-module.exports = async function() {
+module.exports = async function () {
 	const ARGS_ARRAY = process.argv.slice(2);
 
 	const {

--- a/packages/liferay-npm-scripts/src/jest/mocks/Liferay.js
+++ b/packages/liferay-npm-scripts/src/jest/mocks/Liferay.js
@@ -47,7 +47,7 @@ const Language = {
 	/**
 	 * https://github.com/liferay/liferay-portal/blob/31073fb75fb0d3b309f9e0f921cb7a469aa2703d/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/language.js#L18
 	 */
-	get: jest.fn(key => key),
+	get: jest.fn((key) => key),
 };
 
 /**

--- a/packages/liferay-npm-scripts/src/jest/resolver.js
+++ b/packages/liferay-npm-scripts/src/jest/resolver.js
@@ -13,7 +13,7 @@ const CWD = process.cwd();
 const INPUT = BUILD_CONFIG.input.replace('/', path.sep);
 const OUTPUT = BUILD_CONFIG.output;
 
-module.exports = function(request, options) {
+module.exports = function (request, options) {
 	const {basedir, defaultResolver} = options;
 
 	// Redirect imports to .soy.js files from input to output directory

--- a/packages/liferay-npm-scripts/src/jsp/Lexer.js
+++ b/packages/liferay-npm-scripts/src/jsp/Lexer.js
@@ -38,7 +38,7 @@ class Lexer {
 	}
 
 	*lex(input) {
-		const lookup = matcher => this.lookup(matcher);
+		const lookup = (matcher) => this.lookup(matcher);
 
 		const setMatcher = (name, matcher) => this._matchers.set(name, matcher);
 
@@ -135,7 +135,7 @@ class Lexer {
 			const permutations = permute(matchers);
 
 			// ...and transform into: oneOf(sequence(a, b), sequence(b, a)):
-			const matcher = oneOf(...permutations.map(m => sequence(...m)));
+			const matcher = oneOf(...permutations.map((m) => sequence(...m)));
 
 			return {
 				get description() {
@@ -143,7 +143,7 @@ class Lexer {
 						this._description ||
 						'allOf:(' +
 							matchers
-								.map(matcher => lookup(matcher).description)
+								.map((matcher) => lookup(matcher).description)
 								.join(', ') +
 							')'
 					);
@@ -218,7 +218,7 @@ class Lexer {
 				},
 			});
 
-			matcher.exec = string => {
+			matcher.exec = (string) => {
 				const match = RegExp.prototype.exec.call(matcher, string);
 
 				if (match !== null) {
@@ -317,7 +317,7 @@ class Lexer {
 					return (
 						this._description ||
 						matchers
-							.map(matcher => lookup(matcher).description)
+							.map((matcher) => lookup(matcher).description)
 							.join(' | ')
 					);
 				},
@@ -415,7 +415,7 @@ class Lexer {
 					return (
 						this._description ||
 						matchers
-							.map(matcher => lookup(matcher).description)
+							.map((matcher) => lookup(matcher).description)
 							.join(' ')
 					);
 				},
@@ -610,7 +610,7 @@ class Lexer {
 		 * Convenience function for building simple lexers from a map of token
 		 * names to matchers.
 		 */
-		const choose = map => {
+		const choose = (map) => {
 			return () => {
 				if (typeof map[Symbol.iterator] !== 'function') {
 					map = new Map(Object.entries(map));
@@ -681,7 +681,7 @@ class Lexer {
 		/**
 		 * Reports a failure to match.
 		 */
-		const fail = reasonOrMatcher => {
+		const fail = (reasonOrMatcher) => {
 			let reason;
 
 			if (reasonOrMatcher.description) {

--- a/packages/liferay-npm-scripts/src/jsp/dedent.js
+++ b/packages/liferay-npm-scripts/src/jsp/dedent.js
@@ -9,7 +9,7 @@
  */
 function dedent(input, tabWidth = 4) {
 	// Collapse totally blank lines to empty strings.
-	const lines = input.split('\n').map(line => {
+	const lines = input.split('\n').map((line) => {
 		if (line.match(/^\s+$/)) {
 			return '';
 		} else {
@@ -36,7 +36,7 @@ function dedent(input, tabWidth = 4) {
 
 	// Strip out minimum indent from every line.
 	const dedented = isFinite(minimum)
-		? lines.map(line => {
+		? lines.map((line) => {
 				const [, indent, rest] = line.match(/^(\s*)(.*)/);
 
 				if (minimum && indent.length) {

--- a/packages/liferay-npm-scripts/src/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/formatJSP.js
@@ -19,7 +19,7 @@ function formatJSP(source, prettierConfig = getMergedConfig('prettier')) {
 	};
 
 	return processJSP(source, {
-		onFormat: input => {
+		onFormat: (input) => {
 			return prettier.format(input, prettierOptions);
 		},
 	});

--- a/packages/liferay-npm-scripts/src/jsp/indent.js
+++ b/packages/liferay-npm-scripts/src/jsp/indent.js
@@ -10,7 +10,7 @@
 function indent(text, count = 1, whitespace = '\t') {
 	return text
 		.split('\n')
-		.map(line => {
+		.map((line) => {
 			if (line.length) {
 				return `${whitespace.repeat(count)}${line}`;
 			} else {

--- a/packages/liferay-npm-scripts/src/jsp/lex.js
+++ b/packages/liferay-npm-scripts/src/jsp/lex.js
@@ -18,7 +18,7 @@ function lex(source, options = {}) {
 		...options,
 	};
 
-	const lexer = new Lexer(api => {
+	const lexer = new Lexer((api) => {
 		const {
 			a,
 			allOf,
@@ -522,7 +522,7 @@ function lex(source, options = {}) {
 			maybe('SPACE')
 		)
 			.name('ATTRIBUTES')
-			.onEnter(meta => {
+			.onEnter((meta) => {
 				meta.set('attribute:names', []);
 			})
 			.onMatch((_match, meta) => {
@@ -530,7 +530,7 @@ function lex(source, options = {}) {
 
 				if (attributes.length > new Set(attributes).size) {
 					const names = attributes
-						.map(name => JSON.stringify(name))
+						.map((name) => JSON.stringify(name))
 						.join(', ');
 
 					fail(`Attribute names must be unique (got: ${names})`);

--- a/packages/liferay-npm-scripts/src/jsp/lintJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/lintJSP.js
@@ -34,7 +34,7 @@ function lintJSP(source, onReport, options = {}) {
 	const {fix, quiet} = options;
 
 	return processJSP(source, {
-		onLint: input => {
+		onLint: (input) => {
 			let messages;
 			let output;
 
@@ -50,7 +50,7 @@ function lintJSP(source, onReport, options = {}) {
 			let fixableWarningCount = 0;
 			let warningCount = 0;
 
-			messages = messages.filter(message => {
+			messages = messages.filter((message) => {
 				if (message.severity === SEVERITY.ERROR) {
 					errorCount++;
 

--- a/packages/liferay-npm-scripts/src/jsp/processJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/processJSP.js
@@ -28,7 +28,7 @@ function processJSP(source, {onFormat, onLint}) {
 	}
 
 	// TODO: lint for <(aui:)?script> not followed by newline (there are basically none in liferay-portal)
-	const transformed = blocks.map(block => {
+	const transformed = blocks.map((block) => {
 		const {contents, range} = block;
 
 		// Trim leading and trailing whitespace before Prettier eats it.

--- a/packages/liferay-npm-scripts/src/jsp/restoreTags.js
+++ b/packages/liferay-npm-scripts/src/jsp/restoreTags.js
@@ -17,7 +17,7 @@ const {TAB_CHAR, isFiller} = require('./toFiller');
 function restoreTags(source, tags) {
 	let tagCount = 0;
 
-	const lexer = new Lexer(api => {
+	const lexer = new Lexer((api) => {
 		const {choose, match} = api;
 
 		const ANYTHING = match(/[\s\S]/);

--- a/packages/liferay-npm-scripts/src/jsp/stripIndents.js
+++ b/packages/liferay-npm-scripts/src/jsp/stripIndents.js
@@ -39,7 +39,7 @@ const {CLOSE_TAG, OPEN_TAG} = require('./tagReplacements');
 //
 // So, this function does the same.
 function stripIndents(source) {
-	const lexer = new Lexer(api => {
+	const lexer = new Lexer((api) => {
 		const {choose, match} = api;
 
 		const ANYTHING = match(/[\s\S]/);

--- a/packages/liferay-npm-scripts/src/jsp/toFiller.js
+++ b/packages/liferay-npm-scripts/src/jsp/toFiller.js
@@ -57,7 +57,7 @@ function toFiller(string, filler = FILLER_CHAR) {
 			LINE.exec(body) || {};
 
 		if (match) {
-			output += indent.replace(/./g, char => {
+			output += indent.replace(/./g, (char) => {
 				return char[0] === '\t' ? TAB_CHAR : SPACE_CHAR;
 			});
 

--- a/packages/liferay-npm-scripts/src/prettier/rules/newline-before-block-statements.js
+++ b/packages/liferay-npm-scripts/src/prettier/rules/newline-before-block-statements.js
@@ -21,7 +21,7 @@ module.exports = {
 				const indent = '\t'.repeat(last.loc.end.column - 1);
 
 				context.report({
-					fix: fixer => {
+					fix: (fixer) => {
 						if (source.commentsExistBetween(last, keyword)) {
 							const comments = source.getCommentsAfter(last);
 

--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -52,7 +52,7 @@ function runBridge() {
 	// Retrieves the `.npmbridgerc` configuration which we already know exists
 	const bridgeConfig = JSON.parse(fs.readFileSync('.npmbridgerc', 'utf8'));
 
-	Object.keys(bridgeConfig).forEach(moduleKey => {
+	Object.keys(bridgeConfig).forEach((moduleKey) => {
 		const output = bridgeConfig[moduleKey].output;
 
 		if (output) {
@@ -69,7 +69,7 @@ function runBridge() {
  * ".npmbridgerc" and "webpack.config.js" files, respectively, are
  * present, and soy is run when soy files are detected.
  */
-module.exports = function() {
+module.exports = function () {
 	setEnv('production');
 
 	validateConfig(

--- a/packages/liferay-npm-scripts/src/scripts/check/preflight.js
+++ b/packages/liferay-npm-scripts/src/scripts/check/preflight.js
@@ -83,7 +83,7 @@ function checkConfigFileNames() {
 		IGNORE_FILE
 	);
 
-	return disallowedConfigs.map(file => {
+	return disallowedConfigs.map((file) => {
 		const suggested = DISALLOWED_CONFIG_FILE_NAMES[path.basename(file)];
 
 		return `${file}: BAD - use ${suggested} instead`;
@@ -106,19 +106,19 @@ function checkPackageJSONFiles() {
 
 	if (rules && rules[BLACKLISTED_DEPENDENCY_PATTERNS]) {
 		const blacklist = rules[BLACKLISTED_DEPENDENCY_PATTERNS].map(
-			pattern => {
+			(pattern) => {
 				return new RegExp(pattern);
 			}
 		);
 
-		packages.forEach(pkg => {
+		packages.forEach((pkg) => {
 			try {
 				const {dependencies} = JSON.parse(fs.readFileSync(pkg), 'utf8');
 
 				const names = dependencies ? Object.keys(dependencies) : [];
 
-				names.forEach(name => {
-					blacklist.forEach(pattern => {
+				names.forEach((name) => {
+					blacklist.forEach((pattern) => {
 						if (pattern.test(name)) {
 							errors.push(
 								`${pkg}: BAD - contains blacklisted dependency: ${name}`

--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -49,7 +49,7 @@ function format(options = {}) {
 	let bad = 0;
 	let fixed = 0;
 
-	paths.forEach(filepath => {
+	paths.forEach((filepath) => {
 		checked++;
 
 		try {
@@ -90,8 +90,8 @@ function format(options = {}) {
 		}
 	});
 
-	const files = count => (count === 1 ? 'file' : 'files');
-	const have = count => (count === 1 ? 'has' : 'have');
+	const files = (count) => (count === 1 ? 'file' : 'files');
+	const have = (count) => (count === 1 ? 'has' : 'have');
 
 	const summary = [`Prettier checked ${checked} ${files(checked)}`];
 

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -109,7 +109,7 @@ async function lint(options = {}) {
 			try {
 				const updated = await linter(
 					contents,
-					result => {
+					(result) => {
 						report.results.push({
 							...result,
 							filePath: path.resolve(filePath),
@@ -131,8 +131,8 @@ async function lint(options = {}) {
 	// Otherwise keep both errors and warnings.
 	// Filter out everything else.
 	const results = (report.results || [])
-		.map(result => {
-			const messages = result.messages.filter(message => {
+		.map((result) => {
+			const messages = result.messages.filter((message) => {
 				return quiet ? message.severity === 2 : true;
 			});
 
@@ -192,7 +192,7 @@ function formatter(results) {
 	let output = '';
 	let warnings = 0;
 
-	results.forEach(result => {
+	results.forEach((result) => {
 		output += color.UNDERLINE + result.filePath + color.RESET + '\n';
 
 		result.messages.forEach(
@@ -271,11 +271,11 @@ function partitionArray(array, predicates) {
 		default: [],
 	};
 
-	Object.keys(predicates).forEach(key => {
+	Object.keys(predicates).forEach((key) => {
 		results[key] = [];
 	});
 
-	array.forEach(item => {
+	array.forEach((item) => {
 		let matched = false;
 
 		for (const [key, predicate] of Object.entries(predicates)) {

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/lintSCSS.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/lintSCSS.js
@@ -28,7 +28,7 @@ async function lintSCSS(source, onReport, options = {}) {
 
 	const plugins = path.resolve(__dirname, 'plugins');
 
-	fs.readdirSync(plugins).forEach(plugin => {
+	fs.readdirSync(plugins).forEach((plugin) => {
 		if (/^([a-z]+-)*[a-z]+\.js$/.test(plugin)) {
 			const name = path.basename(plugin, path.extname(plugin));
 
@@ -49,7 +49,7 @@ async function lintSCSS(source, onReport, options = {}) {
 		syntax: 'scss',
 	});
 
-	results.forEach(result => {
+	results.forEach((result) => {
 		// - "warnings" array contains both errors and warnings.
 		// - "errored" is true if at least one problem of
 		//   severity "error" is present.

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-block-comments.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-block-comments.js
@@ -12,8 +12,8 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 		'No block-based comments (/* ... */); use line-based (//) comment syntax instead',
 });
 
-module.exports = stylelint.createPlugin(ruleName, actual => {
-	return function(root, result) {
+module.exports = stylelint.createPlugin(ruleName, (actual) => {
+	return function (root, result) {
 		const validOptions = stylelint.utils.validateOptions(result, ruleName, {
 			actual,
 		});
@@ -22,7 +22,7 @@ module.exports = stylelint.createPlugin(ruleName, actual => {
 			return;
 		}
 
-		root.walkComments(comment => {
+		root.walkComments((comment) => {
 			if (!comment.raws.inline) {
 				stylelint.utils.report({
 					message: messages.expected,

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-import-extension.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/no-import-extension.js
@@ -18,7 +18,7 @@ const SCSS_EXT = '.scss';
 module.exports = stylelint.createPlugin(
 	ruleName,
 	(options, secondaryOptions, context) => {
-		return function(root, result) {
+		return function (root, result) {
 			const validOptions = stylelint.utils.validateOptions(
 				result,
 				ruleName,
@@ -43,7 +43,7 @@ module.exports = stylelint.createPlugin(
 
 			const fix = context ? context.fix && !disableFix : false;
 
-			root.walkAtRules('import', rule => {
+			root.walkAtRules('import', (rule) => {
 				if (rule.params.startsWith('url(')) {
 					return;
 				}

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/single-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/single-imports.js
@@ -58,7 +58,7 @@ function tokenize(params) {
 module.exports = stylelint.createPlugin(
 	ruleName,
 	(options, secondaryOptions, context) => {
-		return function(root, result) {
+		return function (root, result) {
 			const validOptions = stylelint.utils.validateOptions(
 				result,
 				ruleName,
@@ -83,10 +83,10 @@ module.exports = stylelint.createPlugin(
 
 			const fix = context ? context.fix && !disableFix : false;
 
-			root.walkAtRules('import', rule => {
+			root.walkAtRules('import', (rule) => {
 				const tokens = tokenize(rule.params);
 
-				const resources = tokens.filter(token => {
+				const resources = tokens.filter((token) => {
 					return (
 						token.kind === 'DOUBLE_QUOTED_STRING' ||
 						token.kind === 'SINGLE_QUOTED_STRING' ||
@@ -96,7 +96,7 @@ module.exports = stylelint.createPlugin(
 
 				if (resources.length > 1) {
 					if (fix) {
-						const replacements = resources.map(resource =>
+						const replacements = resources.map((resource) =>
 							rule.clone({params: resource.text})
 						);
 

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
@@ -20,7 +20,7 @@ function precededByBlankLine(node) {
 module.exports = stylelint.createPlugin(
 	ruleName,
 	(options, secondaryOptions, context) => {
-		return function(root, result) {
+		return function (root, result) {
 			const validOptions = stylelint.utils.validateOptions(
 				result,
 				ruleName,
@@ -49,7 +49,7 @@ module.exports = stylelint.createPlugin(
 
 			let group;
 
-			root.walkAtRules('import', rule => {
+			root.walkAtRules('import', (rule) => {
 				const prev = rule.prev();
 
 				if (
@@ -113,7 +113,7 @@ module.exports = stylelint.createPlugin(
 						} else {
 							const order = desired
 								.slice(firstMismatch, lastMismatch + 1)
-								.map(node => node.params)
+								.map((node) => node.params)
 								.join(' << ');
 
 							stylelint.utils.report({

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/trim-comments.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/trim-comments.js
@@ -59,7 +59,7 @@ function isTrailingComment(_comment, next) {
 module.exports = stylelint.createPlugin(
 	ruleName,
 	(options, secondaryOptions, context) => {
-		return function(root, result) {
+		return function (root, result) {
 			const validOptions = stylelint.utils.validateOptions(
 				result,
 				ruleName,
@@ -84,10 +84,10 @@ module.exports = stylelint.createPlugin(
 
 			const fix = context ? context.fix && !disableFix : false;
 
-			root.walkComments(comment => {
+			root.walkComments((comment) => {
 				if (comment.raws.inline) {
 					if (BLANK_REGEX.test(comment.text)) {
-						const report = message => {
+						const report = (message) => {
 							stylelint.utils.report({
 								message,
 								node: comment,

--- a/packages/liferay-npm-scripts/src/scripts/prettier.js
+++ b/packages/liferay-npm-scripts/src/scripts/prettier.js
@@ -27,13 +27,13 @@ function main(...args) {
 
 	const options = {};
 
-	const set = function(key, value) {
+	const set = function (key, value) {
 		if (arguments.length === 2) {
 			return () => {
 				options[key] = value;
 			};
 		} else {
-			return value => {
+			return (value) => {
 				options[key] = value;
 			};
 		}
@@ -128,7 +128,7 @@ function main(...args) {
 		} else if (arg.startsWith('-')) {
 			// Unknown option, just ignore it.
 		} else if (isGlob(arg)) {
-			getPaths([arg], [], IGNORE_FILE).forEach(filepath => {
+			getPaths([arg], [], IGNORE_FILE).forEach((filepath) => {
 				files.push({
 					contents: null,
 					filepath,

--- a/packages/liferay-npm-scripts/src/scripts/storybook.js
+++ b/packages/liferay-npm-scripts/src/scripts/storybook.js
@@ -48,7 +48,7 @@ function buildNodePath() {
  * @param {Array} files The list of files to copy.
  */
 function copyStorybookConfigFiles(buildPath, files) {
-	files.forEach(file => {
+	files.forEach((file) => {
 		fs.copyFileSync(
 			path.join(STORYBOOK_CONFIG_DIR_PATH, file),
 			path.join(buildPath, file)
@@ -72,7 +72,7 @@ function compileLanguageProperties(buildPath, paths) {
 
 	const output = [];
 
-	LANG_PATHS.filter(fs.existsSync).forEach(langPath => {
+	LANG_PATHS.filter(fs.existsSync).forEach((langPath) => {
 		try {
 			output.push(fs.readFileSync(langPath, 'utf8'));
 		} catch (error) {

--- a/packages/liferay-npm-scripts/src/scripts/test.js
+++ b/packages/liferay-npm-scripts/src/scripts/test.js
@@ -20,7 +20,7 @@ const PREFIX_BACKUP = 'TEMP-';
 /**
  * Main script that runs `jest` with a merged config
  */
-module.exports = function(arrArgs = []) {
+module.exports = function (arrArgs = []) {
 	const useSoy = soyExists();
 
 	const CONFIG_PATH = 'TEMP_jest.config.json';

--- a/packages/liferay-npm-scripts/src/scripts/theme.js
+++ b/packages/liferay-npm-scripts/src/scripts/theme.js
@@ -47,7 +47,7 @@ function findModulesDirectory(from = process.cwd()) {
  */
 function checkExistingBuildArgs(args) {
 	const reservedArgs = new Set(Object.keys(BUILD_ARGS));
-	args.forEach(arg => {
+	args.forEach((arg) => {
 		if (reservedArgs.has(arg)) {
 			throw new Error(
 				`Must not supply ${arg} when invoking \`theme build\``
@@ -71,7 +71,7 @@ function prepareAdditionalBuildArgs() {
 	}
 
 	const args = [];
-	Object.keys(BUILD_ARGS).forEach(key => {
+	Object.keys(BUILD_ARGS).forEach((key) => {
 		const value = BUILD_ARGS[key];
 		args.push(key, value.replace(MODULES_DIR, modules));
 	});

--- a/packages/liferay-npm-scripts/src/scripts/webpack.js
+++ b/packages/liferay-npm-scripts/src/scripts/webpack.js
@@ -15,7 +15,7 @@ const WEBPACK_DEV_CONFIG_FILE = 'webpack.config.dev.js';
 /**
  * Main function for running webpack within the liferay-portal repo.
  */
-module.exports = function(...args) {
+module.exports = function (...args) {
 	const watch = args.indexOf('--watch');
 	if (watch !== -1) {
 		if (!fs.existsSync(WEBPACK_DEV_CONFIG_FILE)) {
@@ -30,7 +30,7 @@ module.exports = function(...args) {
 				...args.slice(watch + 1),
 			];
 
-			withWebpackConfig(WEBPACK_DEV_CONFIG_FILE, configFilePath => {
+			withWebpackConfig(WEBPACK_DEV_CONFIG_FILE, (configFilePath) => {
 				spawnSync('webpack-dev-server', [
 					'--config',
 					configFilePath,
@@ -39,7 +39,7 @@ module.exports = function(...args) {
 			});
 		}
 	} else {
-		withWebpackConfig(WEBPACK_CONFIG_FILE, configFilePath => {
+		withWebpackConfig(WEBPACK_CONFIG_FILE, (configFilePath) => {
 			spawnSync('webpack', ['--config', configFilePath, ...args]);
 		});
 	}

--- a/packages/liferay-npm-scripts/src/storybook/README.md
+++ b/packages/liferay-npm-scripts/src/storybook/README.md
@@ -136,7 +136,7 @@ import ThemeContext from '../../src/main/resources/META-INF/resources/js/ThemeCo
 const {addDecorator, storiesOf} = StorybookReact;
 const {action} = StorybookAddonActions;
 
-addDecorator(storyFn => {
+addDecorator((storyFn) => {
 	const context = {
 		spritemap: STORYBOOK_CONSTANTS.SPRITEMAP_PATH,
 	};

--- a/packages/liferay-npm-scripts/src/storybook/frontend-js-react-web.mock.js
+++ b/packages/liferay-npm-scripts/src/storybook/frontend-js-react-web.mock.js
@@ -7,7 +7,7 @@ const React = require('react');
 
 module.exports = {
 	// See: https://github.com/liferay/liferay-portal/blob/afcb92c2e1/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/usePrevious.es.js
-	usePrevious: value => {
+	usePrevious: (value) => {
 		const ref = React.useRef();
 
 		React.useEffect(() => {

--- a/packages/liferay-npm-scripts/src/storybook/frontend-js-web.mock.js
+++ b/packages/liferay-npm-scripts/src/storybook/frontend-js-web.mock.js
@@ -14,11 +14,11 @@ module.exports = {
 	Slider: () => {},
 	Treeview: () => {},
 	cancelDebounce: () => {},
-	debounce: fn => fn,
+	debounce: (fn) => fn,
 	fetch,
 	navigate: (url, listeners) => console.log({listeners, url}),
-	openSimpleInputModal: config => console.log(config),
-	openToast: config => console.log(config),
+	openSimpleInputModal: (config) => console.log(config),
+	openToast: (config) => console.log(config),
 };
 
 /* eslint-enable no-console */

--- a/packages/liferay-npm-scripts/src/utils/SignalHandler.js
+++ b/packages/liferay-npm-scripts/src/utils/SignalHandler.js
@@ -21,7 +21,7 @@ const SIGNALS = {
 const SignalHandler = {
 	install() {
 		if (!installed) {
-			Object.keys(SIGNALS).forEach(signal => {
+			Object.keys(SIGNALS).forEach((signal) => {
 				process.on(signal, handleSignal);
 			});
 

--- a/packages/liferay-npm-scripts/src/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/src/utils/deepMerge.js
@@ -5,7 +5,7 @@
 
 const merge = require('deepmerge');
 
-const emptyTarget = value => (Array.isArray(value) ? [] : {});
+const emptyTarget = (value) => (Array.isArray(value) ? [] : {});
 const clone = (value, options) => merge(emptyTarget(value), value, options);
 
 /**
@@ -136,13 +136,13 @@ function babelMerge(key) {
 	}[key];
 
 	if (kind === 'plugin' || kind === 'preset') {
-		return function(target, source, options) {
+		return function (target, source, options) {
 			// Create a mutable copy of `source`.
 			const pending = source.slice();
 
-			const result = target.map(targetItem => {
+			const result = target.map((targetItem) => {
 				const targetName = getBabelName(targetItem, kind);
-				const sourceIndex = pending.findIndex(sourceItem => {
+				const sourceIndex = pending.findIndex((sourceItem) => {
 					const sourceName = getBabelName(sourceItem, kind);
 
 					return sourceName === targetName;
@@ -168,7 +168,7 @@ function babelMerge(key) {
 			});
 
 			return result.concat(
-				pending.map(item => {
+				pending.map((item) => {
 					const itemName = getBabelName(item, kind);
 					const itemOptions = getBabelOptions(item);
 
@@ -177,7 +177,7 @@ function babelMerge(key) {
 			);
 		};
 	} else {
-		return function(target, source, options) {
+		return function (target, source, options) {
 			if (Array.isArray(target) && Array.isArray(source)) {
 				return combineMerge(target, source, options);
 			} else if (

--- a/packages/liferay-npm-scripts/src/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/expandGlobs.js
@@ -66,7 +66,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 
 			// Warn about overlapping ignore patterns. This check is O(n^2) but
 			// n is expected to be tiny (approx. 10).
-			seen.forEach(previous => {
+			seen.forEach((previous) => {
 				if (
 					previous.startsWith(base) ||
 					base.startsWith(previous) ||
@@ -116,7 +116,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 		currentDepth++;
 
 		const entries = fs.readdirSync(directory);
-		entries.forEach(entry => {
+		entries.forEach((entry) => {
 			const file = path.posix.join(directory, entry);
 
 			// Check trie to see whether entire subtree can be pruned.
@@ -164,7 +164,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 
 			const stat = fs.statSync(file);
 
-			const match = () => matchers.some(matcher => matcher.test(file));
+			const match = () => matchers.some((matcher) => matcher.test(file));
 
 			if (stat.isDirectory()) {
 				if (type === 'directory' && match()) {

--- a/packages/liferay-npm-scripts/src/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/src/utils/filterChangedFiles.js
@@ -63,14 +63,14 @@ function filterChangedFiles(files) {
 		'HEAD'
 	)
 		.split(/\0/)
-		.map(file => {
+		.map((file) => {
 			return file ? path.join(topLevel, file) : file;
 		})
 		.filter(Boolean);
 
 	const set = new Set(changedFiles);
 
-	return files.filter(file => {
+	return files.filter((file) => {
 		const absolute = path.resolve(file);
 
 		return set.has(absolute);

--- a/packages/liferay-npm-scripts/src/utils/filterGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/filterGlobs.js
@@ -8,7 +8,7 @@
  * specified extension(s).
  */
 function filterGlobs(globs, ...extensions) {
-	extensions.forEach(extension => {
+	extensions.forEach((extension) => {
 		if (!extension.match(/^\.\w+$/)) {
 			throw new Error(
 				`filterGlobs(): expected extension ${JSON.stringify(
@@ -19,8 +19,8 @@ function filterGlobs(globs, ...extensions) {
 	});
 
 	return extensions.length
-		? globs.filter(glob => {
-				return extensions.some(extension => glob.endsWith(extension));
+		? globs.filter((glob) => {
+				return extensions.some((extension) => glob.endsWith(extension));
 		  })
 		: globs;
 }

--- a/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
+++ b/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
@@ -17,7 +17,7 @@ function generateSoyDependencies(dependencies) {
 	const projectName = path.basename(cwd);
 
 	const stringDependencies = dependencies
-		.map(dependency => {
+		.map((dependency) => {
 			let resolvedDependency = null;
 
 			try {
@@ -37,7 +37,7 @@ function generateSoyDependencies(dependencies) {
 		})
 		.filter(Boolean)
 		.filter(
-			dependencyPath => path.basename(dependencyPath) !== projectName
+			(dependencyPath) => path.basename(dependencyPath) !== projectName
 		);
 
 	const joinedDependencies =

--- a/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -67,7 +67,7 @@ function getJestModuleNameMapper() {
 				type: 'directory',
 			});
 
-			projects.forEach(project => {
+			projects.forEach((project) => {
 				const packageJson = path.join(project, 'package.json');
 
 				if (fs.existsSync(packageJson)) {

--- a/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
@@ -42,7 +42,7 @@ function isObject(maybeObject) {
  */
 function filter(object, property, callback) {
 	if (Array.isArray(object)) {
-		return object.map(item => filter(item, property, callback));
+		return object.map((item) => filter(item, property, callback));
 	} else if (isObject(object)) {
 		return Object.entries(object).reduce((acc, [key, value]) => {
 			return {
@@ -72,9 +72,9 @@ function hackilySupportIncrementalDOM(config) {
 	const excludes = (liferay && liferay.excludes) || {};
 
 	return Object.entries(excludes).reduce((acc, [property, values]) => {
-		return filter(acc, property, value => {
+		return filter(acc, property, (value) => {
 			if (Array.isArray(value)) {
-				return value.filter(v => !values.includes(v));
+				return value.filter((v) => !values.includes(v));
 			} else {
 				return value;
 			}

--- a/packages/liferay-npm-scripts/src/utils/getPaths.js
+++ b/packages/liferay-npm-scripts/src/utils/getPaths.js
@@ -33,7 +33,7 @@ function getPaths(globs, extensions, ignoreFile) {
 	}
 
 	// Turn "{src,test}/*" into ["src/*", "test/*"]:
-	globs = [].concat(...globs.map(glob => preprocessGlob(glob)));
+	globs = [].concat(...globs.map((glob) => preprocessGlob(glob)));
 
 	// Filter out globs that don't apply to `extensions`.
 	globs = filterGlobs(globs, ...extensions);

--- a/packages/liferay-npm-scripts/src/utils/getUserConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getUserConfig.js
@@ -12,7 +12,7 @@ const findRoot = require('./findRoot');
  * @param {string} moduleName Name of user config file
  * @param {object} whether to walk up looking for config if needed
  */
-module.exports = function(moduleName, options = {}) {
+module.exports = function (moduleName, options = {}) {
 	const stopDir = (options.upwards && findRoot()) || process.cwd();
 
 	const explorer = cosmiconfigSync(moduleName, {stopDir});

--- a/packages/liferay-npm-scripts/src/utils/log.js
+++ b/packages/liferay-npm-scripts/src/utils/log.js
@@ -5,7 +5,7 @@
 
 function log(...messages) {
 	// eslint-disable-next-line no-console
-	messages.forEach(message => console.log(message));
+	messages.forEach((message) => console.log(message));
 }
 
 module.exports = log;

--- a/packages/liferay-npm-scripts/src/utils/mergeBabelLoaderOptions.js
+++ b/packages/liferay-npm-scripts/src/utils/mergeBabelLoaderOptions.js
@@ -22,7 +22,7 @@ function mergeBabelLoaderOptions(webpackConfig) {
 		return webpackConfig;
 	}
 
-	webpackConfig.module.rules.forEach(rule => {
+	webpackConfig.module.rules.forEach((rule) => {
 		let {use} = rule;
 
 		if (!use) {

--- a/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
+++ b/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
@@ -77,10 +77,10 @@ function fill(template, substitutions) {
 
 	const permutations = [];
 
-	(substitutions[0] || []).forEach(substitution => {
+	(substitutions[0] || []).forEach((substitution) => {
 		permutations.push(
 			...fill(rest, substitutions.slice(1)).map(
-				result => first + substitution + result
+				(result) => first + substitution + result
 			)
 		);
 	});

--- a/packages/liferay-npm-scripts/src/utils/readIgnoreFile.js
+++ b/packages/liferay-npm-scripts/src/utils/readIgnoreFile.js
@@ -22,10 +22,10 @@ function readIgnoreFile(file) {
 	return fs
 		.readFileSync(file, 'utf8')
 		.split(LINE_SEPARATORS)
-		.filter(line => {
+		.filter((line) => {
 			return !COMMENTS.test(line) && !BLANK_LINES.test(line);
 		})
-		.map(line => line.trim());
+		.map((line) => line.trim());
 }
 
 module.exports = readIgnoreFile;

--- a/packages/liferay-npm-scripts/src/utils/runBabel.js
+++ b/packages/liferay-npm-scripts/src/utils/runBabel.js
@@ -13,7 +13,7 @@ const BABEL_CONFIG = getMergedConfig('babel');
  * Runs babel with given args and uses a temp .babelrc file
  */
 function runBabel(...args) {
-	withTempFile('.babelrc', JSON.stringify(BABEL_CONFIG), babelRcPath => {
+	withTempFile('.babelrc', JSON.stringify(BABEL_CONFIG), (babelRcPath) => {
 		spawnSync('babel', [
 			'--no-babelrc',
 			'--config-file',

--- a/packages/liferay-npm-scripts/src/utils/runBundler.js
+++ b/packages/liferay-npm-scripts/src/utils/runBundler.js
@@ -16,7 +16,7 @@ function runBundler(...args) {
 	withTempFile(
 		'.npmbundlerrc',
 		JSON.stringify(BUNDLER_CONFIG),
-		npmbundlerRcPath => {
+		(npmbundlerRcPath) => {
 			spawnSync('liferay-npm-bundler', [
 				'--config',
 				npmbundlerRcPath,

--- a/packages/liferay-npm-scripts/src/utils/soy.js
+++ b/packages/liferay-npm-scripts/src/utils/soy.js
@@ -60,7 +60,7 @@ function translateSoy(directory) {
 
 	let changedFiles = 0;
 
-	files.forEach(file => {
+	files.forEach((file) => {
 		const contents = fs.readFileSync(file, 'utf8');
 
 		const updated = contents.replace(

--- a/packages/liferay-npm-scripts/support/jest/matchers/toLintStyles.js
+++ b/packages/liferay-npm-scripts/support/jest/matchers/toLintStyles.js
@@ -47,7 +47,7 @@ expect.extend({
 		}
 
 		return {
-			message: pass => {
+			message: (pass) => {
 				const count = errors.length;
 
 				const settings = {

--- a/packages/liferay-npm-scripts/test/jsp/Lexer.js
+++ b/packages/liferay-npm-scripts/test/jsp/Lexer.js
@@ -18,7 +18,7 @@ describe('Lexer()', () => {
 		// The idea is to bail out of infinite loops that would be produced by
 		// use of combinators like repeat() combined with a matcher that matches
 		// a zero-width string.
-		const lexer = new Lexer(api => {
+		const lexer = new Lexer((api) => {
 			const {consume, match, oneOf, token} = api;
 
 			return () => {
@@ -39,7 +39,7 @@ describe('Lexer()', () => {
 	});
 
 	it('produces tokens with a non-enumerable "previous" property', () => {
-		const lexer = new Lexer(api => {
+		const lexer = new Lexer((api) => {
 			const {choose, match} = api;
 
 			return choose({
@@ -61,7 +61,7 @@ describe('Lexer()', () => {
 	});
 
 	it('produces tokens with a lazy "next" property', () => {
-		const lexer = new Lexer(api => {
+		const lexer = new Lexer((api) => {
 			const {choose, match} = api;
 
 			return choose({
@@ -147,7 +147,7 @@ describe('Lexer()', () => {
 
 	describe('a()/an()', () => {
 		it('can reference a named matcher that gets defined elsewhere', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {a, consume, match, token} = api;
 
 				const THING = match('thing').name('THING');
@@ -174,7 +174,7 @@ describe('Lexer()', () => {
 		it('wraps a matcher so it can be augmented without mutation', () => {
 			const calls = [];
 
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {an, consume, match, sequence, token} = api;
 
 				const ORIGINAL = match('foo')
@@ -218,7 +218,7 @@ describe('Lexer()', () => {
 		let lexer;
 
 		beforeEach(() => {
-			lexer = new Lexer(api => {
+			lexer = new Lexer((api) => {
 				const {allOf, consume, match, token} = api;
 
 				return () => {
@@ -262,7 +262,7 @@ describe('Lexer()', () => {
 		it('returns a boolean', () => {
 			const atEndValues = [];
 
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {atEnd, consume, match, token} = api;
 
 				return () => {
@@ -288,7 +288,7 @@ describe('Lexer()', () => {
 
 	describe('choose()', () => {
 		it('produces tokens using matchers defined in an object', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {choose, match} = api;
 
 				const BAR = match('bar');
@@ -324,7 +324,7 @@ describe('Lexer()', () => {
 		});
 
 		it('produces tokens using matchers defined in a Map', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {choose, match} = api;
 
 				const BAR = match('bar');
@@ -362,7 +362,7 @@ describe('Lexer()', () => {
 
 	describe('consume()', () => {
 		it('automatically uses sequence() if given multiple argumetns', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, token} = api;
 
 				return () => {
@@ -387,7 +387,7 @@ describe('Lexer()', () => {
 
 		describe('lexing strings', () => {
 			beforeEach(() => {
-				lexer = new Lexer(api => {
+				lexer = new Lexer((api) => {
 					const {consume, match, token} = api;
 
 					return () => {
@@ -431,7 +431,7 @@ describe('Lexer()', () => {
 
 		describe('lexing regular expressions', () => {
 			beforeEach(() => {
-				lexer = new Lexer(api => {
+				lexer = new Lexer((api) => {
 					const {consume, match, token} = api;
 
 					return () => {
@@ -464,7 +464,7 @@ describe('Lexer()', () => {
 
 	describe('maybe()', () => {
 		it('produces an optional match', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, maybe, sequence, token} = api;
 
 				return () => {
@@ -500,7 +500,7 @@ describe('Lexer()', () => {
 
 	describe('peek()', () => {
 		it('automatically uses sequence() if given multiple argumetns', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, peek, token} = api;
 
 				return () => {
@@ -524,7 +524,7 @@ describe('Lexer()', () => {
 
 	describe('never', () => {
 		it('never matches anything', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, never} = api;
 
 				return () => {
@@ -542,7 +542,7 @@ describe('Lexer()', () => {
 		it('is useful as the alternate in a `when()` matcher', () => {
 			let active = false;
 
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, never, oneOf, repeat, token, when} = api;
 
 				return () => {
@@ -594,7 +594,7 @@ describe('Lexer()', () => {
 
 			let meta;
 
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, meta: passedMeta, token} = api;
 
 				meta = passedMeta;
@@ -618,10 +618,10 @@ describe('Lexer()', () => {
 		it('may produce side effects that can be rolled back', () => {
 			const snapshots = [];
 
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, meta, oneOf, sequence, token} = api;
 
-				const record = match => {
+				const record = (match) => {
 					snapshots.push([`match: ${match[0]}`, [...meta.entries()]]);
 				};
 
@@ -761,7 +761,7 @@ describe('Lexer()', () => {
 
 	describe('oneOf()', () => {
 		it('matches using the first matching matcher in a collection', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, oneOf, token} = api;
 
 				return () => {
@@ -785,7 +785,7 @@ describe('Lexer()', () => {
 
 	describe('pass', () => {
 		it('matches an empty string', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, pass, sequence, token} = api;
 
 				return () => {
@@ -807,7 +807,7 @@ describe('Lexer()', () => {
 
 	describe('repeat()', () => {
 		it('matches a matcher one or more times', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, repeat, token} = api;
 
 				return () => {
@@ -837,7 +837,7 @@ describe('Lexer()', () => {
 
 	describe('sequence()', () => {
 		it('matches a series of matchers', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, sequence, token} = api;
 
 				return () => {
@@ -863,7 +863,7 @@ describe('Lexer()', () => {
 		let lexer;
 
 		beforeEach(() => {
-			lexer = new Lexer(api => {
+			lexer = new Lexer((api) => {
 				const {consume, match, token} = api;
 
 				return () => {
@@ -908,7 +908,7 @@ describe('Lexer()', () => {
 		let lexer;
 
 		beforeEach(() => {
-			lexer = new Lexer(api => {
+			lexer = new Lexer((api) => {
 				const {consume, match, peek, token} = api;
 
 				return () => {
@@ -963,7 +963,7 @@ describe('Lexer()', () => {
 
 	describe('when()', () => {
 		it('chooses a matcher based on a predicate', () => {
-			const lexer = new Lexer(api => {
+			const lexer = new Lexer((api) => {
 				const {consume, match, repeat, token, when} = api;
 
 				let count = 0;

--- a/packages/liferay-npm-scripts/test/jsp/__snapshots__/formatJSP.js.snap
+++ b/packages/liferay-npm-scripts/test/jsp/__snapshots__/formatJSP.js.snap
@@ -107,7 +107,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 	);
 
 	if (openFolderSelectorButton) {
-		openFolderSelectorButton.addEventListener('click', function(event) {
+		openFolderSelectorButton.addEventListener('click', function (event) {
 			Liferay.Util.selectEntity(
 				{
 					dialog: {
@@ -128,7 +128,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 					uri: '<%= HtmlUtil.escapeJS(selectFolderURL.toString()) %>',
 				},
-				function(event) {
+				function (event) {
 					var folderData = {
 						idString: 'rootFolderId',
 						idValue: event.folderid,
@@ -303,7 +303,7 @@ if (organization != null) {
 		var typeSelect = document.getElementById('<portlet:namespace />type');
 
 		if (typeSelect) {
-			typeSelect.addEventListener('change', function(event) {
+			typeSelect.addEventListener('change', function (event) {
 				var countryDiv = document.getElementById(
 					'<portlet:namespace />countryDiv'
 				);
@@ -661,7 +661,7 @@ if (Validator.isNotNull(scriptContent)) {
 				NAME: 'searchpalette',
 
 				prototype: {
-					initializer: function() {
+					initializer: function () {
 						var instance = this;
 
 						instance._bindUIACBase();
@@ -670,10 +670,10 @@ if (Validator.isNotNull(scriptContent)) {
 				},
 			});
 
-			var getItems = function() {
+			var getItems = function () {
 				var results = [];
 
-				paletteItems.each(function(item, index) {
+				paletteItems.each(function (item, index) {
 					results.push({
 						data: item.text().trim(),
 						node: item.ancestor(),
@@ -683,7 +683,7 @@ if (Validator.isNotNull(scriptContent)) {
 				return results;
 			};
 
-			var getNoResultsNode = function() {
+			var getNoResultsNode = function () {
 				if (!noResultsNode) {
 					noResultsNode = A.Node.create(
 						'<div class=\\"alert\\"><%= UnicodeLanguageUtil.get(request, \\"there-are-no-results\\") %></div>'
@@ -707,18 +707,18 @@ if (Validator.isNotNull(scriptContent)) {
 				source: getItems(),
 			});
 
-			paletteSearch.on('results', function(event) {
-				paletteItems.each(function(item, index) {
+			paletteSearch.on('results', function (event) {
+				paletteItems.each(function (item, index) {
 					item.ancestor().addClass('hide');
 				});
 
-				event.results.forEach(function(item, index) {
+				event.results.forEach(function (item, index) {
 					item.raw.node.removeClass('hide');
 				});
 
 				var foundVisibleSection;
 
-				paletteSectionsNode.each(function(item, index) {
+				paletteSectionsNode.each(function (item, index) {
 					var visibleItem = item.one('.palette-item-container:not(.hide)');
 
 					if (visibleItem) {
@@ -755,7 +755,7 @@ if (Validator.isNotNull(scriptContent)) {
 			var cursorPos;
 			var processed;
 
-			AObject.each(fragments, function(item, index) {
+			AObject.each(fragments, function (item, index) {
 				if (processed) {
 					cursorPos = editor.getCursorPosition();
 				}
@@ -848,7 +848,7 @@ if (Validator.isNotNull(scriptContent)) {
 
 	A.on(
 		'domready',
-		function(event) {
+		function (event) {
 			richEditor = new A.AceEditor({
 				boundingBox: editorNode,
 				height: 400,
@@ -868,11 +868,11 @@ if (Validator.isNotNull(scriptContent)) {
 				setEditorContent(editorContentElement.val());
 			}
 
-			Liferay.on('<portlet:namespace />saveTemplate', function(event) {
+			Liferay.on('<portlet:namespace />saveTemplate', function (event) {
 				editorContentElement.val(getEditorContent());
 			});
 
-			selectLanguageNode.on('change', function(event) {
+			selectLanguageNode.on('change', function (event) {
 				Liferay.fire('<portlet:namespace />refreshEditor');
 			});
 
@@ -911,7 +911,7 @@ if (Validator.isNotNull(scriptContent)) {
 		'#<portlet:namespace />richEditor'
 	);
 
-	Liferay.on('<portlet:namespace />refreshEditor', function(event) {
+	Liferay.on('<portlet:namespace />refreshEditor', function (event) {
 		var form = A.one('#<portlet:namespace />fm');
 
 		<portlet:renderURL var=\\"refreshTemplateURL\\">
@@ -920,13 +920,7 @@ if (Validator.isNotNull(scriptContent)) {
 
 		form.attr('action', '<%= refreshTemplateURL %>');
 
-		if (
-			richEditor
-				.getEditor()
-				.getSession()
-				.getUndoManager()
-				.hasUndo()
-		) {
+		if (richEditor.getEditor().getSession().getUndoManager().hasUndo()) {
 			Liferay.fire('<portlet:namespace />saveTemplate');
 		}
 		<c:if test=\\"<%= template == null %>\\">
@@ -1195,7 +1189,7 @@ exports[`formatJSP() formatting entire fixtures page.jsp matches snapshot 1`] = 
 
 		Liferay.Language.get('foo');
 
-		Liferay.provide(window, 'testFn', function() {
+		Liferay.provide(window, 'testFn', function () {
 			var foo = false;
 		});
 	</aui:script>
@@ -1531,7 +1525,7 @@ for (int i = 0; i < pages.size(); i++) {
 				'input[name=<portlet:namespace />rowIds]'
 			);
 
-			Array.prototype.forEach.call(rowIdsNodes, function(rowIdsNode, index) {
+			Array.prototype.forEach.call(rowIdsNodes, function (rowIdsNode, index) {
 				if (index > 1) {
 					rowIdsNode.checked = false;
 				}
@@ -1562,7 +1556,7 @@ for (int i = 0; i < pages.size(); i++) {
 
 			var compareButton = document.getElementById('<portlet:namespace />compare');
 
-			compareButton.addEventListener('click', function(event) {
+			compareButton.addEventListener('click', function (event) {
 				<portlet:renderURL var=\\"compareVersionURL\\">
 					<portlet:param name=\\"mvcRenderCommandName\\" value=\\"/wiki/compare_versions\\" />
 					<portlet:param name=\\"backURL\\" value=\\"<%= currentURL %>\\" />
@@ -1620,7 +1614,7 @@ for (int i = 0; i < pages.size(); i++) {
 				searchContainer,
 				'click',
 				'input[name=<portlet:namespace />rowIds]',
-				function(event) {
+				function (event) {
 					<portlet:namespace />updateRowsChecked(event.delegateTarget);
 				}
 			);
@@ -1807,7 +1801,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 			);
 
 			if (selectRegularRoleLink) {
-				selectRegularRoleLink.addEventListener('click', function(event) {
+				selectRegularRoleLink.addEventListener('click', function (event) {
 					var searchContainerName = '<portlet:namespace />rolesSearchContainer';
 
 					var searchContainer = Liferay.SearchContainer.get(searchContainerName);
@@ -1848,7 +1842,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 							uri: '<%= selectRegularRoleURL.toString() %>',
 						},
-						function(event) {
+						function (event) {
 							<portlet:namespace />selectRole(
 								event.entityid,
 								event.entityname,
@@ -2017,7 +2011,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 				searchContainerContentBox.delegate(
 					'click',
-					function(event) {
+					function (event) {
 						var link = event.currentTarget;
 						var tr = link.ancestor('tr');
 
@@ -2049,8 +2043,8 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 					'.modify-link'
 				);
 
-				Liferay.on('<%= organizationRoleSyncEntitiesEventName %>', function(event) {
-					event.selectors.each(function(item, index, collection) {
+				Liferay.on('<%= organizationRoleSyncEntitiesEventName %>', function (event) {
+					event.selectors.each(function (item, index, collection) {
 						var groupId = item.attr('data-groupid');
 						var roleId = item.attr('data-entityid');
 
@@ -2096,7 +2090,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 			);
 
 			if (selectOrganizationRoleLink) {
-				selectOrganizationRoleLink.addEventListener('click', function(event) {
+				selectOrganizationRoleLink.addEventListener('click', function (event) {
 					Liferay.Util.selectEntity(
 						{
 							dialog: {
@@ -2127,7 +2121,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 							uri: '<%= selectOrganizationRoleURL.toString() %>',
 						},
-						function(event) {
+						function (event) {
 							<portlet:namespace />selectRole(
 								event.entityid,
 								event.entityname,
@@ -2250,7 +2244,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 				searchContainerContentBox.delegate(
 					'click',
-					function(event) {
+					function (event) {
 						var link = event.currentTarget;
 						var tr = link.ancestor('tr');
 
@@ -2282,8 +2276,8 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 					'.modify-link'
 				);
 
-				Liferay.on('<%= siteRoleSyncEntitiesEventName %>', function(event) {
-					event.selectors.each(function(item, index, collection) {
+				Liferay.on('<%= siteRoleSyncEntitiesEventName %>', function (event) {
+					event.selectors.each(function (item, index, collection) {
 						var groupId = item.attr('data-groupid');
 						var roleId = item.attr('data-entityid');
 
@@ -2319,7 +2313,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 					});
 				});
 
-				A.one('#<portlet:namespace />selectSiteRoleLink').on('click', function(event) {
+				A.one('#<portlet:namespace />selectSiteRoleLink').on('click', function (event) {
 					Util.selectEntity(
 						{
 							dialog: {
@@ -2349,7 +2343,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 							uri: '<%= selectSiteRoleURL.toString() %>',
 						},
-						function(event) {
+						function (event) {
 							<portlet:namespace />selectRole(
 								event.entityid,
 								event.entityname,
@@ -2476,7 +2470,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 			Liferay.provide(
 				window,
 				'<portlet:namespace />selectRole',
-				function(roleId, name, searchContainer, groupName, groupId, iconCssClass) {
+				function (roleId, name, searchContainer, groupName, groupId, iconCssClass) {
 					var A = AUI();
 					var LString = A.Lang.String;
 
@@ -2575,7 +2569,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 
 			searchContainerContentBox.delegate(
 				'click',
-				function(event) {
+				function (event) {
 					var link = event.currentTarget;
 
 					var rowId = link.attr('data-rowId');
@@ -2601,8 +2595,8 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 				'.modify-link'
 			);
 
-			Liferay.on('<%= regularRoleSyncEntitiesEventName %>', function(event) {
-				event.selectors.each(function(item, index, collection) {
+			Liferay.on('<%= regularRoleSyncEntitiesEventName %>', function (event) {
+				event.selectors.each(function (item, index, collection) {
 					var roleId = item.attr('data-entityid');
 
 					if (<portlet:namespace />deleteRoleIds.indexOf(roleId) != -1) {
@@ -2904,7 +2898,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 			if (removeOrderBySubtype) {
 				Array.prototype.forEach.call(
 					orderingPanel.querySelectorAll('.order-by-subtype'),
-					function(option) {
+					function (option) {
 						dom.exitDocument(option);
 					}
 				);
@@ -3004,13 +2998,13 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 					'#<portlet:namespace /><%= className %>subtypeFieldsWrapper, #<portlet:namespace /><%= className %>subtypeFieldsFilterEnableWrapper'
 				);
 
-				Array.prototype.forEach.call(subtypeFieldsWrappers, function(
+				Array.prototype.forEach.call(subtypeFieldsWrappers, function (
 					subtypeFieldsWrapper
 				) {
 					if (selectedSubtype != 'false' && selectedSubtype != 'true') {
 						Array.prototype.forEach.call(
 							orderingPanel.querySelectorAll('.order-by-subtype'),
-							function(option) {
+							function (option) {
 								dom.exitDocument(option);
 							}
 						);
@@ -3052,7 +3046,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 
 			<%= className %>toggleSubclassesFields(false);
 
-			<%= className %>SubtypeSelector.addEventListener('change', function(event) {
+			<%= className %>SubtypeSelector.addEventListener('change', function (event) {
 				setDDMFields('<%= className %>', '', '', '', '');
 
 				var subtypeFieldsFilterEnabledCheckbox = document.getElementById(
@@ -3067,7 +3061,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 					'.asset-subtypefields'
 				);
 
-				Array.prototype.forEach.call(assetSubtypeFields, function(
+				Array.prototype.forEach.call(assetSubtypeFields, function (
 					assetSubtypeField
 				) {
 					assetSubtypeField.classList.add('hide');
@@ -3110,7 +3104,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 		ddmStructureFieldNameInput &&
 		ddmStructureFieldValueInput
 	) {
-		assetSelector.addEventListener('change', function(event) {
+		assetSelector.addEventListener('change', function (event) {
 			ddmStructureFieldNameInput.value = '';
 			ddmStructureFieldValueInput.value = '';
 
@@ -3122,7 +3116,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 		sourcePanel,
 		'click',
 		'.asset-subtypefields-wrapper-enable label',
-		function(event) {
+		function (event) {
 			var subtypeFieldsFilterEnabledInput = event.delegateTarget.querySelector(
 				'input'
 			);
@@ -3134,7 +3128,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 			if (subtypeFieldsFilterEnabledInput) {
 				Array.prototype.forEach.call(
 					assetSubtypefieldsPopupButtons,
-					function(assetSubtypefieldsPopupButton) {
+					function (assetSubtypefieldsPopupButton) {
 						Util.toggleDisabled(
 							assetSubtypefieldsPopupButton,
 							!subtypeFieldsFilterEnabledInput.checked
@@ -3145,7 +3139,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 		}
 	);
 
-	Liferay.after('inputmoveboxes:moveItem', function(event) {
+	Liferay.after('inputmoveboxes:moveItem', function (event) {
 		if (
 			event.fromBox.attr('id') ==
 				'<portlet:namespace />currentClassNameIds' ||
@@ -3159,7 +3153,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 		'<portlet:namespace />ddmStructureDisplayFieldValue'
 	);
 
-	dom.delegate(sourcePanel, 'click', '.asset-subtypefields-popup', function(
+	dom.delegate(sourcePanel, 'click', '.asset-subtypefields-popup', function (
 		event
 	) {
 		var delegateTarget = event.delegateTarget;
@@ -3196,7 +3190,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList()
 					'<liferay-ui:message arguments=\\"structure-field\\" key=\\"select-x\\" />',
 				uri: uri,
 			},
-			function(event) {
+			function (event) {
 				setDDMFields(
 					event.className,
 					event.name,
@@ -3455,7 +3449,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 		items: [
 			{
 				caption: '<liferay-ui:message key=\\"add-calendar\\" />',
-				fn: function(event) {
+				fn: function (event) {
 					var instance = this;
 
 					var calendarResourceId = instance.calendarResourceId;
@@ -3464,10 +3458,10 @@ String backURL = PortalUtil.getCurrentURL(request);
 						Liferay.Util.openWindow({
 							dialog: {
 								after: {
-									destroy: function(event) {
+									destroy: function (event) {
 										remoteServices.getResourceCalendars(
 											calendarResourceId,
-											function(calendars) {
+											function (calendars) {
 												var calendarList =
 													window
 														.<portlet:namespace />calendarLists[
@@ -3510,7 +3504,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 			},
 			{
 				caption: '<liferay-ui:message key=\\"manage-calendars\\" />',
-				fn: function(event) {
+				fn: function (event) {
 					var instance = this;
 
 					var calendarResourceId = instance.calendarResourceId;
@@ -3534,7 +3528,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 			},
 			{
 				caption: '<liferay-ui:message key=\\"permissions\\" />',
-				fn: function(event) {
+				fn: function (event) {
 					var instance = this;
 
 					<liferay-security:permissionsURL
@@ -3562,7 +3556,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 			},
 		],
 		on: {
-			visibleChange: function(event) {
+			visibleChange: function (event) {
 				var instance = this;
 
 				var hiddenItems = [];
@@ -3589,7 +3583,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 		items: [
 			{
 				caption: '<liferay-ui:message key=\\"add-calendar-booking\\" />',
-				fn: function(event) {
+				fn: function (event) {
 					var instance = this;
 
 					var calendarList = instance.get('host');
@@ -3605,7 +3599,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 					Liferay.Util.openWindow({
 						dialog: {
 							after: {
-								destroy: function(event) {
+								destroy: function (event) {
 									<portlet:namespace />scheduler.load();
 								},
 							},
@@ -3626,7 +3620,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 			},
 			{
 				caption: '<liferay-ui:message key=\\"hide-calendar\\" />',
-				fn: function(event) {
+				fn: function (event) {
 					var instance = this;
 
 					var calendarList = instance.get('host');
@@ -3641,7 +3635,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 			},
 			{
 				caption: '<liferay-ui:message key=\\"calendar-settings\\" />',
-				fn: function(event) {
+				fn: function (event) {
 					var instance = this;
 
 					var calendarList = instance.get('host');
@@ -3651,17 +3645,17 @@ String backURL = PortalUtil.getCurrentURL(request);
 					Liferay.Util.openWindow({
 						dialog: {
 							after: {
-								destroy: function(event) {
+								destroy: function (event) {
 									remoteServices.getCalendar(
 										activeCalendar.get('calendarId'),
-										function(calendar) {
+										function (calendar) {
 											var activeCalendarId = activeCalendar.get(
 												'calendarId'
 											);
 
 											var calendars = calendarList
 												.get('calendars')
-												.map(function(item) {
+												.map(function (item) {
 													if (
 														activeCalendarId ===
 														item.get('calendarId')
@@ -3710,7 +3704,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 			},
 			{
 				caption: '<liferay-ui:message key=\\"permissions\\" />',
-				fn: function(event) {
+				fn: function (event) {
 					var instance = this;
 
 					var calendarList = instance.get('host');
@@ -3720,7 +3714,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 					Liferay.Util.openWindow({
 						dialog: {
 							after: {
-								destroy: function(event) {
+								destroy: function (event) {
 									<portlet:namespace />scheduler.load();
 								},
 							},
@@ -3758,7 +3752,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 			},
 			{
 				caption: '<liferay-ui:message key=\\"delete\\" />',
-				fn: function(event) {
+				fn: function (event) {
 					var instance = this;
 
 					var calendarList = instance.get('host');
@@ -3776,10 +3770,10 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 						remoteServices.deleteCalendar(
 							activeCalendar.get('calendarId'),
-							function() {
+							function () {
 								remoteServices.getResourceCalendars(
 									activeCalendar.get('calendarResourceId'),
-									function(calendars) {
+									function (calendars) {
 										calendarList.set('calendars', calendars);
 
 										<portlet:namespace />syncCalendarsMap();
@@ -3802,7 +3796,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 			<c:if test=\\"<%= enableRSS %>\\">
 				{
 					caption: '<liferay-ui:message key=\\"rss\\" />',
-					fn: function(event) {
+					fn: function (event) {
 						var instance = this;
 
 						var calendarList = instance.get('host');
@@ -3838,7 +3832,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 			},
 		],
 		on: {
-			visibleChange: function(event) {
+			visibleChange: function (event) {
 				var instance = this;
 
 				var calendarList = instance.get('host');
@@ -3901,7 +3895,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 	<portlet:namespace />colorPicker = new Liferay.SimpleColorPicker({
 		on: {
-			colorChange: function(event) {
+			colorChange: function (event) {
 				var instance = this;
 
 				var simpleMenu = instance.get('host');
@@ -3922,7 +3916,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 	A.one('#<portlet:namespace />calendarListContainer').delegate(
 		'click',
-		function(event) {
+		function (event) {
 			var currentTarget = event.currentTarget;
 
 			window.<portlet:namespace />calendarListsMenu.calendarResourceId = currentTarget.getAttribute(
@@ -3955,7 +3949,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 		calendarContainer.createCalendarsAutoComplete(
 			'<%= calendarResourcesURL %>',
 			addOtherCalendarInput,
-			function(event) {
+			function (event) {
 				window.<portlet:namespace />otherCalendarList.add(event.result.raw);
 
 				<portlet:namespace />refreshVisibleCalendarRenderingRules();
@@ -3965,7 +3959,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 		);
 	</c:if>
 
-	A.one('#<portlet:namespace />columnToggler').on('click', function(event) {
+	A.one('#<portlet:namespace />columnToggler').on('click', function (event) {
 		var columnTogglerIconId = '<portlet:namespace />columnTogglerIcon';
 		var columnGrid = A.one('#<portlet:namespace />columnGrid');
 		var columnOptions = A.one('#<portlet:namespace />columnOptions');
@@ -3995,7 +3989,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 		columnTogglerIcon.replace(newIcon);
 	});
 
-	window.<portlet:namespace />refreshMiniCalendarSelectedDates = function() {
+	window.<portlet:namespace />refreshMiniCalendarSelectedDates = function () {
 		<portlet:namespace />miniCalendar._clearSelection();
 
 		var activeView = <portlet:namespace />scheduler.get('activeView');
@@ -4030,7 +4024,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 	var DateMath = A.DataType.DateMath;
 
-	window.<portlet:namespace />refreshVisibleCalendarRenderingRules = function() {
+	window.<portlet:namespace />refreshVisibleCalendarRenderingRules = function () {
 		var miniCalendarStartDate = DateMath.subtract(
 			DateMath.toMidnight(
 				window.<portlet:namespace />miniCalendar.get('date')
@@ -4056,11 +4050,11 @@ String backURL = PortalUtil.getCurrentURL(request);
 			Liferay.CalendarUtil.toUTC(miniCalendarStartDate),
 			Liferay.CalendarUtil.toUTC(miniCalendarEndDate),
 			'busy',
-			function(rulesDefinition) {
+			function (rulesDefinition) {
 				var selectedDates = <portlet:namespace />miniCalendar._getSelectedDatesList();
 
 				window.<portlet:namespace />miniCalendar.set('customRenderer', {
-					filterFunction: function(date, node, rules) {
+					filterFunction: function (date, node, rules) {
 						node.addClass('lfr-busy-day');
 
 						DateMath.toMidnight(date);
@@ -4090,7 +4084,7 @@ String backURL = PortalUtil.getCurrentURL(request);
 	window.<portlet:namespace />miniCalendar = new A.Calendar({
 		after: {
 			dateChange: <portlet:namespace />refreshVisibleCalendarRenderingRules,
-			dateClick: function(event) {
+			dateClick: function (event) {
 				<portlet:namespace />scheduler.setAttrs({
 					date: event.date,
 				});
@@ -4295,17 +4289,17 @@ PowwowMeeting powwowMeeting = PowwowMeetingLocalServiceUtil.fetchPowwowMeeting(p
 			document.getElementById('<portlet:namespace />copyButton')
 		);
 
-		client.on('error', function(event) {
+		client.on('error', function (event) {
 			ZeroClipboard.destroy();
 		});
 
-		client.on('ready', function(readyEvent) {
-			client.on('aftercopy', function(event) {
+		client.on('ready', function (readyEvent) {
+			client.on('aftercopy', function (event) {
 				copyButton.addClass('copied');
 			});
 		});
 
-		copyButton.on('mouseout', function() {
+		copyButton.on('mouseout', function () {
 			copyButton.removeClass('copied');
 		});
 	}

--- a/packages/liferay-npm-scripts/test/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/formatJSP.js
@@ -332,7 +332,7 @@ describe('formatJSP()', () => {
 			// Not including these (rejected by Prettier, see "known
 			// limitations" below):
 			// 'edit_content_redirect.jsp',
-		])('%s matches snapshot', async fixture => {
+		])('%s matches snapshot', async (fixture) => {
 			const source = await getFixture(path.join('jsp', fixture));
 
 			expect(formatJSP(source)).toMatchSnapshot();

--- a/packages/liferay-npm-scripts/test/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/formatJSP.js
@@ -32,13 +32,7 @@ describe('formatJSP()', () => {
 		expect(formatJSP(source)).toBe(`
 			<p>Hi!</p>
 			<script>
-				if (
-					richEditor
-						.getEditor()
-						.getSession()
-						.getUndoManager()
-						.hasUndo()
-				) {
+				if (richEditor.getEditor().getSession().getUndoManager().hasUndo()) {
 					Liferay.fire('<portlet:namespace />saveTemplate');
 				}
 				<c:if test="<%= template == null %>">

--- a/packages/liferay-npm-scripts/test/jsp/lex.js
+++ b/packages/liferay-npm-scripts/test/jsp/lex.js
@@ -503,7 +503,7 @@ describe('lex()', () => {
 			'view.jsp',
 			'view_calendar_menus.jspf',
 			'view_meeting.jsp',
-		])('%s matches snapshot', async fixture => {
+		])('%s matches snapshot', async (fixture) => {
 			const source = await getFixture(path.join('jsp', fixture));
 
 			expect(lex(source).tokens).toMatchSnapshot();

--- a/packages/liferay-npm-scripts/test/jsp/substituteTags.js
+++ b/packages/liferay-npm-scripts/test/jsp/substituteTags.js
@@ -287,7 +287,7 @@ describe('substituteTags()', () => {
 			'view.jsp',
 			'view_calendar_menus.jspf',
 			'view_meeting.jsp',
-		])('%s matches snapshot', async fixture => {
+		])('%s matches snapshot', async (fixture) => {
 			const source = await getFixture(path.join('jsp', fixture));
 
 			expect(substituteTags(source)).toMatchSnapshot();

--- a/packages/liferay-npm-scripts/test/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/expandGlobs.js
@@ -88,7 +88,7 @@ describe('expandGlobs()', () => {
 		const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'scripts-'));
 		process.chdir(directory);
 
-		FIXTURES.forEach(fixture => {
+		FIXTURES.forEach((fixture) => {
 			const dirname = path.dirname(fixture);
 
 			fs.mkdirSync(dirname, {recursive: true});
@@ -160,7 +160,7 @@ describe('expandGlobs()', () => {
 	it('excludes ignored files', () => {
 		const matches = expand(['*'], ['sdk/**']);
 
-		const filtered = FIXTURES.filter(entry => !entry.startsWith('sdk'));
+		const filtered = FIXTURES.filter((entry) => !entry.startsWith('sdk'));
 
 		expect(matches).toEqual(filtered);
 	});
@@ -168,7 +168,7 @@ describe('expandGlobs()', () => {
 	it('respects negated ignore patterns', () => {
 		const matches = expand(['*.js'], ['*.js', '!*.es.js']);
 
-		const filtered = FIXTURES.filter(entry => entry.endsWith('.es.js'));
+		const filtered = FIXTURES.filter((entry) => entry.endsWith('.es.js'));
 
 		expect(matches).toEqual(filtered);
 	});
@@ -176,7 +176,7 @@ describe('expandGlobs()', () => {
 	it('treats negated match patterns as non-negated ignores', () => {
 		const matches = expand(['*.js', '!*.js'], ['!*.es.js']);
 
-		const filtered = FIXTURES.filter(entry => entry.endsWith('.es.js'));
+		const filtered = FIXTURES.filter((entry) => entry.endsWith('.es.js'));
 
 		expect(matches).toEqual(filtered);
 	});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11646,10 +11646,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-error@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Previously manually tested in liferay-portal [here](https://github.com/wincent/liferay-portal/pull/211).

Breaking change because of changes described in [the blog post](https://prettier.io/blog/2020/03/21/2.0.0.html).

A key default changed:

> Change default value for `arrowParens` to `always`

Another big change is:

> Always add a space after the `function` keyword

Includes update of test snapshots (`yarn test -u`) and one manual change I had to make that wasn't covered by `yarn test -u`.

Closes: https://github.com/liferay/liferay-npm-tools/issues/418



