### PR TITLE
fix(preset): remove misleading core-js config

### DIFF
--- a/packages/liferay-npm-bundler-preset-liferay-dev/config.json
+++ b/packages/liferay-npm-bundler-preset-liferay-dev/config.json
@@ -24,7 +24,6 @@
 				"/": ">=1.0.0"
 			},
 			"frontend-js-metal-web": {
-				"core-js": ">=2.6.5",
 				"incremental-dom": ">=0.5.1",
 				"incremental-dom-string": ">=0.0.3",
 				"metal": ">=2.16.5",
@@ -255,8 +254,6 @@
 		"caniuse-lite": true,
 		"chalk": true,
 		"commander": true,
-		"core-js": true,
-		"core-js-pure": true,
 		"electron-to-chromium": true,
 		"lodash": true,
 		"regenerate-unicode-properties": true,


### PR DESCRIPTION
As explained in the related issue, this config makes it look like "frontend-js-metal-web" provides core-js, but it doesn't, and it seems like it never did (at least not explicitly).

So, we can remove the misleading "core-js" form the preset's "imports".

Note that I also remove the "core-js" entries from the "excludes" section. I don't think this is going to impact the build speed at all because nothing is *actually* depending on core-js at the moment. I spot checked this in a few modules by timing builds with and without the exclude, and looking for any evidence of core-js in the "build/" folder. Couldn't see any difference in:

- frontend-js-web (10 seconds)
- frontend-js-metal-web (16 seconds)
- layout-content-page-editor-web (16 seconds)

All of those I tested them by doing "gradlew clean" and then timing "portool yarn run build" and looking at the output of "tree build".  Additionally, I grepped the build folder for references to core-js/corejs; the only hits seem to be in "devDependencies" in "node_modules" package.json files, and a lodash check whose comment says is "Used to detect overreaching core-js shims" (ie. it doesn't actually make use of core-js directly itself).

I also checked frontend-js-recharts, which is actually using the bundler v3 snapshot; evidently that won't be affected by this change but I wanted to confirm there was no actual use of core-js in that build because `yarn why core-js` notes it is a transitive dependency there.

In the future, we may want to create official provider modules for core-js, one for each of v1, v2, v3, which are the main versions of interest in the dependency graph of liferay-portal. If we do that, we'll update the preset accordingly.

Closes: https://github.com/liferay/liferay-npm-tools/issues/446