### PR TITLE
docs(changelog): fix broken link in README

### DIFF
--- a/packages/liferay-changelog-generator/README.md
+++ b/packages/liferay-changelog-generator/README.md
@@ -48,7 +48,7 @@ Options:
 -   [Alloy Editor](https://github.com/liferay/alloy-editor) ([CHANGELOG](https://github.com/liferay/alloy-editor/blob/master/CHANGELOG.md)).
 -   [eslint-config-liferay](https://github.com/liferay/eslint-config-liferay) ([CHANGELOG](https://github.com/liferay/eslint-config-liferay/blob/master/CHANGELOG.md)).
 -   [liferay-ckeditor](https://github.com/liferay/liferay-ckeditor) ([CHANGELOG](https://github.com/liferay/liferay-ckeditor/blob/master/CHANGELOG.md)).
--   [liferay-js-themes-toolkit](https://github.com/liferay/liferay-js-themes-toolkit) ([CHANGELOG](https://github.com/liferay/liferay-js-themes-toolkit/blob/master/CHANGELOG.md)).
+-   [liferay-js-themes-toolkit](https://github.com/liferay/liferay-js-themes-toolkit) (see per-package changelogs in [`packages/*` subdirectories](https://github.com/liferay/liferay-js-themes-toolkit/tree/master/packages)).
 -   [liferay-npm-tools](https://github.com/liferay/liferay-npm-tools) (see per-package changelogs in [`packages/*` subdirectories](https://github.com/liferay/liferay-npm-tools/tree/master/packages)).
 
 ## FAQ


### PR DESCRIPTION
Because in that project, we switched from top-level changelog to per-package ones.