### PR TITLE
chore(scripts): update liferay-npm-bundler-preset-liferay-dev to v4.6.1

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -57,7 +57,7 @@
 		"liferay-lang-key-dev-loader": "^1.0.3",
 		"liferay-npm-bridge-generator": "2.19.1",
 		"liferay-npm-bundler": "2.19.1",
-		"liferay-npm-bundler-preset-liferay-dev": "4.6.0",
+		"liferay-npm-bundler-preset-liferay-dev": "4.6.1",
 		"liferay-theme-tasks": "10.0.2",
 		"metal-tools-soy": "4.3.2",
 		"mini-css-extract-plugin": "0.9.0",


### PR DESCRIPTION
[Release notes for the preset](https://github.com/liferay/liferay-npm-tools/releases/tag/liferay-npm-bundler-preset-liferay-dev%2Fv4.6.1).

Motivation: [getting this PR](https://github.com/liferay/liferay-js-toolkit/pull/636) (a bugfix to the "babel-plugin-namespace-amd-define" package).

Updated with:

    cd packages/liferay-npm-scripts
    yarn add liferay-npm-bundler-preset-liferay-dev@4.6.1