### PR TITLE
feat!: update to eslint-config-liferay v21.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"eslint": "6.8.0",
-		"eslint-config-liferay": "20.0.1",
+		"eslint-config-liferay": "21.0.0",
 		"prettier": "2.0.5"
 	},
 	"jest": {

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -188,6 +188,7 @@ async function getRemote(options) {
 function escape(string) {
 	// At the moment, not escaping some special Markdown characters (such as *,
 	// backticks etc) as they may prove useful.
+
 	return string
 		.replace(/_/g, '\\_')
 		.replace(/&/g, '&amp;')
@@ -234,6 +235,7 @@ const types = {
 
 	// Not a Conventional Commits type; we repeat breaking changes separately to
 	// maximize their visibility:
+
 	breaking: ':boom: Breaking changes',
 
 	feat: ':new: Features',
@@ -247,6 +249,7 @@ const types = {
 	revert: ':leftwards_arrow_with_hook: Reverts',
 
 	// Not a Conventional Commits type; this is our catch-all:
+
 	misc: ':package: Miscellaneous',
 
 	/* eslint-enable sort-keys */
@@ -415,6 +418,7 @@ const V_PREFIX_REGEX = /^v\d/;
 //
 // See: https://semver.org/
 //
+
 const VERSION_REGEX = /^(.*?)(\bv)?(\d+\.\d+\.\d+(?:-[0-9a-z-]+(?:\.[0-9a-z-]+)*)?(?:\+[0-9a-z-]+(?:\.[0-9a-z-]+)*)?)$/i;
 
 /**
@@ -430,14 +434,17 @@ async function normalizeVersion(version, {force}, versionTagPrefix) {
 
 	if (versionTagPrefix) {
 		// We know the desired prefix (from the .yarnrc).
+
 		prefix = versionTagPrefix;
 	} else {
 		// Try to guess the right prefix ("v" or nothing) based on existing
 		// tags.
+
 		const tags = (await git('tag', '-l')).trim().split('\n');
 
 		// Calculate a "coefficient" that reflects the likelihood that
 		// this repo uses a "v" prefix by convention.
+
 		const coefficient = tags.reduce((current, tag) => {
 			return current + (V_PREFIX_REGEX.test(tag) ? 1 : -1);
 		}, 0);
@@ -734,6 +741,7 @@ async function main(_node, _script, ...args) {
 				);
 			} catch (err) {
 				// This will be the last chunk we generate.
+
 				info('No more tags found (this is not an error) 🦄');
 			}
 

--- a/packages/liferay-jest-junit-reporter/test/index.js
+++ b/packages/liferay-jest-junit-reporter/test/index.js
@@ -21,7 +21,9 @@ const failedTestReport = {
 			testResults: [
 				{
 					duration: 46,
+
 					// copied from a failed jest test
+
 					failureMessages: [
 						'Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).toBe(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32mfalse\u001b[39m\nReceived: \u001b[31mtrue\u001b[39m\n    at Object.<anonymous> (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/metal/js/KeyValue/KeyValue.es.js:70:18)\n    at Object.asyncFn (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/jasmine_async.js:108:37)\n    at resolve (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/queue_runner.js:56:12)\n    at new Promise (<anonymous>)\n    at mapper (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/queue_runner.js:43:19)\n    at promise.then (/Users/bryceosterhaus/liferay/repos/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/node_modules/jest-jasmine2/build/queue_runner.js:87:41)\n    at <anonymous>\n    at process._tickCallback (internal/process/next_tick.js:182:7)',
 					],
@@ -57,6 +59,7 @@ describe('liferay-jest-junit-reporter', () => {
 		jest.resetAllMocks();
 
 		// Prevent user-specific context from appearing in snapshots.
+
 		jest.spyOn(process, 'cwd').mockImplementation(() => 'reporter-tests');
 	});
 

--- a/packages/liferay-js-insights/index.js
+++ b/packages/liferay-js-insights/index.js
@@ -41,17 +41,21 @@ async function parse(content) {
 
 async function getModuleMeta(modulePath) {
 	// Resolves current modulePath base directory
+
 	const cwd = path.dirname(path.resolve(modulePath));
 
 	// Finds the closer package.json file to the modulePath
+
 	const pkg = await findUp('package.json', {cwd});
 
 	// Take app from the `name` field in package.json
+
 	const app = JSON.parse(await readFile(pkg, 'utf8')).name;
 
 	const name = path.basename(modulePath);
 
 	// Finds the root git folder
+
 	const gitRoot = await findUp('.git', {
 		cwd,
 		type: 'directory',

--- a/packages/liferay-js-insights/reporters/airtable.js
+++ b/packages/liferay-js-insights/reporters/airtable.js
@@ -52,6 +52,7 @@ module.exports = async function (modulesInfo, config) {
 
 	while (synced < modulesInfo.length) {
 		// Airtable API only allows creating up to 10 records per request. It also expects a flat Map<string, object> `fields` parameter
+
 		const chunk = modulesInfo
 			.slice(synced, synced + 10)
 			.map((moduleInfo) => {

--- a/packages/liferay-js-publish/src/index.js
+++ b/packages/liferay-js-publish/src/index.js
@@ -153,6 +153,7 @@ function getRemote() {
 		})
 		.sort((a, b) => {
 			// Sort by URL, preferring `git` over `http` URLs.
+
 			if (a[1] > b[1]) {
 				return 1;
 			} else if (a[1] < b[1]) {

--- a/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
+++ b/packages/liferay-npm-scripts/bin/liferay-npm-scripts.js
@@ -16,6 +16,7 @@ main().catch((error) => {
 	if (error instanceof SpawnError) {
 		// For this common error case (spawned tools exiting with an error)
 		// we avoid printing a stack trace.
+
 		log(error.message);
 	} else {
 		log(error);

--- a/packages/liferay-npm-scripts/contrib/prettier/prettier.js
+++ b/packages/liferay-npm-scripts/contrib/prettier/prettier.js
@@ -32,6 +32,7 @@ const debug = (line) => {
 };
 
 // Remember last-used prettier instance so that it can be used as a fallback.
+
 let prettier;
 
 /**
@@ -47,6 +48,7 @@ module.exports = {
 			return prettier.format(source, options);
 		} else {
 			// Last-resort fallback.
+
 			return source;
 		}
 	},
@@ -987,6 +989,7 @@ module.exports = {
  */
 function getPortalRoot(filepath) {
 	// Walk up until we find portal-web (in the root).
+
 	let current = filepath;
 
 	while (true) {
@@ -1001,6 +1004,7 @@ function getPortalRoot(filepath) {
 		} else {
 			if (parent === current) {
 				// Can't go any higher.
+
 				return null;
 			}
 
@@ -1009,6 +1013,7 @@ function getPortalRoot(filepath) {
 	}
 
 	// Confirm that this really is liferay-portal by looking down.
+
 	if (fs.existsSync(path.join(current, 'docroot/WEB-INF/liferay-web.xml'))) {
 		return path.dirname(current);
 	} else {

--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -42,7 +42,7 @@
 		"css-loader": "^3.0.0",
 		"deepmerge": "^4.0.0",
 		"eslint": "6.8.0",
-		"eslint-config-liferay": "20.0.1",
+		"eslint-config-liferay": "21.0.0",
 		"fs-extra": "^8.1.0",
 		"globby": "11.0.0",
 		"gulp": "^4.0.2",

--- a/packages/liferay-npm-scripts/src/jest/resolver.js
+++ b/packages/liferay-npm-scripts/src/jest/resolver.js
@@ -17,6 +17,7 @@ module.exports = function (request, options) {
 	const {basedir, defaultResolver} = options;
 
 	// Redirect imports to .soy.js files from input to output directory
+
 	if (basedir.startsWith(CWD)) {
 		if (/\.soy(?:\.js)?$/.test(request)) {
 			const dir = basedir.replace(INPUT, OUTPUT);
@@ -30,5 +31,6 @@ module.exports = function (request, options) {
 	}
 
 	// Fallback to default resolver
+
 	return defaultResolver(request, options);
 };

--- a/packages/liferay-npm-scripts/src/jsp/Lexer.js
+++ b/packages/liferay-npm-scripts/src/jsp/Lexer.js
@@ -132,9 +132,11 @@ class Lexer {
 		 */
 		function allOf(...matchers) {
 			// Given matchers [a, b], permute them (eg. [[a, b], [b, a]])...
+
 			const permutations = permute(matchers);
 
 			// ...and transform into: oneOf(sequence(a, b), sequence(b, a)):
+
 			const matcher = oneOf(...permutations.map((m) => sequence(...m)));
 
 			return {
@@ -264,6 +266,7 @@ class Lexer {
 						return match;
 					} else {
 						// Fake a zero-width match.
+
 						return getMatchObject('');
 					}
 				},
@@ -641,11 +644,13 @@ class Lexer {
 			}
 
 			// Potentially re-use result of preceeding `peek()`.
+
 			const peeked = peek.peeked;
 			delete peek.peeked;
 
 			if (matcher === undefined) {
 				// Return result of previous `peek()`.
+
 				if (peeked != undefined) {
 					result = peeked;
 				} else {
@@ -657,6 +662,7 @@ class Lexer {
 				if (peeked !== null) {
 					// We previously peeked but aren't consuming the memoized
 					// result, so we need to rollback the peek's side-effects.
+
 					meta.rollback();
 				}
 
@@ -691,6 +697,7 @@ class Lexer {
 			}
 
 			// TODO: report index, maybe.
+
 			const context =
 				remaining.length > 20
 					? `${remaining.slice(0, 20)}...`
@@ -723,6 +730,7 @@ class Lexer {
 			}
 
 			// Memoize the result so that we can `consume()` it if desired.
+
 			peek.peeked = matcher.exec(remaining);
 
 			if (peek.peeked === null) {
@@ -842,6 +850,7 @@ class Lexer {
 				next: {
 					// Lazy because token N+1 doesn't exist yet when
 					// token N is produced.
+
 					get() {
 						if (!atEnd() && !tokens.has(counter + 1)) {
 							const nextToken = produceToken();
@@ -857,6 +866,7 @@ class Lexer {
 				previous: {
 					// Non-enumerable so that tokens can be
 					// introspected without the clutter.
+
 					value: tokens.get(counter - 1),
 				},
 			});
@@ -896,6 +906,7 @@ class Lexer {
  */
 function escape(literal) {
 	// https://github.com/benjamingr/RegExp.escape/blob/master/EscapedChars.md
+
 	return literal.replace(/[\^$\\.*+?()[\]{}|]/g, '\\$&');
 }
 
@@ -907,6 +918,7 @@ function getMatchObject(string) {
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
 	// TODO: needs index and input properties
 	// might also want to set lastIndex on regexp
+
 	return [string];
 }
 

--- a/packages/liferay-npm-scripts/src/jsp/ReversibleMap.js
+++ b/packages/liferay-npm-scripts/src/jsp/ReversibleMap.js
@@ -15,6 +15,7 @@ class ReversibleMap extends Map {
 		super(iterable);
 
 		// A stack of operations that can be applied to reverse mutations.
+
 		this.undo = [];
 	}
 
@@ -28,6 +29,7 @@ class ReversibleMap extends Map {
 	 */
 	_snapshot() {
 		// If called from constructor, this.undo won't be set yet.
+
 		if (this.undo) {
 			const entries = [...this.entries()];
 

--- a/packages/liferay-npm-scripts/src/jsp/dedent.js
+++ b/packages/liferay-npm-scripts/src/jsp/dedent.js
@@ -9,6 +9,7 @@
  */
 function dedent(input, tabWidth = 4) {
 	// Collapse totally blank lines to empty strings.
+
 	const lines = input.split('\n').map((line) => {
 		if (line.match(/^\s+$/)) {
 			return '';
@@ -18,6 +19,7 @@ function dedent(input, tabWidth = 4) {
 	});
 
 	// Find minimum indent (ignoring empty lines).
+
 	const minimum = lines.reduce((acc, line) => {
 		const [, indent, rest] = line.match(/^(\s*)(.*)/);
 
@@ -35,6 +37,7 @@ function dedent(input, tabWidth = 4) {
 	}, Infinity);
 
 	// Strip out minimum indent from every line.
+
 	const dedented = isFinite(minimum)
 		? lines.map((line) => {
 				const [, indent, rest] = line.match(/^(\s*)(.*)/);
@@ -42,6 +45,7 @@ function dedent(input, tabWidth = 4) {
 				if (minimum && indent.length) {
 					// Remove leftmost character until hitting desired length;
 					// if you overshoot (due to a tab), pad with spaces.
+
 					const chars = Array.from(indent);
 
 					let currentLength = chars.reduce((count, char) => {
@@ -72,6 +76,7 @@ function dedent(input, tabWidth = 4) {
 		: lines;
 
 	// Trim first and last line if empty.
+
 	if (dedented[0] === '') {
 		dedented.shift();
 	}

--- a/packages/liferay-npm-scripts/src/jsp/extractJS.js
+++ b/packages/liferay-npm-scripts/src/jsp/extractJS.js
@@ -88,6 +88,7 @@ function extractJS(source) {
 
 					// Handle edge case where the openTag and the content all
 					// fit on one line (eg. <script>code();</script>).
+
 					const lastLine =
 						contentLines.length === 1
 							? lastPrefixLine + lastContentLine
@@ -98,7 +99,9 @@ function extractJS(source) {
 						contents: body,
 						match,
 						openTag,
+
 						// TODO: consider getting rid of end/start
+
 						range: {
 							end: {
 								column: lastLine.length + 1,

--- a/packages/liferay-npm-scripts/src/jsp/lex.js
+++ b/packages/liferay-npm-scripts/src/jsp/lex.js
@@ -590,10 +590,9 @@ function lex(source, options = {}) {
 			a('TEMPLATE_CHAR').until(match(/<|\$\{|#\{/))
 		).name('TEMPLATE_TEXT');
 
+		// TODO: these first two should also only be when(ELEnabled)
+
 		const TEMPLATE_CHAR = oneOf(
-
-			// TODO: these two should also only be when(ELEnabled)
-
 			match('\\$'),
 			match('\\#'),
 

--- a/packages/liferay-npm-scripts/src/jsp/lex.js
+++ b/packages/liferay-npm-scripts/src/jsp/lex.js
@@ -496,7 +496,9 @@ function lex(source, options = {}) {
 
 		const EL_EXPRESSION = when(
 			() => meta.get('ELEnabled'),
+
 			// TODO: Implement full "Expression Language Specification" spec
+
 			sequence(EL_EXPRESSION_START, CHAR.to(EL_EXPRESSION_END)),
 			never
 		);
@@ -589,7 +591,9 @@ function lex(source, options = {}) {
 		).name('TEMPLATE_TEXT');
 
 		const TEMPLATE_CHAR = oneOf(
+
 			// TODO: these two should also only be when(ELEnabled)
+
 			match('\\$'),
 			match('\\#'),
 
@@ -715,6 +719,7 @@ function lex(source, options = {}) {
 				return token('EL_EXPRESSION', text);
 			} else if (peek(PORTLET_NAMESPACE)) {
 				// This one is a special case of "CustomAction" for liferay-portal.
+
 				const text = consume(PORTLET_NAMESPACE);
 
 				return token('PORTLET_NAMESPACE', text);
@@ -728,6 +733,7 @@ function lex(source, options = {}) {
 				let text = consume();
 
 				// TODO: consider making this a stack
+
 				const name = meta.get('customAction:name');
 
 				const E_TAG = sequence(
@@ -748,6 +754,7 @@ function lex(source, options = {}) {
 					return token('CUSTOM_ACTION', text);
 				} else {
 					// Will continue tokenizing next time around.
+
 					text += consume(match('>'));
 
 					return token('CUSTOM_ACTION_START', text);

--- a/packages/liferay-npm-scripts/src/jsp/lintJSP.js
+++ b/packages/liferay-npm-scripts/src/jsp/lintJSP.js
@@ -59,6 +59,7 @@ function lintJSP(source, onReport, options = {}) {
 					}
 				} else if (quiet) {
 					// In quiet mode, we only report errors, not warnings.
+
 					return false;
 				} else {
 					warningCount++;
@@ -72,6 +73,7 @@ function lintJSP(source, onReport, options = {}) {
 			});
 
 			// Ensure trailing newline, matching Prettier's convention.
+
 			source = output.endsWith('\n') ? output : `${output}\n`;
 
 			if (messages.length) {

--- a/packages/liferay-npm-scripts/src/jsp/restoreTags.js
+++ b/packages/liferay-npm-scripts/src/jsp/restoreTags.js
@@ -10,6 +10,7 @@ const indent = require('./indent');
 const {SCRIPTLET_CONTENT} = require('./substituteTags');
 const {CLOSE_TAG, OPEN_TAG} = require('./tagReplacements');
 const {TAB_CHAR, isFiller} = require('./toFiller');
+
 /**
  * Takes a source string and reinserts tags that were previously extracted with
  * substituteTags().
@@ -53,6 +54,7 @@ function restoreTags(source, tags) {
 
 	// First pass: restore internal indents related to JSP entities
 	// (ie. undo the effects of `stripIndents()`.
+
 	for (let i = 0; i < tokens.length; i++) {
 		const token = tokens[i];
 		const {contents, name} = token;
@@ -115,6 +117,7 @@ function restoreTags(source, tags) {
 	}
 
 	// Second pass: re-insert JSP tags into source.
+
 	tagCount = 0;
 	tokens = [...lexer.lex(output)];
 	output = '';
@@ -165,6 +168,7 @@ function appendScriptlet(scriptlet, token, output) {
 	let suffix = '';
 
 	// Look up neighboring tokens.
+
 	const tokens = {
 		/* eslint-disable sort-keys */
 		'-3':
@@ -181,6 +185,7 @@ function appendScriptlet(scriptlet, token, output) {
 
 	if (!tokens[-1]) {
 		// SCRIPTLET is the very first thing in the script block.
+
 		prefix = '\n';
 	}
 
@@ -191,6 +196,7 @@ function appendScriptlet(scriptlet, token, output) {
 		tokens[-2].name !== 'NEWLINE'
 	) {
 		// Need to add another newline to force a blank line.
+
 		prefix = '\n';
 	}
 
@@ -206,10 +212,12 @@ function appendScriptlet(scriptlet, token, output) {
 		//
 		// Note: cannot use `tokens[-1].index` here because it may have been
 		// invalidated by previous edits.
+
 		const whitespace = tokens[-1].contents;
 		output = output.slice(0, -whitespace.length);
 
 		// Add newline to force blank line, then re-add trimmed whitespace.
+
 		prefix = '\n' + whitespace;
 	}
 
@@ -224,6 +232,7 @@ function appendScriptlet(scriptlet, token, output) {
 
 	if (tokens[1] && tokens[1].name === 'NEWLINE' && !tokens[2]) {
 		// Scriptlet is (basically) the last thing in the script block.
+
 		suffix = '\n';
 	}
 
@@ -296,14 +305,17 @@ function getIndentedTag(tag, token) {
 
 	if (lines.length > 1) {
 		// Look at last line to figure out original indent.
+
 		const last = lines.pop();
 		const {0: original} = last.match(new RegExp(`^${TAB_CHAR}*`));
 
 		// Restore original indent to first line, then dedent the whole tag.
+
 		const [dedented] = dedent('\t'.repeat(original.length) + tag);
 
 		// And indent it to the correct level, but trim off the indent on
 		// the first line because we already emitted that.
+
 		return indent(dedented, 1, previous).replace(previous, '');
 	}
 
@@ -319,6 +331,7 @@ function getImpliedIndentFromScriptlet(tag) {
 
 	// Keeping this simple for now; can always extend to lex more rigorously if
 	// we find that it's needed.
+
 	tag.replace(/[{}]/g, ([brace]) => {
 		if (brace === '}') {
 			delta--;
@@ -338,6 +351,7 @@ function removeIndent(output, token, count = 1) {
 		token.previous.previous.name === 'NEWLINE'
 	) {
 		// We already emitted too much indent; roll it back.
+
 		return output.replace(
 			new RegExp(`\t{0,${count}}${token.previous.contents}$`),
 			token.previous.contents

--- a/packages/liferay-npm-scripts/src/jsp/stripIndents.js
+++ b/packages/liferay-npm-scripts/src/jsp/stripIndents.js
@@ -38,6 +38,7 @@ const {CLOSE_TAG, OPEN_TAG} = require('./tagReplacements');
 //      /* close placeholder */
 //
 // So, this function does the same.
+
 function stripIndents(source) {
 	const lexer = new Lexer((api) => {
 		const {choose, match} = api;
@@ -84,6 +85,7 @@ function stripIndents(source) {
 
 					// Peek ahead to see if the next token is whitespace,
 					// and trim it if necessary.
+
 					const [maybeWhitespace, maybeCloseTag] = tokens.slice(
 						i + 1,
 						i + 3

--- a/packages/liferay-npm-scripts/src/jsp/substituteTags.js
+++ b/packages/liferay-npm-scripts/src/jsp/substituteTags.js
@@ -40,6 +40,7 @@ function substituteTags(source) {
 
 		// Provisionally assume that "contents" corresponds to a tag that we're
 		// going to substitute.
+
 		tags.push(contents);
 
 		if (name === 'CUSTOM_ACTION') {
@@ -49,6 +50,7 @@ function substituteTags(source) {
 		} else if (name === 'CUSTOM_ACTION_START') {
 			// Special case 1: scan ahead to detect actions that have no
 			// non-whitespace children.
+
 			let j = i + 1;
 			let outer = contents;
 			let text = '';
@@ -56,6 +58,7 @@ function substituteTags(source) {
 
 			// Special case 2: scan ahead to detect single-line open
 			// tags that have nothing after them on the same line.
+
 			let last;
 
 			while (j < tokens.length) {

--- a/packages/liferay-npm-scripts/src/jsp/tagReplacements.js
+++ b/packages/liferay-npm-scripts/src/jsp/tagReplacements.js
@@ -86,9 +86,11 @@ const OPEN_TAG = new RegExp(`${isFiller(BLOCK_OPEN).source}|//${BLOCK_OPEN}+`);
 //         }                           |               }
 //     </c:if>                         |           /*ʅʅʅ*/
 //
+
 function getOpenTagReplacement(tag, last = false) {
 	if (last && !tag.match(/[\n\r]/)) {
 		// Replace with a one-line (//) comment.
+
 		if (tag.length < 2) {
 			throw new Error(`Invalid (underlength) tag: ${tag}`);
 		}
@@ -96,6 +98,7 @@ function getOpenTagReplacement(tag, last = false) {
 		return `//${BLOCK_OPEN.repeat(tag.length - 2)}`;
 	} else {
 		// Replace with a C-style (/*...*/) comment.
+
 		return toFiller(tag, BLOCK_OPEN);
 	}
 }
@@ -116,6 +119,7 @@ function getOpenTagReplacement(tag, last = false) {
 //                ...becomes:
 //     /*ʅʅ*/
 //
+
 function getCloseTagReplacement(tag) {
 	return toFiller(tag, BLOCK_CLOSE);
 }
@@ -131,6 +135,7 @@ function getCloseTagReplacement(tag) {
 //                 ...becomes:
 //     /*╳╳╳╳╳╳*/
 //
+
 function getSelfClosingTagReplacement(tag) {
 	return toFiller(tag);
 }

--- a/packages/liferay-npm-scripts/src/jsp/toFiller.js
+++ b/packages/liferay-npm-scripts/src/jsp/toFiller.js
@@ -48,6 +48,7 @@ function toFiller(string, filler = FILLER_CHAR) {
 
 	// Special case: if `body` is just whitespace; must insert at least
 	// one filler.
+
 	let output = body.match(/^\s+$/) ? FILLER_CHAR : '';
 
 	const LINE = /([ \t]*)([^\r\n]*)(\r?\n)?/g;

--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -17,22 +17,26 @@ module.exports = {
 	build: {
 		// Passed to:
 		// - `metalsoy` executable (via `generateSoyDependencies()`).
+
 		dependencies: [...clay, ...liferay, ...metal],
 
 		// Passed to:
 		// - `babel` executable (via `runBabel()`).
 		// - `jest` executable (via resolver.js).
 		// - `metalsoy` executable (via `buildSoy()`).
+
 		input: 'src/main/resources/META-INF/resources',
 
 		// Passed to:
 		// - `babel` executable (via `runBabel()`).
 		// - `jest` executable (via resolver.js).
 		// - `translateSoy()`.
+
 		output: 'build/node/packageRunBuild/resources',
 
 		// Used in various places to keep intermediate artefacts out of Gradle's
 		// way (see `buildSoy()`, `withTempFile()`, etc).
+
 		temp: 'build/npmscripts',
 	},
 	check: CHECK_AND_FIX_GLOBS,

--- a/packages/liferay-npm-scripts/src/prettier/index.js
+++ b/packages/liferay-npm-scripts/src/prettier/index.js
@@ -88,6 +88,7 @@ function format(source, options) {
 			// Override "parser" value from `getConfigForFile()`, which
 			// is an absolute path; make it a name that matches the
 			// parser we defined with `defineParser()` above.
+
 			parser: 'babel-eslint',
 		},
 

--- a/packages/liferay-npm-scripts/src/prettier/rules/newline-before-block-statements.js
+++ b/packages/liferay-npm-scripts/src/prettier/rules/newline-before-block-statements.js
@@ -12,12 +12,14 @@ module.exports = {
 		 */
 		function check(node) {
 			// We only fix if on same line.
+
 			let last = source.getLastToken(node);
 			const keyword = source.getTokenAfter(last);
 
 			if (last.loc.end.line === keyword.loc.start.line) {
 				// Possibly fragile assumption here: source code is
 				// using tabs for indentation.
+
 				const indent = '\t'.repeat(last.loc.end.column - 1);
 
 				context.report({
@@ -51,6 +53,7 @@ module.exports = {
 				//                } else {
 				//     consequent ^      ^ alternate
 				//
+
 				const {alternate, consequent} = node;
 
 				if (alternate) {
@@ -81,6 +84,7 @@ module.exports = {
 				// preceding node (whether that be a "block" or a "handler") and
 				// they both stop at their ending "}" punctuator.
 				//
+
 				const {block, finalizer, handler} = node;
 
 				if (handler) {

--- a/packages/liferay-npm-scripts/src/scripts/build.js
+++ b/packages/liferay-npm-scripts/src/scripts/build.js
@@ -46,10 +46,12 @@ const CWD = process.cwd();
 //
 // See https://github.com/petershin/liferay-portal/pull/724 for more details.
 //
+
 function runBridge() {
 	spawnSync('liferay-npm-bridge-generator');
 
 	// Retrieves the `.npmbridgerc` configuration which we already know exists
+
 	const bridgeConfig = JSON.parse(fs.readFileSync('.npmbridgerc', 'utf8'));
 
 	Object.keys(bridgeConfig).forEach((moduleKey) => {

--- a/packages/liferay-npm-scripts/src/scripts/check/preflight.js
+++ b/packages/liferay-npm-scripts/src/scripts/check/preflight.js
@@ -23,6 +23,7 @@ const STYLELINT_CONFIG_FILE_NAME = '.stylelintrc.js';
 
 const DISALLOWED_CONFIG_FILE_NAMES = {
 	// https://babeljs.io/docs/en/config-files/
+
 	'.babelrc': BABEL_CONFIG_FILE_NAME,
 	'.babelrc.cjs': BABEL_CONFIG_FILE_NAME,
 	'.babelrc.json': BABEL_CONFIG_FILE_NAME,
@@ -33,6 +34,7 @@ const DISALLOWED_CONFIG_FILE_NAMES = {
 	'babel.config.mjs': BABEL_CONFIG_FILE_NAME,
 
 	// https://eslint.org/docs/user-guide/configuring
+
 	'.eslintrc': ESLINT_CONFIG_FILE_NAME,
 	'.eslintrc.cjs': ESLINT_CONFIG_FILE_NAME,
 	'.eslintrc.json': ESLINT_CONFIG_FILE_NAME,
@@ -40,6 +42,7 @@ const DISALLOWED_CONFIG_FILE_NAMES = {
 	'.eslintrc.yml': ESLINT_CONFIG_FILE_NAME,
 
 	// https://prettier.io/docs/en/configuration.html
+
 	'.prettierrc': PRETTIER_CONFIG_FILE_NAME,
 	'.prettierrc.json': PRETTIER_CONFIG_FILE_NAME,
 	'.prettierrc.toml': PRETTIER_CONFIG_FILE_NAME,
@@ -48,6 +51,7 @@ const DISALLOWED_CONFIG_FILE_NAMES = {
 	'prettier.config.js': PRETTIER_CONFIG_FILE_NAME,
 
 	// https://stylelint.io/user-guide/configuration
+
 	'.stylelintrc': STYLELINT_CONFIG_FILE_NAME,
 	'.stylelintrc.json': STYLELINT_CONFIG_FILE_NAME,
 	'.stylelintrc.yml': STYLELINT_CONFIG_FILE_NAME,

--- a/packages/liferay-npm-scripts/src/scripts/format.js
+++ b/packages/liferay-npm-scripts/src/scripts/format.js
@@ -54,6 +54,7 @@ function format(options = {}) {
 
 		try {
 			// TODO: don't re-read file, run eslint on it too
+
 			const source = fs.readFileSync(filepath, 'utf8');
 
 			const prettierOptions = {
@@ -85,6 +86,7 @@ function format(options = {}) {
 			}
 		} catch (error) {
 			// Generally this means a syntax error.
+
 			log(`${filepath}: ${error}`);
 			bad++;
 		}

--- a/packages/liferay-npm-scripts/src/scripts/lint.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint.js
@@ -73,10 +73,12 @@ async function lint(options = {}) {
 		//   fixes do not have an "output" property, but
 		//   `report.fixableErrorCount` and `report.fixableWarningCount` will be
 		//   set.
+
 		fix,
 
 		// Avoid spurious warnings of the form, "File ignored by
 		// default. Use a negated ignore pattern ... to override"
+
 		ignorePattern: '!*',
 	});
 
@@ -92,6 +94,7 @@ async function lint(options = {}) {
 
 		if (fix && jsPaths.length) {
 			// This is what actually writes to the file-system.
+
 			CLIEngine.outputFixes(report);
 		}
 	} else {
@@ -104,6 +107,7 @@ async function lint(options = {}) {
 	]) {
 		for (const filePath of paths) {
 			// TODO: non-sync version to make use of I/O concurrency
+
 			const contents = fs.readFileSync(filePath, 'utf8');
 
 			try {
@@ -130,6 +134,7 @@ async function lint(options = {}) {
 	// In `quiet` mode, keep only errors.
 	// Otherwise keep both errors and warnings.
 	// Filter out everything else.
+
 	const results = (report.results || [])
 		.map((result) => {
 			const messages = result.messages.filter((message) => {

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/lintSCSS.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/lintSCSS.js
@@ -21,6 +21,7 @@ async function lintSCSS(source, onReport, options = {}) {
 	// doesn't tell us which problems are autofixable and there is no
 	// totally reliable way to guess, so these counts will always be
 	// (possibly innaccurately) zero.
+
 	const fixableErrorCount = 0;
 	const fixableWarningCount = 0;
 
@@ -44,6 +45,7 @@ async function lintSCSS(source, onReport, options = {}) {
 		// Beware: if `fix` is true, stylelint will return the autofixed
 		// source as `output`; when false, it will return an object
 		// containing non-source metadata instead.
+
 		fix,
 
 		syntax: 'scss',
@@ -53,6 +55,7 @@ async function lintSCSS(source, onReport, options = {}) {
 		// - "warnings" array contains both errors and warnings.
 		// - "errored" is true if at least one problem of
 		//   severity "error" is present.
+
 		if (result.errored || (result.warnings.length && !quiet)) {
 			messages.push(
 				...result.warnings.map(
@@ -61,6 +64,7 @@ async function lintSCSS(source, onReport, options = {}) {
 							errorCount++;
 						} else if (quiet) {
 							// In quiet mode, we only report errors, not warnings.
+
 							return;
 						} else {
 							warningCount++;
@@ -68,7 +72,9 @@ async function lintSCSS(source, onReport, options = {}) {
 
 						return {
 							column,
+
 							// fix,
+
 							line,
 							message: text,
 							ruleId: rule,
@@ -81,6 +87,7 @@ async function lintSCSS(source, onReport, options = {}) {
 	});
 
 	// Ensure trailing newline, matching Prettier's convention.
+
 	source = fix ? (output.endsWith('\n') ? output : `${output}\n`) : source;
 
 	if (messages.length) {

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/single-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/single-imports.js
@@ -23,6 +23,7 @@ function tokenize(params) {
 	const tokens = [];
 
 	// Slow but simple iteration through string.
+
 	let i = 0;
 
 	for (; i < params.length; ) {
@@ -109,6 +110,7 @@ module.exports = stylelint.createPlugin(
 						// Note that changes to "raws" have to be made after
 						// the `replaceWith` call, or they won't have any
 						// effect.
+
 						const trailing = /(.*?)(\n+)([ \t]*)$/.exec(
 							rule.raws.before
 						);

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/sort-imports.js
@@ -85,6 +85,7 @@ module.exports = stylelint.createPlugin(
 					// Try to make error messages (somewhat) minimal
 					// by only reporting from the first to the last
 					// mismatch (ie. not a full Myers diff algorithm).
+
 					const [firstMismatch, lastMismatch] = group.reduce(
 						([first, last], node, index) => {
 							if (node !== desired[index]) {

--- a/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/trim-comments.js
+++ b/packages/liferay-npm-scripts/src/scripts/lint/stylelint/plugins/trim-comments.js
@@ -14,6 +14,7 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 
 // In practice, PostCSS represents whitespace-only comments with empty
 // strings, but just to be safe, we employ a looser check.
+
 const BLANK_REGEX = /^\s*$/;
 
 function isLeadingComment(comment, prev) {
@@ -30,6 +31,7 @@ function isLeadingComment(comment, prev) {
 	if (newlines && newlines.length > 1) {
 		// Special case: previous node is a comment, but we have at least one
 		// intervening blank line.
+
 		return true;
 	}
 
@@ -50,6 +52,7 @@ function isTrailingComment(_comment, next) {
 	if (newlines && newlines.length > 1) {
 		// Special case: next node is a comment, but we have at least one
 		// intervening blank line.
+
 		return true;
 	}
 
@@ -104,6 +107,7 @@ module.exports = stylelint.createPlugin(
 								// PostCSS will kill preceding blank lines,
 								// so we have to reattach them to the next
 								// node.
+
 								const blanks = comment.raws.before.match(
 									/^\n+/
 								);
@@ -121,6 +125,7 @@ module.exports = stylelint.createPlugin(
 						if (isTrailingComment(comment, next)) {
 							if (fix) {
 								// PostCSS doesn't touch following blank lines.
+
 								comment.remove();
 							} else {
 								report(messages.noTrailingBlanks);

--- a/packages/liferay-npm-scripts/src/scripts/prettier.js
+++ b/packages/liferay-npm-scripts/src/scripts/prettier.js
@@ -106,17 +106,20 @@ function main(...args) {
 			if (option.endsWith('=')) {
 				if (arg === option.slice(0, -1)) {
 					// eg. "--some-opt value"
+
 					const value = args[++i];
 
 					handler = callback.bind(null, value);
 				} else if (arg.startsWith(option)) {
 					// eg. "--some-opt=value"
+
 					const value = arg.slice(option.length);
 
 					handler = callback.bind(null, value);
 				}
 			} else if (arg === option) {
 				// eg. "--flag"
+
 				handler = callback;
 			}
 
@@ -148,6 +151,7 @@ function main(...args) {
 		// When `--stdin` is in effect, Prettier ignores file arguments
 		// and the `--write` option, requires --stdin-filepath, and
 		// prints the output to stdout.
+
 		if (!options.stdinFilepath) {
 			throw new Error(`No --stdin-filepath provided`);
 		}

--- a/packages/liferay-npm-scripts/src/scripts/storybook.js
+++ b/packages/liferay-npm-scripts/src/scripts/storybook.js
@@ -93,17 +93,20 @@ function compileLanguageProperties(buildPath, paths) {
  */
 function storybook() {
 	// Create directory to store built storybook configs.
+
 	const buildPath = fs.mkdtempSync(path.join(os.tmpdir(), 'storybook-'));
 
 	log(`Building storybook files to: ${buildPath}`);
 
 	// Generate custom babel config using current working directory's .babelrc.
+
 	fs.writeFileSync(
 		path.join(buildPath, '.babelrc'),
 		JSON.stringify(BABEL_CONFIG)
 	);
 
 	// Write storybook config to a file for storybook files to access.
+
 	fs.writeFileSync(
 		path.join(buildPath, 'storybook-config.json'),
 		JSON.stringify(STORYBOOK_CONFIG)
@@ -115,14 +118,17 @@ function storybook() {
 
 	const args = [
 		// Set port that storybook will use to run the server on.
+
 		'--port',
 		STORYBOOK_CONFIG.port,
 
 		// Set directory where the storybook config files are.
+
 		'--config-dir',
 		buildPath,
 
 		// Set portal root directory to retrieve static resources from.
+
 		'--static-dir',
 		PORTAL_ROOT,
 	];

--- a/packages/liferay-npm-scripts/src/scripts/webpack.js
+++ b/packages/liferay-npm-scripts/src/scripts/webpack.js
@@ -25,6 +25,7 @@ module.exports = function (...args) {
 		} else {
 			// Cut out the "watch" argument; `splice()` would mutate, so create
 			// a new array instead.
+
 			const otherArgs = [
 				...args.slice(0, watch),
 				...args.slice(watch + 1),

--- a/packages/liferay-npm-scripts/src/storybook/frontend-js-react-web.mock.js
+++ b/packages/liferay-npm-scripts/src/storybook/frontend-js-react-web.mock.js
@@ -7,6 +7,7 @@ const React = require('react');
 
 module.exports = {
 	// See: https://github.com/liferay/liferay-portal/blob/afcb92c2e1/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/usePrevious.es.js
+
 	usePrevious: (value) => {
 		const ref = React.useRef();
 

--- a/packages/liferay-npm-scripts/src/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/src/utils/deepMerge.js
@@ -40,6 +40,7 @@ function getItemDescription(item) {
 	} catch (error) {
 		// Could be a circular reference, but we're unlikely to ever get here
 		// because the deepmerge package itself will die first.
+
 		return `[unstringifiable item: ${error}]`;
 	}
 }
@@ -57,10 +58,12 @@ function checkBabelName(name, kind) {
 		plugin: {
 			/* eslint-disable sort-keys */
 			// @babel/plugin-foo -> @babel/foo
+
 			'^@babel/(?:plugin-)?([\\w-]+)': '@babel/$1',
 
 			// @org/babel-plugin-foo -> @org/foo
 			// babel-plugin-foo      -> foo
+
 			'^(@[\\w-]+/)?babel-plugin-([\\w-]+)': '$1$2',
 			/* eslint-enable sort-keys */
 		},
@@ -68,10 +71,12 @@ function checkBabelName(name, kind) {
 			/* eslint-disable sort-keys */
 			// @babel/preset-foo -> @babel/preset-foo
 			// @babel/foo        -> @babel/preset-foo
+
 			'^@babel/(?:preset-)?([\\w-]+)': '@babel/preset-$1',
 
 			// @org/babel-preset-foo -> @org/foo
 			// babel-preset-foo      -> foo
+
 			'^(@[\\w-]+/)?babel-preset-([\\w-]+)': '$1$2',
 			/* eslint-enable sort-keys */
 		},
@@ -122,6 +127,7 @@ function getBabelOptions(item) {
 			: null;
 	} else {
 		// We never expect to get here, but just in case...
+
 		throw new Error('getBabelOptions(): incompatible item type');
 	}
 }
@@ -138,6 +144,7 @@ function babelMerge(key) {
 	if (kind === 'plugin' || kind === 'preset') {
 		return function (target, source, options) {
 			// Create a mutable copy of `source`.
+
 			const pending = source.slice();
 
 			const result = target.map((targetItem) => {

--- a/packages/liferay-npm-scripts/src/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/src/utils/expandGlobs.js
@@ -27,9 +27,11 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 	const results = [];
 
 	// If any matchers are negated, move them into the "ignores" list.
+
 	for (let i = matchers.length - 1; i >= 0; i--) {
 		if (matchers[i].negated) {
 			// Make a copy of the regular expression without the "negated" flag.
+
 			ignorers.unshift(getRegExpForGlob(matchGlobs[i].slice(1)));
 		}
 	}
@@ -37,6 +39,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 	// Make note of index of the last negation. (If a file has been
 	// ignored, we can stop testing it as soon as we get past the last
 	// negation.)
+
 	let lastNegationIndex = 0;
 
 	ignorers.push(
@@ -53,6 +56,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 
 	// As a special case, if we see an ignore glob like "a/b/c/**" past the
 	// lastNegationIndex we can short-circuit.
+
 	const prunable = new Map();
 	const seen = [];
 
@@ -66,6 +70,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 
 			// Warn about overlapping ignore patterns. This check is O(n^2) but
 			// n is expected to be tiny (approx. 10).
+
 			seen.forEach((previous) => {
 				if (
 					previous.startsWith(base) ||
@@ -87,6 +92,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 			//
 			//     c -> b -> a -> true
 			//
+
 			let current = prunable;
 
 			for (let j = components.length - 1; j >= 0; j--) {
@@ -97,6 +103,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 						current.set(component, new Map());
 					} else {
 						// Mark the root with "true".
+
 						current.set(component, true);
 					}
 				}
@@ -120,6 +127,7 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 			const file = path.posix.join(directory, entry);
 
 			// Check trie to see whether entire subtree can be pruned.
+
 			let trie = prunable;
 			let current = file;
 
@@ -143,21 +151,25 @@ function expandGlobs(matchGlobs, ignoreGlobs = [], options = {}) {
 				if (ignored ^ ignorer.negated) {
 					// File is ignored, but ignorer is not a negation;
 					// or file is not ignored, and ignorer is a negation.
+
 					continue;
 				}
 
 				if (ignorer.test(file)) {
 					if (ignorer.negated) {
 						// File got unignored.
+
 						ignored = false;
 					} else {
 						// File is provisionally ignored, for now.
+
 						ignored = true;
 					}
 				}
 
 				if (ignored && i >= lastNegationIndex) {
 					// File got definitively ignored.
+
 					return;
 				}
 			}

--- a/packages/liferay-npm-scripts/src/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/src/utils/filterChangedFiles.js
@@ -35,6 +35,7 @@ function filterChangedFiles(files) {
 	const mergeBase = git('merge-base', 'HEAD', upstream);
 
 	// Check for changes in liferay-npm-scripts version.
+
 	try {
 		git(
 			'diff',
@@ -49,6 +50,7 @@ function filterChangedFiles(files) {
 		//
 		// https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---quiet
 		// https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---exit-code
+
 		if (error.toString().includes('exited with status 1.')) {
 			return files;
 		}

--- a/packages/liferay-npm-scripts/src/utils/findRoot.js
+++ b/packages/liferay-npm-scripts/src/utils/findRoot.js
@@ -32,6 +32,7 @@ function findRoot() {
 
 		if (path.dirname(directory) === directory) {
 			// Can't go any higher.
+
 			directory = null;
 		} else {
 			directory = path.dirname(directory);

--- a/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
+++ b/packages/liferay-npm-scripts/src/utils/generateSoyDependencies.js
@@ -24,6 +24,7 @@ function generateSoyDependencies(dependencies) {
 				// Requires the `package.json` file to avoid resolving
 				// the main entry point of the package so we can safely
 				// infer the directory from the package root
+
 				resolvedDependency = path.dirname(
 					resolve.sync(`${dependency}/package.json`, {
 						basedir: cwd,

--- a/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
+++ b/packages/liferay-npm-scripts/src/utils/getJestModuleNameMapper.js
@@ -49,6 +49,7 @@ function getJestModuleNameMapper() {
 	// means that, for now, tests in projects in "modules/private" can import
 	// from projects under "modules/apps" but not from those under
 	// "modules/private/apps".
+
 	const root = findRoot();
 
 	if (root) {

--- a/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/src/utils/getMergedConfig.js
@@ -104,6 +104,7 @@ function getMergedConfig(type, property) {
 			//
 			// TODO: Remove once incremental-dom is no longer used in
 			// liferay-portal.
+
 			mergedConfig = hackilySupportIncrementalDOM(mergedConfig);
 
 			break;
@@ -150,11 +151,13 @@ function getMergedConfig(type, property) {
 			let userConfig = getUserConfig('npmscripts');
 
 			// Use default config if no user config exists
+
 			if (Object.keys(userConfig).length === 0) {
 				userConfig = require('../config/npmscripts.config');
 			}
 
 			// Check for preset before creating config
+
 			if (userConfig.preset) {
 				// eslint-disable-next-line liferay/no-dynamic-require
 				presetConfig = require(userConfig.preset);

--- a/packages/liferay-npm-scripts/src/utils/getPaths.js
+++ b/packages/liferay-npm-scripts/src/utils/getPaths.js
@@ -28,14 +28,17 @@ function getPaths(globs, extensions, ignoreFile) {
 	const ignores = fs.existsSync(ignoreFile) ? readIgnoreFile(ignoreFile) : [];
 
 	// Match Prettier behavior and ignore node_modules by default.
+
 	if (ignores.indexOf('node_modules/**') === -1) {
 		ignores.unshift('node_modules/**');
 	}
 
 	// Turn "{src,test}/*" into ["src/*", "test/*"]:
+
 	globs = [].concat(...globs.map((glob) => preprocessGlob(glob)));
 
 	// Filter out globs that don't apply to `extensions`.
+
 	globs = filterGlobs(globs, ...extensions);
 
 	if (!globs.length) {
@@ -49,9 +52,11 @@ function getPaths(globs, extensions, ignoreFile) {
 	}
 
 	// Actually traverse the file system.
+
 	let paths = expandGlobs(globs, ignores);
 
 	// Potentially reduce file list to only files changed on the current branch.
+
 	paths = filterChangedFiles(paths);
 
 	return paths;

--- a/packages/liferay-npm-scripts/src/utils/getRegExpForGlob.js
+++ b/packages/liferay-npm-scripts/src/utils/getRegExpForGlob.js
@@ -41,6 +41,7 @@ function scan(prefix, state) {
 
 function escape(pattern) {
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+
 	return pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
@@ -64,6 +65,7 @@ function getRegExpForGlob(glob) {
 	if (!anchored && !state.input.startsWith('**/')) {
 		// Unless anchored, all patterns implicitly match anywhere in the
 		// hierarchy.
+
 		state.input = `**/${state.input}`;
 	}
 

--- a/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
+++ b/packages/liferay-npm-scripts/src/utils/preprocessGlob.js
@@ -17,6 +17,7 @@ function preprocessGlob(glob) {
 	// This function considers each "{}" to be a "hole" in the template (the
 	// glob), to be filled in with permutations of the substitutions defined
 	// inside the braces.
+
 	const template = [''];
 	const substitutions = [];
 
@@ -43,6 +44,7 @@ function preprocessGlob(glob) {
 			const index = substitutions.length - 1;
 			if (substitutions[index] === '') {
 				// There were no substitutions at all; braces are literal.
+
 				substitutions.pop();
 				template[template.length - 1] += '{}';
 			} else {
@@ -51,10 +53,12 @@ function preprocessGlob(glob) {
 			}
 		} else if (bracketCount === 0) {
 			// We are capturing normal text.
+
 			const index = template.length - 1;
 			template[index] = template[index] + char;
 		} else {
 			// We are capturing substitution(s).
+
 			const index = substitutions.length - 1;
 			substitutions[index] += char;
 		}
@@ -72,6 +76,7 @@ function fill(template, substitutions) {
 
 	if (!rest.length && !substitutions.length) {
 		// Recursion base case (nothing left to substitute).
+
 		return [first];
 	}
 

--- a/packages/liferay-npm-scripts/src/utils/spawnSync.js
+++ b/packages/liferay-npm-scripts/src/utils/spawnSync.js
@@ -47,6 +47,7 @@ function spawnSync(command, args = [], options = {}) {
 		);
 	} else if (error) {
 		// We didn't successfully spawn, so this is a hard error.
+
 		throw new Error(
 			`Command ${getDescription(
 				executable,

--- a/packages/liferay-npm-scripts/test/config/babel.json.js
+++ b/packages/liferay-npm-scripts/test/config/babel.json.js
@@ -11,6 +11,7 @@ describe('babel.json', () => {
 		expect(() => {
 			// Merging the config with itself will force us to visit and
 			// check the entire thing.
+
 			deepMerge([config, config], deepMerge.MODE.BABEL);
 		}).not.toThrow();
 	});

--- a/packages/liferay-npm-scripts/test/jsp/Lexer.js
+++ b/packages/liferay-npm-scripts/test/jsp/Lexer.js
@@ -18,6 +18,7 @@ describe('Lexer()', () => {
 		// The idea is to bail out of infinite loops that would be produced by
 		// use of combinators like repeat() combined with a matcher that matches
 		// a zero-width string.
+
 		const lexer = new Lexer((api) => {
 			const {consume, match, oneOf, token} = api;
 
@@ -81,6 +82,7 @@ describe('Lexer()', () => {
 		});
 
 		// Peek ahead using `next` before the iterator gets that far.
+
 		tokens.push(tokens[0].next);
 
 		expect(tokens[1]).toEqual({
@@ -90,6 +92,7 @@ describe('Lexer()', () => {
 		});
 
 		// Tokens are doubly linked:
+
 		expect(tokens[1].previous).toBe(tokens[0]);
 		expect(tokens[0].next).toBe(tokens[1]);
 
@@ -105,10 +108,12 @@ describe('Lexer()', () => {
 		expect(tokens[1].next).toBe(tokens[2]);
 
 		// Note that that was just lookahead; iterator did not advance:
+
 		expect(iterator.next().value).toBe(tokens[1]);
 		expect(iterator.next().value).toBe(tokens[2]);
 
 		// Now scan ahead with iterator, then verify `next` links.
+
 		tokens.push(iterator.next().value);
 		tokens.push(iterator.next().value);
 		tokens.push(iterator.next().value);
@@ -134,12 +139,14 @@ describe('Lexer()', () => {
 		expect(iterator.next().done).toBe(true);
 
 		// Note: can ask for "next" links in any order.
+
 		expect(tokens[2].next).toBe(tokens[3]);
 		expect(tokens[4].next).toBe(tokens[5]);
 		expect(tokens[3].next).toBe(tokens[4]);
 		expect(tokens[5].next).toBe(undefined);
 
 		// And same for "previous" links.
+
 		expect(tokens[3].previous).toBe(tokens[2]);
 		expect(tokens[5].previous).toBe(tokens[4]);
 		expect(tokens[4].previous).toBe(tokens[3]);
@@ -205,6 +212,7 @@ describe('Lexer()', () => {
 			// Note how ORIGINAL is used to match COPY, but after SEPARATOR we
 			// match ORGINAL alone and see that it wasn't mutated (ie. it didn't
 			// trigger COPY's onMatch() action as well).
+
 			expect(calls).toEqual([
 				'ORIGINAL',
 				'COPY',
@@ -550,6 +558,7 @@ describe('Lexer()', () => {
 					// would have us infinitely matching zero-width strings;
 					// in contrast, "never" forces "oneOf" to try the next
 					// alternative(s).
+
 					const text = consume(
 						repeat(
 							oneOf(
@@ -565,6 +574,7 @@ describe('Lexer()', () => {
 			});
 
 			// When active is "false", we can only match a/b.
+
 			expect([...lexer.lex('ababaabb')]).toEqual([
 				{
 					contents: 'ababaabb',
@@ -576,6 +586,7 @@ describe('Lexer()', () => {
 			expect(() => [...lexer.lex('axb')]).toThrow(/Failed to match/);
 
 			// When active is "true", we can match anything.
+
 			active = true;
 
 			expect([...lexer.lex('ababzzzaabb')]).toEqual([
@@ -630,6 +641,7 @@ describe('Lexer()', () => {
 					// "undo-tree" in action. We pursue a branch that
 					// will fail and get rolled back before we pursue
 					// another that succeeds.
+
 					const text = consume(
 						sequence(
 							match('a').onMatch((match, meta) => {
@@ -644,6 +656,7 @@ describe('Lexer()', () => {
 								sequence(
 									match('c').onMatch((match, meta) => {
 										// Doing something destructive.
+
 										meta.delete('a');
 										record(match);
 									}),
@@ -927,6 +940,7 @@ describe('Lexer()', () => {
 
 		it('matches 0 or more times up-to-and-not-including a predicate', () => {
 			// 0-times.
+
 			expect([...lexer.lex('x')]).toEqual([
 				{
 					contents: 'x',
@@ -936,6 +950,7 @@ describe('Lexer()', () => {
 			]);
 
 			// n-times.
+
 			expect([...lexer.lex('aaax')]).toEqual([
 				{
 					contents: 'aaa',

--- a/packages/liferay-npm-scripts/test/jsp/ReversibleMap.js
+++ b/packages/liferay-npm-scripts/test/jsp/ReversibleMap.js
@@ -83,6 +83,7 @@ describe('ReversibleMap()', () => {
 			]);
 
 			// Goes as far back as previous checkpoint (the 2nd) and removes it.
+
 			map.rollback();
 
 			expect(map.undo.length).toBe(3);
@@ -96,6 +97,7 @@ describe('ReversibleMap()', () => {
 			]);
 
 			// Goes to previous checkpoint (the 1st) and removes it.
+
 			map.rollback();
 
 			expect(map.undo.length).toBe(1);
@@ -108,6 +110,7 @@ describe('ReversibleMap()', () => {
 			]);
 
 			// Completely flushes the queue (no more checkpoints).
+
 			map.rollback();
 
 			expect(map.undo.length).toBe(0);
@@ -197,6 +200,7 @@ describe('ReversibleMap()', () => {
 			map.rollback();
 
 			// Doesn't rollback mutation inside `deep` value.
+
 			expect([...map.entries()]).toEqual([
 				['a', 1],
 				['b', 2],

--- a/packages/liferay-npm-scripts/test/jsp/dedent.js
+++ b/packages/liferay-npm-scripts/test/jsp/dedent.js
@@ -21,6 +21,7 @@ describe('dedent()', () => {
 	it('handles mixed tabs and spaces', () => {
 		// Mixed tabs and spaces are common, for example, in source with
 		// multiline comments.
+
 		const [dedented] = dedent(`
 			/**
 			 * This is a comment.
@@ -31,7 +32,9 @@ describe('dedent()', () => {
 		`);
 
 		expect(dedented).toBe(
+
 			// prettier-ignore
+
 			'/**\n' +
 			' * This is a comment.\n' +
 			' */\n' +
@@ -52,7 +55,9 @@ describe('dedent()', () => {
 		);
 
 		expect(dedented).toBe(
+
 			// prettier-ignore
+
 			'function fn() {\n' +
 			'\treturn;\n' +
 			'} // tab, 8 spaces, tab, a brace'
@@ -84,8 +89,11 @@ describe('dedent()', () => {
 	it('handles partial "for" control structures', () => {
 		// It's common in JSP to have an incomplete control structure
 		// that starts in one scriptlet and ends in another.
+
 		const [dedented] = dedent(
+
 			// prettier-ignore
+
 			'<%\n' +
 			'// This one was getting mangled.\n' +
 			'for (AssetRendererFactory<?> curRendererFactory : classTypesAssetRendererFactories) {\n' +
@@ -94,7 +102,9 @@ describe('dedent()', () => {
 		);
 
 		expect(dedented).toBe(
+
 			// prettier-ignore
+
 			'<%\n' +
 			'// This one was getting mangled.\n' +
 			'for (AssetRendererFactory<?> curRendererFactory : classTypesAssetRendererFactories) {\n' +

--- a/packages/liferay-npm-scripts/test/jsp/dedent.js
+++ b/packages/liferay-npm-scripts/test/jsp/dedent.js
@@ -31,10 +31,9 @@ describe('dedent()', () => {
 			}
 		`);
 
+		// prettier-ignore
+
 		expect(dedented).toBe(
-
-			// prettier-ignore
-
 			'/**\n' +
 			' * This is a comment.\n' +
 			' */\n' +
@@ -54,10 +53,9 @@ describe('dedent()', () => {
 			8
 		);
 
+		// prettier-ignore
+
 		expect(dedented).toBe(
-
-			// prettier-ignore
-
 			'function fn() {\n' +
 			'\treturn;\n' +
 			'} // tab, 8 spaces, tab, a brace'
@@ -90,10 +88,9 @@ describe('dedent()', () => {
 		// It's common in JSP to have an incomplete control structure
 		// that starts in one scriptlet and ends in another.
 
+		// prettier-ignore
+
 		const [dedented] = dedent(
-
-			// prettier-ignore
-
 			'<%\n' +
 			'// This one was getting mangled.\n' +
 			'for (AssetRendererFactory<?> curRendererFactory : classTypesAssetRendererFactories) {\n' +
@@ -101,10 +98,9 @@ describe('dedent()', () => {
 			'%>'
 		);
 
+		// prettier-ignore
+
 		expect(dedented).toBe(
-
-			// prettier-ignore
-
 			'<%\n' +
 			'// This one was getting mangled.\n' +
 			'for (AssetRendererFactory<?> curRendererFactory : classTypesAssetRendererFactories) {\n' +

--- a/packages/liferay-npm-scripts/test/jsp/extractJS.js
+++ b/packages/liferay-npm-scripts/test/jsp/extractJS.js
@@ -80,6 +80,7 @@ describe('extractJS()', () => {
 
 	it('extracts one-line "<script>" tags', () => {
 		// Testing an edge-case in the `range` arithemetic.
+
 		const blocks = extractJS("<script>alert('Hello');</script>");
 
 		expect(blocks).toEqual([
@@ -115,6 +116,7 @@ describe('extractJS()', () => {
 	it('does not extract non-JavaScript scripts', () => {
 		// (Abbreviated) example taken from:
 		// https://github.com/liferay/liferay-portal/blob/44c1be7f1725ca00e9/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/event_recorder.jspf
+
 		let blocks = extractJS(`
 			<script id="<portlet:namespace />eventRecorderHeaderTpl" type="text/x-alloy-template">
 				alert('Hello');
@@ -124,6 +126,7 @@ describe('extractJS()', () => {
 		expect(blocks).toEqual([]);
 
 		// Counter-example:
+
 		blocks = extractJS(`
 			<script id="<portlet:namespace />eventRecorderHeaderTpl" type="text/javascript">
 				alert('Hello');
@@ -153,6 +156,7 @@ describe('extractJS()', () => {
 
 	it('extracts blocks from test fixture', async () => {
 		// This is the test fixture from the check-source-formatting package.
+
 		const source = await getFixture('jsp/page.jsp');
 
 		const blocks = extractJS(source);

--- a/packages/liferay-npm-scripts/test/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/formatJSP.js
@@ -12,6 +12,7 @@ describe('formatJSP()', () => {
 	it('deals with interleaved JS control structures and JSP tags', () => {
 		// eg. an `if()` that is conditionally added augmented with an `else()`
 		// based on a tag.
+
 		const source = `
 			<p>Hi!</p>
 			<script>
@@ -29,6 +30,7 @@ describe('formatJSP()', () => {
 		// Note that Prettier keeps the `else` in the right place
 		// due to special casing explained in the notes in the
 		// `tagReplacements()` implementation.
+
 		expect(formatJSP(source)).toBe(`
 			<p>Hi!</p>
 			<script>
@@ -88,6 +90,7 @@ describe('formatJSP()', () => {
 
 	it('correctly handles internal indentation inside control structures', () => {
 		// This is a reduced example of what's in the source.jsp fixture.
+
 		const source = `
 			<aui:script require="metal-dom/src/dom as dom">
 				var sourcePanel = document.querySelector('.source-container');
@@ -165,6 +168,7 @@ describe('formatJSP()', () => {
 
 	it('respects indentation within a nested control structures', () => {
 		// This is a reduced example of what's in the source.jsp fixture.
+
 		const source = `
 			<aui:script>
 
@@ -245,6 +249,7 @@ describe('formatJSP()', () => {
 	it('handles an edge case (#258)', () => {
 		// Reduced example of what's in
 		// modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+
 		const source = `
 			<aui:script>
 
@@ -339,6 +344,7 @@ describe('formatJSP()', () => {
 			// trailing commas after the "redirect" and "refresh" properties,
 			// Prettier will report a syntax error. We can't add commas to
 			// either because that would break IE 11.
+
 			const source = `
 				<aui:script>
 					Liferay.fire(

--- a/packages/liferay-npm-scripts/test/jsp/lex.js
+++ b/packages/liferay-npm-scripts/test/jsp/lex.js
@@ -116,6 +116,7 @@ describe('lex()', () => {
 		]);
 
 		// Note it agnostic about attribute order.
+
 		expect(lex('<%@ taglib uri="bar" prefix="foo" %>').tokens).toEqual([
 			{
 				contents: '<%@ taglib uri="bar" prefix="foo" %>',
@@ -125,6 +126,7 @@ describe('lex()', () => {
 		]);
 
 		// But it requires all attributes to be present.
+
 		expect(() => lex('<%@ taglib prefix="foo">').tokens).toThrow(
 			'Failed to match "taglib" allOf:(SPACE "prefix" EQ ATTRIBUTE_VALUE, SPACE "tagdir" EQ ATTRIBUTE_VALUE | SPACE "uri" EQ ATTRIBUTE_VALUE) at: "taglib prefix=\\"foo\\">"'
 		);
@@ -172,6 +174,7 @@ describe('lex()', () => {
 		// TODO: provide more challenging examples here.
 
 		// Immediate evaluation.
+
 		expect(lex('${Foo.Bar}').tokens).toEqual([
 			{
 				contents: '${Foo.Bar}',
@@ -181,6 +184,7 @@ describe('lex()', () => {
 		]);
 
 		// Deferred evaluation.
+
 		expect(lex('#{Foo.Bar}').tokens).toEqual([
 			{
 				contents: '#{Foo.Bar}',
@@ -277,6 +281,7 @@ describe('lex()', () => {
 
 	it('lexes the <portlet:namespace /> action', () => {
 		// With whitespace.
+
 		expect(lex('<portlet:namespace />').tokens).toEqual([
 			{
 				contents: '<portlet:namespace />',
@@ -286,6 +291,7 @@ describe('lex()', () => {
 		]);
 
 		// Without whitespace.
+
 		expect(lex('<portlet:namespace/>').tokens).toEqual([
 			{
 				contents: '<portlet:namespace/>',
@@ -297,6 +303,7 @@ describe('lex()', () => {
 
 	it('lexes a custom action', () => {
 		// Self-closing.
+
 		expect(lex('<custom:tag with="stuff" />').tokens).toEqual([
 			{
 				contents: '<custom:tag with="stuff" />',
@@ -306,6 +313,7 @@ describe('lex()', () => {
 		]);
 
 		// Same without whitspace at end.
+
 		expect(lex('<custom:tag with="stuff"/>').tokens).toEqual([
 			{
 				contents: '<custom:tag with="stuff"/>',
@@ -315,6 +323,7 @@ describe('lex()', () => {
 		]);
 
 		// A self-closing tag with an attribute that contains a JSP expression.
+
 		expect(lex('<custom:tag with="<%= SomeVariable %>" />').tokens).toEqual(
 			[
 				{
@@ -326,6 +335,7 @@ describe('lex()', () => {
 		);
 
 		// An opening tag with an attribuhte that contains a JSP expression.
+
 		expect(lex('<c:if test="<%= enableRSS %>">').tokens).toEqual([
 			{
 				contents: '<c:if test="<%= enableRSS %>">',
@@ -335,6 +345,7 @@ describe('lex()', () => {
 		]);
 
 		// Empty body.
+
 		expect(lex('<custom:tag with="stuff"></custom:tag>').tokens).toEqual([
 			{
 				contents: '<custom:tag with="stuff"></custom:tag>',
@@ -344,6 +355,7 @@ describe('lex()', () => {
 		]);
 
 		// Tag with duplicate attributes.
+
 		expect(
 			() => lex('<custom:tag foo="a" bar="b" foo="c" />').tokens
 		).toThrow(
@@ -355,8 +367,10 @@ describe('lex()', () => {
 	// Disabled because I want to be able to lex document subsets, in
 	// which case, we might not have enough contextual information to determine
 	// tag validity.
+
 	it.skip('rejects invalid tags', () => {
 		// Invalid tag.
+
 		expect(() => lex('<custom:tag with="stuff"></bad:tag>').tokens).toThrow(
 			/Failed to match .+ at: "><\/bad:tag>"/
 		);
@@ -398,6 +412,7 @@ describe('lex()', () => {
 		// Note that the spec starts a new token whenever it sees a delimiting
 		// sequence like "<" or "${" etc, and "<" always ends up being a token
 		// of its own.
+
 		expect(lex('one < two').tokens).toEqual([
 			{
 				contents: 'one ',
@@ -419,6 +434,7 @@ describe('lex()', () => {
 
 	it('lexes a complex attributes', () => {
 		// A non-JSP tag.
+
 		expect(
 			lex(`
 				<div class="browse-image-controls <%= (fileEntryId != 0) ? "hide" : StringPool.BLANK %>">
@@ -456,6 +472,7 @@ describe('lex()', () => {
 		// page.jsp fixture. Quotes in JSP-tags must be escaped as
 		// per Section 1.6 of the JSP 2.3 spec, "Quoting and Escape
 		// Conventions".
+
 		expect(
 			() =>
 				lex(`
@@ -464,6 +481,7 @@ describe('lex()', () => {
 		).toThrow(/Failed to match .+ at: "scriptletblock/);
 
 		// Escaping the quotes leads to a successful tokenization.
+
 		expect(
 			lex(`
 				<aui:nav cssClass="\${currentTab == tab ? 'active' : ''} foo abc <%= \\"scriptletblock\\" %>"></aui:nav>

--- a/packages/liferay-npm-scripts/test/jsp/lintJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/lintJSP.js
@@ -37,6 +37,7 @@ describe('lintJSP()', () => {
 		const result = lintJSP(source, onReport);
 
 		// Note: did not autofix because we didn't pass `{fix: true}`.
+
 		expect(result).toBe(dedent(3)`
 			<script>
 				var bool = !!!other;
@@ -72,6 +73,7 @@ describe('lintJSP()', () => {
 		const result = lintJSP(source, onReport);
 
 		// No autofix.
+
 		expect(result).toBe(dedent(3)`
 			<script>
 				debugger;
@@ -106,6 +108,7 @@ describe('lintJSP()', () => {
 		const result = lintJSP(source, onReport);
 
 		// No autofix.
+
 		expect(result).toBe(dedent(3)`
 			<script>
 				const x = 1;
@@ -141,6 +144,7 @@ describe('lintJSP()', () => {
 		const result = lintJSP(source, onReport);
 
 		// No autofix.
+
 		expect(result).toBe(dedent(3)`
 			<script>
 				var x = () => 1;
@@ -168,6 +172,7 @@ describe('lintJSP()', () => {
 
 	it('deals with a mixture of fixable and not-fixable errors', () => {
 		// eg: 1 autofix and 1 not-autofix
+
 		const source = dedent(3)`
 			<script>
 				var bool = !!!other;
@@ -178,6 +183,7 @@ describe('lintJSP()', () => {
 		const result = lintJSP(source, onReport);
 
 		// No autofix.
+
 		expect(result).toBe(dedent(3)`
 			<script>
 				var bool = !!!other;
@@ -242,6 +248,7 @@ describe('lintJSP()', () => {
 			`);
 
 			// Note: no report because there are no unfixed problems left.
+
 			expect(onReport).not.toBeCalled();
 		});
 
@@ -307,6 +314,7 @@ describe('lintJSP()', () => {
 
 		it('deals with a mixture of fixable and not-fixable errors', () => {
 			// eg: 1 autofix and 1 not-autofix
+
 			const source = dedent(3)`
 				<script>
 					var bool = !!!other;
@@ -346,8 +354,10 @@ describe('lintJSP()', () => {
 		// Nothing much to meaningfully test here because we almost don't use
 		// "warn"  at all in liferay-portal; so we just show that it basically
 		// works the same as above.
+
 		it('works', () => {
 			// eg: 1 autofix and 1 not-autofix
+
 			const source = dedent(3)`
 				<script>
 					var bool = !!!other;

--- a/packages/liferay-npm-scripts/test/jsp/restoreTags.js
+++ b/packages/liferay-npm-scripts/test/jsp/restoreTags.js
@@ -28,6 +28,7 @@ describe('restoreTags()', () => {
 		const stripped = stripIndents(substituted);
 
 		// Some fake formatting that moves and changes text.
+
 		const formattedText =
 			'\n\t\t\t// Prefix' + stripped.replace('children', 'CHILDREN');
 
@@ -54,6 +55,7 @@ describe('restoreTags()', () => {
 	it('restores blocks indentation to counteract Prettier', () => {
 		// Original `alert()` was indented, but Prettier will dedent it, and we
 		// do a preemptive `stripIndents()` to match that.
+
 		const text = stripIndents(`
 			/*ʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃ*/
 				alert('done');
@@ -88,6 +90,7 @@ describe('restoreTags()', () => {
 		const [substituted, tags] = substituteTags(source);
 
 		// Sanity-check that `substituteTags()` does what we think it does.
+
 		expect(substituted).toBe(`
 			if (condition) {
 						/*
@@ -97,6 +100,7 @@ describe('restoreTags()', () => {
 		`);
 
 		// Now imagine Prettier "fixes" the indent like this:
+
 		const formattedText = `
 			if (condition) {
 				/*
@@ -123,6 +127,7 @@ describe('restoreTags()', () => {
 	it('correctly handles internal indentation when nested', () => {
 		// This is a reduced example of what's in the page_iterator.jsp
 		// fixture.
+
 		const source = `
 			<c:if test="<%= pages.size() > 1 %>">
 
@@ -138,6 +143,7 @@ describe('restoreTags()', () => {
 		const [substituted, tags] = substituteTags(source);
 
 		// Sanity-check that `substituteTags()` does what we think it does.
+
 		expect(substituted).toBe(`
 			//ʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃ
 
@@ -151,6 +157,7 @@ describe('restoreTags()', () => {
 		`);
 
 		// Now imagine Prettier "fixes" the indents like this:
+
 		const formattedText = `
 			//ʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃʃ
 
@@ -183,6 +190,7 @@ describe('restoreTags()', () => {
 
 	it('correctly handles internal indentation inside control structures', () => {
 		// This is a reduced example of what's in the source.jsp fixture.
+
 		const source = `
 			var sourcePanel = document.querySelector('.source-container');
 
@@ -218,6 +226,7 @@ describe('restoreTags()', () => {
 		const [substituted, tags] = substituteTags(source);
 
 		// Sanity-check that `substituteTags()` does what we think it does.
+
 		expect(substituted).toBe(`
 			var sourcePanel = document.querySelector('.source-container');
 
@@ -251,6 +260,7 @@ describe('restoreTags()', () => {
 		`);
 
 		// Now imagine Prettier "fixes" the indents like this:
+
 		const formattedText = `
 			var sourcePanel = document.querySelector('.source-container');
 
@@ -286,6 +296,7 @@ describe('restoreTags()', () => {
 		const result = restoreTags(formattedText, tags);
 
 		// Note the line after both `for` keywords is still indented:
+
 		const expected = `
 			var sourcePanel = document.querySelector('.source-container');
 

--- a/packages/liferay-npm-scripts/test/jsp/substituteTags.js
+++ b/packages/liferay-npm-scripts/test/jsp/substituteTags.js
@@ -240,6 +240,7 @@ describe('substituteTags()', () => {
 	it('turns JSP tags into multiline comments if followed on same line ', () => {
 		// Possibly rare(?) example from liferay-portal, and can be seen in our
 		// fixtures too:
+
 		let [transformed, tags] = substituteTags(dedent(3)`
 			<c:if test="<%= a %>">*</c:if>
 		`);
@@ -252,6 +253,7 @@ describe('substituteTags()', () => {
 
 		// We shouldn't have anything like this in liferay-portal, but
 		// just in case...
+
 		[transformed, tags] = substituteTags(dedent(3)`
 			<c:if test="<%= a %>"><c:if test="<%= b %>">
 				alert('hi');

--- a/packages/liferay-npm-scripts/test/jsp/tagReplacements.js
+++ b/packages/liferay-npm-scripts/test/jsp/tagReplacements.js
@@ -27,6 +27,7 @@ describe('getCloseTagReplacement()', () => {
 	it('degrades gracefully if passed an impossibly short tag', () => {
 		// Not a valid JSP tag anyway, but no matter what, we always produce a
 		// reversible replacement.
+
 		expect(getCloseTagReplacement('</a>')).toBe('/*ʅ*/');
 	});
 });
@@ -56,6 +57,7 @@ describe('getOpenTagReplacement()', () => {
 	it('degrades gracefully if passed an impossibly short tag', () => {
 		// Not a valid JSP tag anyway, but no matter what, we always produce a
 		// reversible replacement.
+
 		expect(getOpenTagReplacement('<ab>')).toBe('/*ʃ*/');
 	});
 });
@@ -85,6 +87,7 @@ describe('getSelfClosingTagReplacement()', () => {
 	it('degrades gracefully if passed an impossibly short tag', () => {
 		// Not a valid JSP tag anyway, but no matter what, we always produce a
 		// reversible replacement.
+
 		expect(getSelfClosingTagReplacement('<a/>')).toBe('/*╳*/');
 	});
 });

--- a/packages/liferay-npm-scripts/test/jsp/toFiller.js
+++ b/packages/liferay-npm-scripts/test/jsp/toFiller.js
@@ -55,6 +55,7 @@ describe('toFiller()', () => {
 	it('accepts even "invalid" non-zero-width strings', () => {
 		// Make a "best effort" to create a same-sized replacement even when we
 		// can't exactly.
+
 		expect(toFiller('a')).toBe('/*╳*/');
 		expect(toFiller('ab')).toBe('/*╳*/');
 		expect(toFiller('abc')).toBe('/*╳*/');
@@ -69,12 +70,15 @@ describe('toFiller()', () => {
 
 		it('does not match ordinary comments', () => {
 			// Empty comment.
+
 			expect(toFiller.isFiller().test('/**/')).toBe(false);
 
 			// Whitespace-only comment.
+
 			expect(toFiller.isFiller().test('/* */')).toBe(false);
 
 			// Comment with text.
+
 			expect(toFiller.isFiller().test('/* foo */')).toBe(false);
 		});
 

--- a/packages/liferay-npm-scripts/test/prettier/index.js
+++ b/packages/liferay-npm-scripts/test/prettier/index.js
@@ -23,6 +23,7 @@ function code(strings, ...interpolations) {
 	}
 
 	// Remove leading and trailing blank lines.
+
 	const trimmed = strings[0].replace(/^\n/, '').trimEnd();
 
 	let minimumIndent = null;
@@ -208,6 +209,7 @@ describe('prettier/index.js', () => {
 				// Prettier does some "crazy" things with comments (moving them
 				// in and out of blocks) but this is one case where it leaves
 				// them alone.
+
 				expect(
 					format(code`
 						if (test) {
@@ -254,6 +256,7 @@ describe('prettier/index.js', () => {
 				//
 				// We were incorrectly stripping the comment before the
 				// alternate (ie. the first one).
+
 				expect(
 					format(code`
 						if (test) {
@@ -281,6 +284,7 @@ describe('prettier/index.js', () => {
 				// Prettier will first move the "else" here back onto
 				// the preceding line, then our wrapper moves it back down
 				// again.
+
 				expect(
 					format(code`
 						if (test) {
@@ -320,6 +324,7 @@ describe('prettier/index.js', () => {
 			});
 
 			// Disabled until we switch our ESLint ecmaVersion to '2019'.
+
 			it.skip('breaks before "catch" (without optional catch binding)', () => {
 				expect(
 					format(code`
@@ -385,6 +390,7 @@ describe('prettier/index.js', () => {
 			it('copes with comments near "try"/"catch" constructs', () => {
 				// Note: the movement of "comment 2" below is Prettier
 				// craziness and not the fault of our post-processor.
+
 				expect(
 					format(code`
 						try {

--- a/packages/liferay-npm-scripts/test/scripts/lint.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint.js
@@ -33,6 +33,7 @@ describe('scripts/lint.js', () => {
 
 			// Use [] here to avoid unwanted hoisting by
 			// babel-plugin-jest-hoist.
+
 			jest['mock']('../../src/utils/getMergedConfig', () => {
 				return () => {
 					return globs;
@@ -93,6 +94,7 @@ describe('scripts/lint.js', () => {
 				]);
 
 				// No errors or warnings, so no results.
+
 				expect(log).toBeCalledWith('');
 			});
 		});
@@ -133,6 +135,7 @@ describe('scripts/lint.js', () => {
 
 				// `isTTY` varies in different CI environments, so we use a
 				// regex here to match in a color-agnostic way.
+
 				expect(logged).toMatch(
 					/20:10 {2}.*error.* {2}Avoid explosions. {2}no-boom/
 				);

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/single-imports.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/single-imports.js
@@ -53,6 +53,7 @@ describe('liferay/single-imports', () => {
 	it('autofixes imports in column 0', async () => {
 		// Seeing as indented code like that in the test above isn't going to be
 		// typical in our codebase.
+
 		await expect(plugin).toLintStyles({
 			code:
 				`@import 'a', "b", url(c.css), url('d.css'), url("e.css");\n` +

--- a/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/sort-imports.js
+++ b/packages/liferay-npm-scripts/test/scripts/lint/stylelint/plugins/sort-imports.js
@@ -20,6 +20,7 @@ describe('liferay/sort-imports', () => {
 
 	it('interprets blank lines as group separators', async () => {
 		// We don't care about order between groups, only within groups.
+
 		await expect(plugin).toLintStyles({
 			code: `
 				@import 'stuff';

--- a/packages/liferay-npm-scripts/test/scripts/theme.js
+++ b/packages/liferay-npm-scripts/test/scripts/theme.js
@@ -11,6 +11,7 @@ const spawnSync = require('../../src/utils/spawnSync');
 jest.mock('../../src/utils/spawnSync');
 
 // Use path.normalize to make tests behave uniformly on Linux and Windows.
+
 const {normalize} = path;
 const join = (...segments) => normalize(path.join(...segments));
 const resolve = (...segments) => normalize(path.resolve(...segments));

--- a/packages/liferay-npm-scripts/test/utils/deepMerge.js
+++ b/packages/liferay-npm-scripts/test/utils/deepMerge.js
@@ -8,6 +8,7 @@ const deepMerge = require('../../src/utils/deepMerge');
 describe('deepMerge()', () => {
 	it('uses the "DEFAULT" mode by default', () => {
 		// DEFAULT mode concatenates arrays.
+
 		expect(deepMerge([[1], [2]])).toEqual([1, 2]);
 	});
 
@@ -194,6 +195,7 @@ describe('deepMerge()', () => {
 		it('merges presets correctly as well', () => {
 			// Just a smoke test here, because it is powered by the exact same
 			// code that's exercised in all the "plugins" tests above.
+
 			expect(
 				deepMerge(
 					[
@@ -289,11 +291,13 @@ describe('deepMerge()', () => {
 
 		it("doesn't break when a stale .babelrc.js file is left on disk", () => {
 			// This is the original project-local .babelrc.js config.
+
 			const project = {
 				presets: ['@babel/preset-react'],
 			};
 
 			// This is the config provided by liferay-npm-scripts.
+
 			const defaults = {
 				overrides: [
 					{
@@ -319,6 +323,7 @@ describe('deepMerge()', () => {
 
 			// This should be the result of merging "defaults" and "project"; imagine that
 			// it could be left on disk if the build gets interrupted.
+
 			const stale = {
 				overrides: [
 					{
@@ -400,6 +405,7 @@ describe('deepMerge()', () => {
 			// "@babel/foo", but in the docs it recommends the long-hand
 			// form. This is unlike plugins, where it again understands
 			// both, but recommends the short-hand form.
+
 			expect(() => {
 				deepMerge(
 					[{presets: []}, {presets: ['@babel/foo']}],

--- a/packages/liferay-npm-scripts/test/utils/expandGlobs.js
+++ b/packages/liferay-npm-scripts/test/utils/expandGlobs.js
@@ -79,6 +79,7 @@ describe('expandGlobs()', () => {
 		// Isolate ourselves from platform-specific file-system traversal
 		// ordering issues (for example, on Windows, files starting with "_"
 		// will be visited after other files).
+
 		return expandGlobs(...arguments).sort();
 	}
 

--- a/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
+++ b/packages/liferay-npm-scripts/test/utils/filterChangedFiles.js
@@ -44,6 +44,7 @@ describe('filterChangedFiles()', () => {
 		//      * b (touches nothing)
 		//      * a (root commit)
 		//
+
 		repo = join(
 			TMP_DIR,
 			`liferay-npm-scripts-${randomBytes(16).toString('hex')}`
@@ -168,6 +169,7 @@ describe('filterChangedFiles()', () => {
 
 		it('returns only changed files, unless it detects a liferay-npm-scripts update', () => {
 			// Top-level.
+
 			let files = getFiles();
 
 			git('checkout', '--detach', 'c');
@@ -186,6 +188,7 @@ describe('filterChangedFiles()', () => {
 			]);
 
 			// Private.
+
 			process.chdir('private');
 
 			files = getFiles();

--- a/packages/liferay-npm-scripts/test/utils/findRoot.js
+++ b/packages/liferay-npm-scripts/test/utils/findRoot.js
@@ -49,6 +49,7 @@ describe('findRoot()', () => {
 
 	it('returns undefined when there is no yarn.lock', () => {
 		// Will pass as long as nobody does a `yarn install` in $TMPDIR.
+
 		process.chdir(os.tmpdir());
 		expect(findRoot()).toBe(undefined);
 	});
@@ -56,6 +57,7 @@ describe('findRoot()', () => {
 	it('returns undefined when in the wrong repository', () => {
 		// For example, in this project, we have a yarn.lock, but this is not
 		// liferay-portal.
+
 		expect(findRoot()).toBe(undefined);
 	});
 });

--- a/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
+++ b/packages/liferay-npm-scripts/test/utils/getMergedConfig.js
@@ -35,6 +35,7 @@ describe('getMergedConfig()', () => {
 					// Example use case from dynamic-data-mapping-form-builder:
 					// blacklist the "react" preset in order to use the
 					// "incremental-dom" plug-in.
+
 					return jest.fn(() => ({
 						liferay: {
 							excludes: {
@@ -44,6 +45,7 @@ describe('getMergedConfig()', () => {
 
 						// This bit isn't real config, but it shows that
 						// we can filter down below the top level:
+
 						overrides: [
 							{
 								presets: ['fancy', '@babel/preset-react'],

--- a/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js
+++ b/packages/liferay-npm-scripts/test/utils/getRegExpForGlob.js
@@ -158,8 +158,10 @@ describe('getRegExpForGlob()', () => {
 	});
 
 	// prettier-ignore
+
 	it('handles real glob patterns from liferay-portal', () => {
 		// These taken from liferay-portal as of ced3d6d93c8721ae09ea2c2c88.
+
 		expect('apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js')
 			.toMatchGlob('**/*.js');
 		expect('apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js')

--- a/packages/liferay-npm-scripts/test/utils/run.js
+++ b/packages/liferay-npm-scripts/test/utils/run.js
@@ -13,6 +13,7 @@ describe('run()', () => {
 	it('reports the exit status of failed commands', () => {
 		// NOTE: we want the error message format to be stable, because
 		// `filterChangedFiles()` depends on it.
+
 		expect(() => run('false')).toThrow(
 			'run(): command `false` exited with status 1.'
 		);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5532,10 +5532,10 @@ escodegen@^1.11.0, escodegen@^1.11.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-liferay@20.0.1:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-20.0.1.tgz#966b1c538d9af8a63685efadd8d9a81c1d7321f1"
-  integrity sha512-9SSavMhQhgaN4NUzEkoD4GGMdAeIBW+YonnRhIqosfa/rwed1twKWeR55s8yR0p2MOUsORl87bhb9UkD2UVKBg==
+eslint-config-liferay@21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-liferay/-/eslint-config-liferay-21.0.0.tgz#65749b5b2b58ffd1dd2395ad320720fd4b5909dc"
+  integrity sha512-FMXe/ajc2OWW5U+4nU2sWhYzDWJ/bleRXYzhJfXoJIU6MAutx8W/SLw4nnux1JxmhTXtNiZhPaKTAZivbo6sfw==
   dependencies:
     eslint-config-prettier "^6.5.0"
     eslint-plugin-no-for-of-loops "^1.0.0"


### PR DESCRIPTION
Breaking because there are some new lint rules activated in this release ([release notes](https://github.com/liferay/eslint-config-liferay/releases/tag/v21.0.0)).

-   feat!: require blank lines before and after line comments ([\#170](https://github.com/liferay/eslint-config-liferay/pull/170))
-   feat!: enforce standard formatting for deprecation annotations ([\#175](https://github.com/liferay/eslint-config-liferay/pull/175))
