### PR TITLE
feat(scripts)!: make "blank line before comments" follow Java convention

### DIFF
--- a/packages/liferay-npm-scripts/src/jsp/getPaddedReplacement.js
+++ b/packages/liferay-npm-scripts/src/jsp/getPaddedReplacement.js
@@ -47,5 +47,7 @@ function getPaddedReplacement(match, template) {
 }
 
 getPaddedReplacement.IDENTIFIER = IDENTIFIER;
+getPaddedReplacement.ID_END = ID_END;
+getPaddedReplacement.ID_START = ID_START;
 
 module.exports = getPaddedReplacement;

--- a/packages/liferay-npm-scripts/src/jsp/tagReplacements.js
+++ b/packages/liferay-npm-scripts/src/jsp/tagReplacements.js
@@ -141,6 +141,8 @@ function getSelfClosingTagReplacement(tag) {
 }
 
 module.exports = {
+	BLOCK_CLOSE,
+	BLOCK_OPEN,
 	CLOSE_TAG,
 	OPEN_TAG,
 

--- a/packages/liferay-npm-scripts/src/jsp/toFiller.js
+++ b/packages/liferay-npm-scripts/src/jsp/toFiller.js
@@ -81,6 +81,8 @@ function isFiller(char = FILLER_CHAR) {
 	return new RegExp(`/\\*(?:\\s*[${char}${SPACE_CHAR}${TAB_CHAR}]\\s*)+\\*/`);
 }
 
+toFiller.FILLER_CHAR = FILLER_CHAR;
+toFiller.SPACE_CHAR = SPACE_CHAR;
 toFiller.TAB_CHAR = TAB_CHAR;
 toFiller.isFiller = isFiller;
 

--- a/packages/liferay-npm-scripts/src/prettier/index.js
+++ b/packages/liferay-npm-scripts/src/prettier/index.js
@@ -22,6 +22,10 @@ const path = require('path');
 const prettier = require('prettier');
 
 const eslintConfig = require('../config/eslint.config');
+const {ID_END, ID_START} = require('../jsp/getPaddedReplacement');
+const {SCRIPTLET_CONTENT} = require('../jsp/substituteTags');
+const {BLOCK_CLOSE, BLOCK_OPEN} = require('../jsp/tagReplacements');
+const {FILLER_CHAR, SPACE_CHAR, TAB_CHAR} = require('../jsp/toFiller');
 
 const EXTENSIONS = new Set(['.js', '.jsp', '.jspf']);
 
@@ -52,6 +56,36 @@ const cli = new CLIEngine({
 		sourceType: 'module',
 	},
 	rules: {
+		'lines-around-comment': [
+			'error',
+			{
+				afterBlockComment: false,
+				afterLineComment: true,
+				allowArrayEnd: false,
+				allowArrayStart: false,
+				allowBlockEnd: false,
+				allowBlockStart: false,
+				allowClassStart: false,
+				allowObjectEnd: false,
+				allowObjectStart: false,
+				beforeBlockComment: true,
+				beforeLineComment: true,
+
+				// Don't mess with placeholder comments inserted by JSP
+				// formatter.
+
+				ignorePattern: [
+					BLOCK_CLOSE,
+					BLOCK_OPEN,
+					FILLER_CHAR,
+					ID_END,
+					ID_START,
+					SCRIPTLET_CONTENT,
+					SPACE_CHAR,
+					TAB_CHAR,
+				].join('|'),
+			},
+		],
 		'newline-before-block-statements': 'error',
 	},
 	useEslintrc: false,

--- a/packages/liferay-npm-scripts/test/prettier/index.js
+++ b/packages/liferay-npm-scripts/test/prettier/index.js
@@ -151,6 +151,7 @@ describe('prettier/index.js', () => {
 					format(code`
 						// Random ES6 to prove that custom lint rule can handle
 						// it without choking.
+
 						const arrow = () => {};
 
 						function thing() {
@@ -164,6 +165,7 @@ describe('prettier/index.js', () => {
 				).toBe(code`
 						// Random ES6 to prove that custom lint rule can handle
 						// it without choking.
+
 						const arrow = () => {};
 
 						function thing() {
@@ -262,20 +264,26 @@ describe('prettier/index.js', () => {
 						if (test) {
 							a();
 						}
+
 						// opening JSP tag comment
+
 						else if (x) {
 							b();
 						}
+
 						// closing JSP tag comment
 				`)
 				).toBe(code`
 						if (test) {
 							a();
 						}
+
 						// opening JSP tag comment
+
 						else if (x) {
 							b();
 						}
+
 						// closing JSP tag comment
 				`);
 			});


### PR DESCRIPTION
We were doing this in most places thanks to [this change in eslint-config-liferay](https://github.com/liferay/eslint-config-liferay/issues/169), but there were a few places where we didn't enforce blank lines because ESLint and Prettier disagree about comments at the beginning and end of blocks, classes, arrays, objects etc.

Brian would like us to handle those "few places" too, so after thinking about it for a bit, I realized that it is actually quite easy because:

1. We already have this post-Prettier hook in place in liferay-npm-scripts that allows us to override Prettier if needed.
2. We don't need to make a custom lint rule for it; we can just use the existing "lines-around-comment" rule that ESLint provides, appropriately configured.
3. This doesn't fundamentally undermine the main mission of Prettier, which is to wrap lines, because inserting/removing blank lines never changes line width.

I'm feeling pretty lucky that I used all those crazy Unicode sentinels when I implemented JSP formatting, because it means that we can ignore all the temporary placeholder comments that get inserted into the source code so that Prettier can parse it. eg.

```jsp
<c:if test="<% blah() %>">
   stuff();
</c:if>
```

gets transformed into (something like):

```js
// crazy Unicode placeholder
  stuff();
// crazy Unicode placeholder
```

to make it into valid JS. Now, with this change, Prettier + ESLint would want to inject blank lines:

```js
// crazy Unicode placeholder

  stuff();

// crazy Unicode placeholder
```

and when we round-trip back to JSP again, it would be:

```jsp
<c:if test="<% blah() %>">

   stuff();

</c:if>
```

which is obviously not what we want. Luckily for us, we can configure ESLint to ignore the "crazy Unicode stuff", and that means we don't mangle any of our JSP.

Test plan: Run on liferay-portal, producing [this diff](https://gist.github.com/wincent/6ff619293a0644a731c621b6aa2819ed).

Closes: https://github.com/liferay/liferay-npm-tools/issues/444