### PR TITLE
chore(scripts): update liferay-npm-bundler-preset-liferay-dev to v4.6.2

### DIFF
--- a/packages/liferay-npm-scripts/package.json
+++ b/packages/liferay-npm-scripts/package.json
@@ -57,7 +57,7 @@
 		"liferay-lang-key-dev-loader": "^1.0.3",
 		"liferay-npm-bridge-generator": "2.19.2",
 		"liferay-npm-bundler": "2.19.2",
-		"liferay-npm-bundler-preset-liferay-dev": "4.6.1",
+		"liferay-npm-bundler-preset-liferay-dev": "4.6.2",
 		"liferay-theme-tasks": "10.0.2",
 		"metal-tools-soy": "4.3.2",
 		"mini-css-extract-plugin": "0.9.0",


### PR DESCRIPTION
[Preset release notes](https://github.com/liferay/liferay-npm-tools/releases/tag/liferay-npm-bundler-preset-liferay-dev%2Fv4.6.2).

Motivating change: [getting this PR](https://github.com/liferay/liferay-js-toolkit/pull/645), which reverts a broken feature.

Updated with:

    cd packages/liferay-npm-scripts
    yarn add liferay-npm-bundler-preset-liferay-dev@4.6.2