### PR TITLE
docs(scripts): fix version numbers in CHANGELOG.md

### DIFF
--- a/packages/liferay-npm-scripts/CHANGELOG.md
+++ b/packages/liferay-npm-scripts/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [liferay-npm-scripts/v33.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v33.3.0) (2020-06-02)
+## [liferay-npm-scripts/v32.3.0](https://github.com/liferay/liferay-npm-tools/tree/liferay-npm-scripts/v32.3.0) (2020-06-02)
 
-[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v32.2.0...liferay-npm-scripts/v33.3.0)
+[Full changelog](https://github.com/liferay/liferay-npm-tools/compare/liferay-npm-scripts/v32.2.0...liferay-npm-scripts/v32.3.0)
 
 ### :new: Features
 


### PR DESCRIPTION
Caused because I thought the next version was going to be v33.3.0 but then when I actually updated/published (with `yarn version --minor`) I saw that it's actually v32.3.0.