### PR TITLE
docs(CONTRIBUTING): simplify liferay-changelog-generator invocation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ yarn ci
 cd packages/liferay-npm-scripts
 
 # Update the changelog:
-npx liferay-changelog-generator --version=liferay-npm-scripts/v29.0.1
+npx liferay-changelog-generator --version=29.0.1
 
 # Review and stage the generated changes:
 git add -p


### PR DESCRIPTION
There is no need to spell out the full package name, and it is probably a good idea to avoid spelling it out, so as to avoid the possibility of human error.

The generator will automatically prepend the necessary prefix, although it will print a message like:

    warning: Replacing unexpected "" prefix with expected
    "liferay-npm-scripts/v" prefix in version "32.6.1"

That's what you'd see if you passed `--version=32.6.1`. And if you passed `v32.6.1`, you'd see this:

    warning: Replacing unexpected "v" prefix with expected
    "liferay-npm-scripts/v" prefix in version "v32.6.1"

So, the warning might scare people, but probably only the first time they see it, so I think this is likely a good change to make.