### PR TITLE
feat(scripts): catch more dev dependencies hiding in non-dev section

### DIFF
--- a/packages/liferay-npm-scripts/src/presets/standard/index.js
+++ b/packages/liferay-npm-scripts/src/presets/standard/index.js
@@ -42,7 +42,11 @@ module.exports = {
 	check: CHECK_AND_FIX_GLOBS,
 	fix: CHECK_AND_FIX_GLOBS,
 	rules: {
-		'blacklisted-dependency-patterns': ['^liferay-npm-bundler-loader-.+'],
+		'blacklisted-dependency-patterns': [
+			'^@testing-library/',
+			'^liferay-npm-bundler-loader-.+',
+			'^react-test-renderer$',
+		],
 	},
 	storybook: {
 		languagePaths: ['src/main/resources/content/Language.properties'],


### PR DESCRIPTION
As per [this comment](https://github.com/liferay-frontend/liferay-portal/pull/384/files#r490801624), in that PR, somebody is avoiding the lint warning about adding `devDependencies`, which we don't allow in liferay-portal for reasons [described here](https://github.com/liferay/liferay-frontend-guidelines/blob/master/dxp/dev_dependencies.md), by including them in `dependencies` instead. We can catch that by adding a couple more entries to the blacklist. Obviously this is whack-a-mole, but it's way better than having dev dependencies shoved into built JARs.

Test plan: `yarn add` in liferay-portal and see if our `check` script catches the issue on the PR linked above.