### PR TITLE
fix(scripts): don't merge Babel options into webpack loaders other than babel-loader

### DIFF
--- a/packages/liferay-npm-scripts/src/utils/mergeBabelLoaderOptions.js
+++ b/packages/liferay-npm-scripts/src/utils/mergeBabelLoaderOptions.js
@@ -34,10 +34,7 @@ function mergeBabelLoaderOptions(webpackConfig) {
 				}
 
 				const mergeUseEntry = (useEntry) => {
-					if (
-						typeof useEntry === 'string' &&
-						useEntry === 'babel-loader'
-					) {
+					if (useEntry === 'babel-loader') {
 						return {
 							loader: useEntry,
 							options: {...BABEL_CONFIG},

--- a/packages/liferay-npm-scripts/test/utils/mergeBabelLoaderOptions.js
+++ b/packages/liferay-npm-scripts/test/utils/mergeBabelLoaderOptions.js
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const getMergedConfig = require('../../src/utils/getMergedConfig');
+const mergeBabelLoaderOptions = require('../../src/utils/mergeBabelLoaderOptions');
+
+const BABEL_CONFIG = getMergedConfig('babel');
+
+describe('mergeBabelLoaderOptions()', () => {
+	it('returns unchanged config when it doesn\'t include a "module" field', () => {
+		const config = {};
+
+		expect(mergeBabelLoaderOptions(config)).toEqual(config);
+	});
+
+	it("returns unchanged config when module configs don't include rules", () => {
+		const config = {module: {}};
+
+		expect(mergeBabelLoaderOptions(config)).toEqual(config);
+	});
+
+	it('returns unchanged rules when they don\'t include a "use" field', () => {
+		const config = {
+			module: {
+				rules: [
+					{
+						exclude: /node_modules/,
+						test: /\.(js|jsx)$/,
+					},
+				],
+			},
+		};
+
+		expect(mergeBabelLoaderOptions(config)).toEqual(config);
+	});
+
+	it('returns unchanged rules the loader is not the babel-loader', () => {
+		const config = {
+			module: {
+				rules: [
+					{
+						test: /\.(js|jsx)$/,
+						use: 'ts-loader',
+					},
+					{
+						test: /\.(js|jsx)$/,
+						use: ['ts-loader'],
+					},
+				],
+			},
+		};
+
+		expect(mergeBabelLoaderOptions(config)).toEqual(config);
+	});
+
+	it('merges babel options when the loader is the babel-loader', () => {
+		const config = {
+			module: {
+				rules: [
+					{
+						test: /\.(js|jsx)$/,
+						use: 'babel-loader',
+					},
+					{
+						test: /\.(js|jsx)$/,
+						use: [
+							{
+								loader: 'babel-loader',
+							},
+						],
+					},
+				],
+			},
+		};
+
+		const merged = mergeBabelLoaderOptions(config);
+
+		expect(merged.module.rules[0].use.options).toEqual(BABEL_CONFIG);
+		expect(merged.module.rules[1].use[0].options).toEqual(BABEL_CONFIG);
+	});
+});

--- a/packages/liferay-npm-scripts/test/utils/mergeBabelLoaderOptions.js
+++ b/packages/liferay-npm-scripts/test/utils/mergeBabelLoaderOptions.js
@@ -68,6 +68,9 @@ describe('mergeBabelLoaderOptions()', () => {
 						use: [
 							{
 								loader: 'babel-loader',
+								options: {
+									include: 'bruno',
+								},
 							},
 						],
 					},
@@ -77,7 +80,30 @@ describe('mergeBabelLoaderOptions()', () => {
 
 		const merged = mergeBabelLoaderOptions(config);
 
-		expect(merged.module.rules[0].use.options).toEqual(BABEL_CONFIG);
-		expect(merged.module.rules[1].use[0].options).toEqual(BABEL_CONFIG);
+		expect(merged).toEqual({
+			module: {
+				rules: [
+					{
+						test: /\.(js|jsx)$/,
+						use: {
+							loader: 'babel-loader',
+							options: BABEL_CONFIG,
+						},
+					},
+					{
+						test: /\.(js|jsx)$/,
+						use: [
+							{
+								loader: 'babel-loader',
+								options: {
+									...BABEL_CONFIG,
+									include: 'bruno',
+								},
+							},
+						],
+					},
+				],
+			},
+		});
 	});
 });

--- a/packages/liferay-npm-scripts/test/utils/mergeBabelLoaderOptions.js
+++ b/packages/liferay-npm-scripts/test/utils/mergeBabelLoaderOptions.js
@@ -36,7 +36,7 @@ describe('mergeBabelLoaderOptions()', () => {
 		expect(mergeBabelLoaderOptions(config)).toEqual(config);
 	});
 
-	it('returns unchanged rules the loader is not the babel-loader', () => {
+	it('returns unchanged rules when the loader is not the babel-loader', () => {
 		const config = {
 			module: {
 				rules: [


### PR DESCRIPTION
And because these loaders now seem to validate their configuration schema, it will throw errors and fail to build:

```
ERROR in ./src/main/resources/META-INF/resources/styles/main.scss
Module build failed (from /Users/brunobasto/Projects/liferay-portal/modules/node_modules/style-loader/dist/cjs.js):
ValidationError: Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'overrides'. These properties are valid:
   object { injectType?, attributes?, insert?, base?, esModule? }
    at validate (/Users/brunobasto/Projects/liferay-portal/modules/node_modules/style-loader/node_modules/schema-utils/dist/validate.js:85:11)
    at Object.loader (/Users/brunobasto/Projects/liferay-portal/modules/node_modules/style-loader/dist/index.js:22:28)
 @ ./test/dev/components/Summary.js 3:0-74
```

In this fix I'm not merging the babel loader configs if it's not the babel loader. I've also went from changing the values by reference to returning a new merged reference. That fixed an issue where [this line](https://github.com/liferay/liferay-npm-tools/blob/master/packages/liferay-npm-scripts/src/utils/mergeBabelLoaderOptions.js#L38) was effectively doing nothing when the `use` was not an array.