### PR TITLE
fix(changelog): consistently autodetect prefixes for non-monorepos too

### DIFF
--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -632,16 +632,21 @@ async function generate({date, from, remote, to, version}) {
  *     monorepo and a ".yarnrc" file exists, we return its "version-tag-prefix".
  *
  *     For example, given a prefix of "my-package/v", then we can find matching
- *     tags using `git-describe`--match='my-package/v*'".
+ *     tags using `git describe --match='my-package/v*'.
  *
- * -   If we can't get a "version-tag-prefix", or if we're being run from the repo
- *     root, we use a fallback prefix of "".
+ *     Likewise, if we're being run from the repo root and a ".yarnrc" file
+ *     exists.
+ *
+ *     For example, given a prefix of "v", then we can find matching tags using
+ *     `git describe --match='v*'`.
+ *
+ * -   If we can't get a "version-tag-prefix", we use a fallback prefix of "".
  *
  *     With the fallback prefix of "", we can find matching tags using
- *     `git-describe --match='*'`.
+ *     `git describe --match='*'`.
  *
- * It none of the above apply (eg. because we're not being run from the repo
- * root), an error is thrown.
+ * If none of the above apply (eg. because we're not being run from the wrong
+ * directory), an error is thrown.
  */
 async function getVersionTagPrefix() {
 	const root = (await git('rev-parse', '--show-toplevel')).trim();
@@ -650,11 +655,11 @@ async function getVersionTagPrefix() {
 
 	const basename = path.basename(cwd);
 
-	const project = path.join(root, 'packages', basename);
+	const monorepoPackage = path.join(root, 'packages', basename);
 
 	let prefix;
 
-	if (cwd === project) {
+	if (cwd === root || cwd === monorepoPackage) {
 		try {
 			const contents = await readFileAsync(
 				path.join(cwd, '.yarnrc'),
@@ -673,7 +678,7 @@ async function getVersionTagPrefix() {
 		} catch (_error) {
 			// No readable .yarnrc.
 		}
-	} else if (cwd !== root) {
+	} else {
 		throw new Error(
 			`Expected to run from repo root (${path.relative(
 				cwd,

--- a/packages/liferay-changelog-generator/src/index.js
+++ b/packages/liferay-changelog-generator/src/index.js
@@ -661,10 +661,7 @@ async function getVersionTagPrefix() {
 
 	if (cwd === root || cwd === monorepoPackage) {
 		try {
-			const contents = await readFileAsync(
-				path.join(cwd, '.yarnrc'),
-				'utf8'
-			);
+			const contents = await readFileAsync('.yarnrc', 'utf8');
 
 			contents.split(/\r\n|\r|\n/).find((line) => {
 				const match = line.match(/^\s*version-tag-prefix\s+"([^"]+)"/);


### PR DESCRIPTION
Noticed while looking at [the liferay-ckeditor releases](https://github.com/liferay/liferay-ckeditor/releases) that the links to the "full changelog" are missing the "v" prefix in a lot of places.

That's because the code we have to read the prefix from the ".yarnrc" was inadequately tested outside of monorepos. This small fix makes sure that it reads the top-level ".yarnrc" as well, for the non-monorepo case.

Test plan: Make a merge commit in liferay-ckeditor and run the generator with and without a "v" prefix. Then apply this change and repeat the test; results:

1. "master", with "v" prefix: get valid links in changelog.
2. "master", without "v" prefix: get bad links in changelog.
3. This commit, with "v" prefix: get valid links in changelog.
4. This commit, without "v" prefix: get valid links in changelog.

ie. broken case "2" is fixed.