### PR TITLE
fix(scripts): catch whole-script indentation problems in JSP (#467)

### DIFF
--- a/packages/liferay-npm-scripts/src/jsp/dedent.js
+++ b/packages/liferay-npm-scripts/src/jsp/dedent.js
@@ -85,9 +85,7 @@ function dedent(input, tabWidth = 4) {
 		dedented.pop();
 	}
 
-	const lastMinimum = isFinite(minimum) ? Math.floor(minimum / tabWidth) : 0;
-
-	return [dedented.join('\n'), lastMinimum];
+	return dedented.join('\n');
 }
 
 module.exports = dedent;

--- a/packages/liferay-npm-scripts/src/jsp/restoreTags.js
+++ b/packages/liferay-npm-scripts/src/jsp/restoreTags.js
@@ -311,7 +311,7 @@ function getIndentedTag(tag, token) {
 
 		// Restore original indent to first line, then dedent the whole tag.
 
-		const [dedented] = dedent('\t'.repeat(original.length) + tag);
+		const dedented = dedent('\t'.repeat(original.length) + tag);
 
 		// And indent it to the correct level, but trim off the indent on
 		// the first line because we already emitted that.

--- a/packages/liferay-npm-scripts/test/jsp/__snapshots__/formatJSP.js.snap
+++ b/packages/liferay-npm-scripts/test/jsp/__snapshots__/formatJSP.js.snap
@@ -1229,7 +1229,7 @@ exports[`formatJSP() formatting entire fixtures page.jsp matches snapshot 1`] = 
 
 	<aui:script>
 		window.foo = 'foo';
-</aui:script>
+	</aui:script>
 
 	<aui:script>
 		var SOME_OBJ = {
@@ -1245,7 +1245,7 @@ exports[`formatJSP() formatting entire fixtures page.jsp matches snapshot 1`] = 
 	</aui:script>
 
 	<aui:script require=\\"\\">
-</aui:script>
+	</aui:script>
 </body>
 </html>
 "

--- a/packages/liferay-npm-scripts/test/jsp/dedent.js
+++ b/packages/liferay-npm-scripts/test/jsp/dedent.js
@@ -7,13 +7,13 @@ const dedent = require('../../src/jsp/dedent');
 
 describe('dedent()', () => {
 	it('dedents based on the smallest existing indent (spaces)', () => {
-		const [dedented] = dedent('  def foo\n    1\n  end');
+		const dedented = dedent('  def foo\n    1\n  end');
 
 		expect(dedented).toBe('def foo\n  1\nend');
 	});
 
 	it('dedents based on the smallest existing indent (tabs)', () => {
-		const [dedented] = dedent('\t\tdef foo\n\t\t\t1\n\t\tend');
+		const dedented = dedent('\t\tdef foo\n\t\t\t1\n\t\tend');
 
 		expect(dedented).toBe('def foo\n\t1\nend');
 	});
@@ -22,7 +22,7 @@ describe('dedent()', () => {
 		// Mixed tabs and spaces are common, for example, in source with
 		// multiline comments.
 
-		const [dedented] = dedent(`
+		const dedented = dedent(`
 			/**
 			 * This is a comment.
 			 */
@@ -44,7 +44,7 @@ describe('dedent()', () => {
 	});
 
 	it('accepts a custom tabWidth argument', () => {
-		const [dedented] = dedent(
+		const dedented = dedent(
 			`
 			function fn() {
 				return;
@@ -62,35 +62,13 @@ describe('dedent()', () => {
 		);
 	});
 
-	it('exposes the minimum indent (tab count) from the last call', () => {
-		let [, lastMinimum] = dedent('no indent');
-
-		expect(lastMinimum).toBe(0);
-
-		[, lastMinimum] = dedent('  less than one tab indent');
-
-		expect(lastMinimum).toBe(0);
-
-		[, lastMinimum] = dedent('\tone tab indent');
-
-		expect(lastMinimum).toBe(1);
-
-		[, lastMinimum] = dedent('\t  "1.5" tabs indent');
-
-		expect(lastMinimum).toBe(1);
-
-		[, lastMinimum] = dedent('\t\ttwo tabs indent');
-
-		expect(lastMinimum).toBe(2);
-	});
-
 	it('handles partial "for" control structures', () => {
 		// It's common in JSP to have an incomplete control structure
 		// that starts in one scriptlet and ends in another.
 
 		// prettier-ignore
 
-		const [dedented] = dedent(
+		const dedented = dedent(
 			'<%\n' +
 			'// This one was getting mangled.\n' +
 			'for (AssetRendererFactory<?> curRendererFactory : classTypesAssetRendererFactories) {\n' +

--- a/packages/liferay-npm-scripts/test/jsp/formatJSP.js
+++ b/packages/liferay-npm-scripts/test/jsp/formatJSP.js
@@ -88,6 +88,115 @@ describe('formatJSP()', () => {
 		expect(formatJSP(source)).toBe(expected);
 	});
 
+	describe('fixing problems with indentation relative to script tag (#437)', () => {
+		// ie. each line is correct with respect to its neighbors, but overall,
+		// the code is wrong relative to the script tag.
+
+		it('corrects script content that is insufficiently indented', () => {
+			const source = `
+				<aui:script>
+				function <portlet:namespace />deleteOrganization(
+					organizationId,
+					organizationsRedirect
+				) {
+					<portlet:namespace />doDeleteOrganization(
+						'<%= Organization.class.getName() %>',
+						organizationId,
+						organizationsRedirect
+					);
+				}
+				</aui:script>
+			`;
+
+			const expected = `
+				<aui:script>
+					function <portlet:namespace />deleteOrganization(
+						organizationId,
+						organizationsRedirect
+					) {
+						<portlet:namespace />doDeleteOrganization(
+							'<%= Organization.class.getName() %>',
+							organizationId,
+							organizationsRedirect
+						);
+					}
+				</aui:script>
+			`;
+
+			expect(formatJSP(source)).toBe(expected);
+		});
+
+		it('corrects script content that is excessively indented', () => {
+			// Note that it works for <script> as well.
+
+			const source = `
+				<script>
+						function <portlet:namespace />deleteOrganization(
+							organizationId,
+							organizationsRedirect
+						) {
+							<portlet:namespace />doDeleteOrganization(
+								'<%= Organization.class.getName() %>',
+								organizationId,
+								organizationsRedirect
+							);
+						}
+				</script>
+			`;
+
+			const expected = `
+				<script>
+					function <portlet:namespace />deleteOrganization(
+						organizationId,
+						organizationsRedirect
+					) {
+						<portlet:namespace />doDeleteOrganization(
+							'<%= Organization.class.getName() %>',
+							organizationId,
+							organizationsRedirect
+						);
+					}
+				</script>
+			`;
+
+			expect(formatJSP(source)).toBe(expected);
+		});
+
+		it('fixes content that is on the same line as the script tag', () => {
+			// source-formatter doesn't behave well with one-line scripts like
+			// this, so let's fix them for it.
+			//
+			// Specifically, first run will turn
+			//
+			//              <aui:script>alert('Hi!');</aui:script>
+			//
+			// into:
+			//
+			//              <aui:script>alert('Hi!');
+			//      </aui:script>
+			//
+			// (Presumably because Prettier always adds a trailing newline.)
+			//
+			// Then, second run turns it into:
+			//
+			//              <aui:script>alert('Hi!');
+			//              </aui:script>
+			//
+
+			const source = `
+				<aui:script>alert('Hi!');</aui:script>
+			`;
+
+			const expected = `
+				<aui:script>
+					alert('Hi!');
+				</aui:script>
+			`;
+
+			expect(formatJSP(source)).toBe(expected);
+		});
+	});
+
 	it('correctly handles internal indentation inside control structures', () => {
 		// This is a reduced example of what's in the source.jsp fixture.
 


### PR DESCRIPTION
The way our JS-in-JSP formatting works is as follows:

1. Extract JS.
2. Pass through Prettier.
3. Put JS back where it was.

This means that if the entire block is misindented (ie. too far to the left or the right) but each line is correctly indented relative to its neighbors, the formatting won't complain, because the round trip via Prettier won't actually change anything.

So, we need add an additional layer of enforcement here, which is that the initial indent is correct compared to its containing block.

The fix is straightforward, but I also wanted to make sure that it played nicely in an edge case scenario like this:

    <script>alert('boom');</script>

We don't have any tags like that in liferay-portal, but if we did we wouldn't want to mess them up. In general, the Java source formatter wants opening and closing tags to be on lines of their own. So I made it reformat them to:

    <script>
        alert('boom');
    </script>

Closes: https://github.com/liferay/liferay-npm-tools/issues/467